### PR TITLE
chore: enforce PR workflow in project rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,8 +186,9 @@ then narrated. The LLM only summarises pre-computed results.
 - ✅ Run a script/query, then explain the output
 - ❌ "The average MoM return is ~X%" — if you derived it yourself, do not state it
 
-### No Co-Authored-By in Commits
-Never add a `Co-Authored-By:` trailer to git commit messages. Write clean, single-author commit messages only.
+### Commits and PR Workflow
+- Never push directly to `main`. Always create a Pull Request (PR) for any changes.
+- Never add a `Co-Authored-By:` trailer to git commit messages. Write clean, single-author commit messages only.
 
 ### Grounding — Pipeline Outputs
 The GOLDBEES pipeline produces a fixed output set. Never invent anything beyond these fields:

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -231,9 +231,9 @@ to narrate results that already exist in the tool/script output.
 - ❌ "The average MoM return is approximately X%" — if you computed that yourself, do not state it
 - ❌ Deriving PE ratios, CAGR, Kelly weights, or any financial metric from training knowledge
 
-### Commit Style
-Never add a `Co-Authored-By:` trailer to git commit messages. Write clean,
-single-author commit messages only.
+### Commit and PR Workflow
+- Never push directly to `main`. Always create a Pull Request (PR) for any changes.
+- Never add a `Co-Authored-By:` trailer to git commit messages. Write clean, single-author commit messages only.
 
 ### Verify Dilution Before Flagging Promoter Sale
 A drop in promoter % is **not** the same as a promoter sale. Before concluding


### PR DESCRIPTION
Enforces the rule to always create PRs instead of pushing directly to main.