### PR TITLE
feat: add one-click Docker setup and CLI wrapper scripts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,11 +55,13 @@ python tests/_backtest_anomaly.py
 ```
 
 ### Docker
-```bash
-docker compose run mosaic analyze
-docker compose up ui -d
-docker compose up                          # full stack (clickhouse + ui + app)
-```
+- **Start UI:** `./run.sh` (macOS/Linux) or `run.bat` (Windows)
+- **Stop UI:** `./stop.sh` (macOS/Linux) or `stop.bat` (Windows)
+- **Run CLI/Scripts in Docker:** Use the `mosaic.sh`/`mosaic.bat` wrappers:
+  - `./mosaic.sh comex`
+  - `./mosaic.sh ask "what is my riskiest holding?"`
+  - `./mosaic.sh src/scripts/goldbees_report.py`
+
 
 ## Architecture
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,9 @@ ENV PYTHONUNBUFFERED=1
 # The HTML dashboard is still generated and available via the mounted volume.
 ENV NO_BROWSER=1
 
+# Mark that the code is running inside the Docker container
+ENV RUNNING_IN_DOCKER=1
+
 # ENTRYPOINT is always the CLI; CMD provides a safe no-auth default.
 # Override CMD by appending the desired subcommand to `docker compose run mosaic`.
 ENTRYPOINT ["python", "src/main.py"]

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -41,6 +41,8 @@ python src/ml/trend_predictor.py                                   # LightGBM fo
 ```
 
 ### Setup & Docker
+
+**Manual setup (requires Python 3.11):**
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
@@ -49,6 +51,15 @@ cp .env.example .env         # fill in API keys
 docker compose up clickhouse -d
 docker compose up            # full stack (clickhouse + ui + app)
 ```
+
+**Zero-dependency / Docker setup (Docker Desktop required):**
+- **Start Dashboard:** `./run.sh` (macOS/Linux) or `run.bat` (Windows)
+- **Stop Dashboard:** `./stop.sh` (macOS/Linux) or `stop.bat` (Windows)
+- **Run CLI/Scripts in Docker:** Use the `mosaic.sh`/`mosaic.bat` wrappers:
+  - `./mosaic.sh comex`
+  - `./mosaic.sh ask "question"`
+  - `./mosaic.sh src/scripts/goldbees_report.py`
+
 
 ### Tests
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,14 +32,31 @@ Licensed under the [Apache License 2.0](LICENSE).
 
 ## Quick Start
 
-### Prerequisites
+### One-Click Setup (Non-Technical)
 
-- Python 3.11+
-- Zerodha account
-- OpenAI / Anthropic API key **or** a local LLM (LM Studio / Ollama)
-- Docker (for ClickHouse — required only for data hub features)
+If you are not a developer or want to avoid setting up Python and installing libraries manually, you can run the entire stack (ClickHouse database, Streamlit Web Dashboard, and agents) with **Docker Desktop**:
 
-### Install
+1. Install **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** and make sure it is running.
+2. Double-click **[run.sh](file:///home/dt/project/Mosaic-fund-agent/run.sh)** (macOS/Linux) or **[run.bat](file:///home/dt/project/Mosaic-fund-agent/run.bat)** (Windows).
+   - *First-run only:* This creates a `.env` file in the project folder. Open it in a text editor to add your API keys (like OpenAI, Zerodha login, etc.).
+3. Once configured, run the script again. It will automatically build the image, start the containers, and open the Web Dashboard at **http://localhost:8501** in your browser.
+4. To run individual CLI commands or scripts without installing Python locally, use the **[mosaic.sh](file:///home/dt/project/Mosaic-fund-agent/mosaic.sh)** (macOS/Linux) or **[mosaic.bat](file:///home/dt/project/Mosaic-fund-agent/mosaic.bat)** (Windows) wrappers:
+   - For standard CLI commands:
+     ```bash
+     ./mosaic.sh comex
+     ./mosaic.sh ask "am I overexposed to IT?"
+     ./mosaic.sh analyze --max 3
+     ```
+   - For specific Python scripts:
+     ```bash
+     ./mosaic.sh src/scripts/goldbees_report.py
+     ```
+5. To stop the application, double-click **[stop.sh](file:///home/dt/project/Mosaic-fund-agent/stop.sh)** (macOS/Linux) or **[stop.bat](file:///home/dt/project/Mosaic-fund-agent/stop.bat)** (Windows).
+
+See the detailed **[Docker Setup Guide](file:///home/dt/project/Mosaic-fund-agent/docs/docker_install_guide.md)** for platform-specific installation steps.
+
+### Developer Install (Manual)
+
 
 ```bash
 git clone https://github.com/Mosaic-agent/Mosaic-fund-agent.git

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,10 @@ services:
     env_file: .env
     environment:
       CLICKHOUSE_HOST: clickhouse
+    volumes:
+      - ./src:/app/src
+      - ./config:/app/config
+      - ./output:/app/output
     depends_on:
       clickhouse:
         condition: service_healthy
@@ -58,6 +62,8 @@ services:
       # Persist JSON reports and the HTML dashboard on the host filesystem.
       # The disk cache (output/.cache/) is included automatically.
       - ./output:/app/output
+      - ./src:/app/src
+      - ./config:/app/config
 
     depends_on:
       clickhouse:

--- a/docs/docker_install_guide.md
+++ b/docs/docker_install_guide.md
@@ -1,0 +1,125 @@
+# One-Click Setup Guide (Docker)
+
+This guide walks you through setting up and running the Mosaic Fund Agent platform on **Windows**, **macOS**, and **Ubuntu (Linux)** using Docker. This method packages all python libraries and database dependencies automatically, so you do not need to install Python, compilers, or local packages.
+
+---
+
+## 🪟 Windows Setup
+
+### 1. Install Docker Desktop
+1. Download the installer from **[Docker Desktop for Windows](https://www.docker.com/products/docker-desktop/)**.
+2. Run the installer. Ensure **"Use WSL 2 instead of Hyper-V (recommended)"** is checked when prompted.
+3. If prompted, restart your computer to finish the WSL2 integration.
+4. Launch **Docker Desktop** from your Start menu and accept the agreement. Keep the application open.
+
+### 2. Configure & Run
+1. Open the project folder (`Mosaic-fund-agent`) in Windows Explorer.
+2. Double-click the file **`run.bat`**.
+   - *First-run only:* The script will create a file named `.env` in the root folder and then exit.
+3. Open the new **`.env`** file using Notepad, fill in your API keys (e.g. `OPENAI_API_KEY`, Zerodha keys, etc.), and save it.
+4. Double-click **`run.bat`** again. It will build the container, configure ClickHouse, and open the Streamlit dashboard automatically in your browser at:
+   **http://localhost:8501/**
+
+### 3. Stop
+When you are done, double-click **`stop.bat`** to shut down the background containers.
+
+---
+
+## 🍎 macOS Setup
+
+### 1. Install Docker Desktop
+1. Download the installer for your chip:
+   - **[Docker Desktop for Mac (Apple Silicon / M1/M2/M3)](https://desktop.docker.com/mac/main/arm64/Docker.dmg)**
+   - **[Docker Desktop for Mac (Intel Chip)](https://desktop.docker.com/mac/main/amd64/Docker.dmg)**
+2. Open the downloaded `.dmg` file, drag **Docker** to your Applications folder, and launch it.
+3. Accept the license agreement and wait for the status indicator in the bottom-left corner to turn green.
+
+### 2. Configure & Run
+1. Open terminal and navigate to the project directory:
+   ```bash
+   cd /path/to/Mosaic-fund-agent
+   ```
+2. Run the startup script:
+   ```bash
+   ./run.sh
+   ```
+   - *First-run only:* This script will create a `.env` file in the folder and prompt you to configure it.
+3. Open the **`.env`** file in your text editor, add your API credentials, and save it.
+4. Run the script again:
+   ```bash
+   ./run.sh
+   ```
+   This will automatically build the images, start the containers, and launch the dashboard in your default browser.
+
+### 3. Stop
+To turn off the services, run:
+```bash
+./stop.sh
+```
+
+---
+
+## 🐧 Ubuntu (Linux) Setup
+
+### 1. Install Docker & Docker Compose
+Open your terminal and run the following command block to install Docker Engine:
+```bash
+# Update package index and install certificates
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg
+
+# Add Docker's official GPG key
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Set up the repository
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+# Install Docker Engine and Compose
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Add your user to the docker group so you can run docker commands without sudo
+sudo usermod -aG docker $USER
+```
+*Note: After adding your user to the group, close your terminal window and open a new one (or run `newgrp docker`) for the changes to apply.*
+
+### 2. Configure & Run
+1. Navigate to the project directory:
+   ```bash
+   cd /path/to/Mosaic-fund-agent
+   ```
+2. Run the startup script:
+   ```bash
+   ./run.sh
+   ```
+   - *First-run only:* The script will copy `.env.example` to `.env` and exit.
+3. Edit the newly created **`.env`** file to add your API credentials.
+4. Run the script again:
+   ```bash
+   ./run.sh
+   ```
+   It will start the database and Streamlit UI, opening **http://localhost:8501/** when live.
+
+### 3. Stop
+To stop all containers, run:
+```bash
+./stop.sh
+```
+
+---
+
+## 💻 Running Commands / Custom Scripts (All Platforms)
+
+To run specific analysis commands or scripts directly in the Docker container (without needing a local Python setup), run the CLI proxy wrapper in your terminal:
+
+| Operation | macOS / Ubuntu / WSL Bash | Windows CMD |
+| :--- | :--- | :--- |
+| Run COMEX pre-market | `./mosaic.sh comex` | `mosaic.bat comex` |
+| Ask the LLM Portfolio Agent | `./mosaic.sh ask "what is my riskiest holding?"` | `mosaic.bat ask "what is my riskiest holding?"` |
+| Analyze active portfolio | `./mosaic.sh analyze --max 3` | `mosaic.bat analyze --max 3` |
+| Run GOLDBEES Report | `./mosaic.sh src/scripts/goldbees_report.py` | `mosaic.bat src/scripts/goldbees_report.py` |

--- a/mosaic.bat
+++ b/mosaic.bat
@@ -1,0 +1,36 @@
+@echo off
+REM ── Mosaic CLI Docker Wrapper (Windows) ────────────────────────────────────
+REM
+REM This script forwards commands to the Docker container, removing the need
+REM to have Python or packages installed locally.
+REM
+REM Usage:
+REM   mosaic.bat [command/script] [options]
+REM
+REM Examples:
+REM   mosaic.bat analyze --max 3
+REM   mosaic.bat ask "what is my riskiest holding?"
+REM   mosaic.bat comex
+REM   mosaic.bat src/scripts/goldbees_report.py
+
+docker info >nul 2>&1
+if %errorlevel% neq 0 (
+    echo ERROR: Docker Desktop is not running. Please start Docker and try again.
+    exit /b 1
+)
+
+set FIRST_ARG=%1
+
+if "%FIRST_ARG%"=="" goto default_run
+
+:: Extract the last 3 characters to check if it ends with .py
+set EXT=%FIRST_ARG:~-3%
+if /I "%EXT%"==".py" (
+    echo Running Python script in Docker...
+    docker compose run --rm --entrypoint python mosaic %*
+    exit /b %errorlevel%
+)
+
+:default_run
+docker compose run --rm mosaic %*
+exit /b %errorlevel%

--- a/mosaic.sh
+++ b/mosaic.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# ── Mosaic CLI Docker Wrapper ────────────────────────────────────────────────
+#
+# This script forwards commands to the Docker container, removing the need
+# to have Python or packages installed locally.
+#
+# Usage:
+#   ./mosaic.sh [command/script] [options]
+#
+# Examples:
+#   ./mosaic.sh analyze --max 3
+#   ./mosaic.sh ask "what is my riskiest holding?"
+#   ./mosaic.sh comex
+#   ./mosaic.sh src/scripts/goldbees_report.py
+
+# Check if Docker is running
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: Docker Desktop is not running. Please start Docker and try again."
+    exit 1
+fi
+
+FIRST_ARG="$1"
+
+# If first arg is a python file, run it directly with python
+if [[ "$FIRST_ARG" == *.py ]]; then
+    echo "Running Python script in Docker..."
+    docker compose run --rm --entrypoint python mosaic "$@"
+else
+    # Default: pass args to main.py
+    docker compose run --rm mosaic "$@"
+fi

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,57 @@
+@echo off
+REM ── Mosaic Fund Agent — Click-to-Run Bootstrap Script (Windows) ────────────
+REM
+REM Usage:
+REM   Double-click run.bat to start.
+REM   It will verify Docker, set up your .env file, launch the containers,
+REM   and open the Streamlit dashboard automatically.
+
+:: 1. Check if Docker is running
+docker info >nul 2>&1
+if %errorlevel% neq 0 (
+    echo =================================================================
+    echo  ERROR: Docker Desktop is not running.
+    echo  Please start Docker Desktop and try running this script again.
+    echo =================================================================
+    pause
+    exit /b 1
+)
+
+:: 2. Check for .env file
+if not exist .env (
+    echo =================================================================
+    echo  First-time setup: Creating '.env' configuration file.
+    echo =================================================================
+    copy .env.example .env
+    echo  Created '.env' from template.
+    echo  IMPORTANT: Please open the '.env' file in this folder and add
+    echo  your API keys (e.g. Zerodha login, OpenAI/Anthropic keys).
+    echo =================================================================
+    pause
+    exit /b 1
+)
+
+:: 3. Spin up the stack in background
+echo Starting Mosaic Fund Agent services (ClickHouse + UI)...
+docker compose up -d --build
+if %errorlevel% neq 0 (
+    echo ERROR: Failed to run docker compose. Make sure Docker Desktop is running.
+    pause
+    exit /b 1
+)
+
+:: 4. Wait for Streamlit UI to be healthy
+echo Waiting for dashboard to start at http://localhost:8501...
+:wait_loop
+curl -s -I http://localhost:8501 | findstr "200" >nul
+if %errorlevel% neq 0 (
+    timeout /t 1 /nobreak >nul
+    goto wait_loop
+)
+
+echo.
+echo Dashboard is live!
+
+:: 5. Open browser automatically
+echo Opening browser...
+start http://localhost:8501

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# ── Mosaic Fund Agent — Click-to-Run Bootstrap Script ────────────────────────
+#
+# Usage:
+#   Double-click this file or run `./run.sh` from the terminal.
+#   It will verify Docker, set up your .env file, launch the containers,
+#   and open the Streamlit dashboard automatically.
+
+# 1. Check if Docker is running
+if ! docker info >/dev/null 2>&1; then
+    echo "================================================================="
+    echo " ERROR: Docker Desktop is not running."
+    echo " Please start Docker Desktop and try running this script again."
+    echo "================================================================="
+    read -p "Press Enter to exit..."
+    exit 1
+fi
+
+# 2. Check for .env file
+if [ ! -f .env ]; then
+    echo "================================================================="
+    echo " First-time setup: Creating '.env' configuration file."
+    echo "================================================================="
+    cp .env.example .env
+    echo " Created '.env' from template."
+    echo " IMPORTANT: Please open the '.env' file in this folder and add"
+    echo " your API keys (e.g. Zerodha login, OpenAI/Anthropic keys)."
+    echo "================================================================="
+    read -p "Press Enter to exit..."
+    exit 1
+fi
+
+# 3. Spin up the stack in background
+echo "Starting Mosaic Fund Agent services (ClickHouse + UI)..."
+docker compose up -d --build
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to run docker compose. Make sure Docker is running properly."
+    read -p "Press Enter to exit..."
+    exit 1
+fi
+
+# 4. Wait for Streamlit UI to be healthy
+echo "Waiting for dashboard to start at http://localhost:8501..."
+until curl -s -I http://localhost:8501 | grep -q "200 OK"; do
+    printf "."
+    sleep 1
+done
+echo ""
+echo " Dashboard is live!"
+
+# 5. Open browser automatically
+URL="http://localhost:8501"
+echo "Opening browser at $URL..."
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    open "$URL"
+elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    if command -v xdg-open > /dev/null; then
+        xdg-open "$URL"
+    else
+        echo "Please open $URL manually in your browser."
+    fi
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" ]]; then
+    start "$URL"
+else
+    echo "Please open $URL manually in your browser."
+fi

--- a/src/main.py
+++ b/src/main.py
@@ -26,6 +26,22 @@ from rich import box
 # Ensure project root is on sys.path when running as script
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+# Guard: Ensure script is running inside the Docker container to prevent local package import errors
+import os
+if not os.environ.get('RUNNING_IN_DOCKER') and not os.path.exists('/.dockerenv') and os.environ.get('ALLOW_LOCAL_RUN') != '1':
+    print("=================================================================", file=sys.stderr)
+    print(" ERROR: This command must be run inside the Docker container", file=sys.stderr)
+    print(" to ensure that all required dependencies are loaded correctly.", file=sys.stderr)
+    print("-----------------------------------------------------------------", file=sys.stderr)
+    print(" Please use the wrapper script instead:", file=sys.stderr)
+    print(f"   ./mosaic.sh {' '.join(sys.argv[1:])}", file=sys.stderr)
+    print(" (On Windows, use 'mosaic.bat' instead)", file=sys.stderr)
+    print("-----------------------------------------------------------------", file=sys.stderr)
+    print(" If you are a developer and want to bypass this check, set:", file=sys.stderr)
+    print("   export ALLOW_LOCAL_RUN=1  (or set it in your environment)", file=sys.stderr)
+    print("=================================================================", file=sys.stderr)
+    sys.exit(1)
+
 from config.settings import settings
 
 app = typer.Typer(

--- a/src/scripts/goldbees_report.py
+++ b/src/scripts/goldbees_report.py
@@ -9,6 +9,21 @@ _ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__
 sys.path.insert(0, os.path.join(_ROOT, "src"))
 sys.path.insert(0, _ROOT)
 
+# Guard: Ensure script is running inside the Docker container to prevent local package import errors
+if not os.environ.get('RUNNING_IN_DOCKER') and not os.path.exists('/.dockerenv') and os.environ.get('ALLOW_LOCAL_RUN') != '1':
+    print("=================================================================", file=sys.stderr)
+    print(" ERROR: This script must be run inside the Docker container", file=sys.stderr)
+    print(" to ensure that all required dependencies are loaded correctly.", file=sys.stderr)
+    print("-----------------------------------------------------------------", file=sys.stderr)
+    print(" Please use the wrapper script instead:", file=sys.stderr)
+    print(f"   ./mosaic.sh src/scripts/goldbees_report.py", file=sys.stderr)
+    print(" (On Windows, use 'mosaic.bat' instead)", file=sys.stderr)
+    print("-----------------------------------------------------------------", file=sys.stderr)
+    print(" If you are a developer and want to bypass this check, set:", file=sys.stderr)
+    print("   export ALLOW_LOCAL_RUN=1  (or set it in your environment)", file=sys.stderr)
+    print("=================================================================", file=sys.stderr)
+    sys.exit(1)
+
 from db.pool import query_df, get_pool
 from db.repository import MarketDataRepository
 

--- a/stop.bat
+++ b/stop.bat
@@ -1,0 +1,21 @@
+@echo off
+REM ── Mosaic Fund Agent — Stop Services Script (Windows) ─────────────────────
+REM
+REM Usage:
+REM   Double-click stop.bat to stop the services.
+
+:: Check if Docker is running
+docker info >nul 2>&1
+if %errorlevel% neq 0 (
+    echo Docker is not running, services are likely already stopped.
+    timeout /t 3 >nul
+    exit /b 0
+)
+
+echo Stopping Mosaic Fund Agent services...
+docker compose down
+
+echo =================================================================
+echo  All services have been stopped successfully.
+echo =================================================================
+timeout /t 3 >nul

--- a/stop.sh
+++ b/stop.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# ── Mosaic Fund Agent — Stop Services Script ────────────────────────────────
+#
+# Usage:
+#   Double-click this file or run `./stop.sh` from the terminal.
+#   It will gracefully stop all running Docker containers for the application.
+
+# Check if Docker is running
+if ! docker info >/dev/null 2>&1; then
+    echo "Docker is not running, services are likely already stopped."
+    exit 0
+fi
+
+echo "Stopping Mosaic Fund Agent services..."
+docker compose down
+
+echo "================================================================="
+echo " All services have been stopped successfully."
+echo "================================================================="
+sleep 2


### PR DESCRIPTION
- Add double-clickable run/stop scripts for Windows and macOS/Linux
- Create mosaic.sh/bat CLI proxy wrappers to run all python code in Docker
- Add volumes for live code updates in docker-compose.yml
- Enforce Docker container runtime checks in main CLI and key scripts
- Create detailed Docker installation and usage guide
- Update agent documentation in GEMINI.md and CLAUDE.md