### PR TITLE
fix: fall back to direct LLM Q&A if the model does not support tool calling

### DIFF
--- a/src/agents/portfolio_agent.py
+++ b/src/agents/portfolio_agent.py
@@ -290,6 +290,16 @@ class PortfolioAgent:
             msgs = result.get("messages", [])
             return msgs[-1].content if msgs else "No answer generated."
         except Exception as exc:
+            err_msg = str(exc).lower()
+            if "tool" in err_msg or "400" in err_msg or "invalid_request" in err_msg:
+                logger.warning("Model does not support tools. Falling back to direct LLM Q&A.")
+                if self._llm is not None:
+                    try:
+                        res = self._llm.invoke(messages)
+                        return str(res.content)
+                    except Exception as fallback_exc:
+                        logger.error("Fallback LLM query failed: %s", fallback_exc)
+                        return f"Error: {fallback_exc}"
             logger.error("Agent query failed: %s", exc)
             return f"Error: {exc}"
 


### PR DESCRIPTION
This PR adds a fallback mechanism to PortfolioAgent.ask so that if the configured model (such as gemma:7b) does not support function/tool calling, the agent will gracefully fall back to direct LLM Q&A using the compacted portfolio report context.