### PR TITLE
feat: Kite iNAV, live NAV pipeline, company resolver, and IST timezone

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,6 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
-      ollama-init:
-        condition: service_completed_successfully
 
   mosaic:
     build: .
@@ -131,8 +129,6 @@ services:
     depends_on:
       clickhouse:
         condition: service_healthy
-      ollama-init:
-        condition: service_completed_successfully
 
     # ENTRYPOINT is fixed to `python src/main.py` in the Dockerfile.
     # Override the default CMD per call:

--- a/mosaic.sh
+++ b/mosaic.sh
@@ -24,9 +24,15 @@ fi
 
 # No arguments → start interactive chat (ensure ClickHouse + Ollama are up first)
 if [[ $# -eq 0 ]]; then
-    echo "Starting services (first run pulls gemma4 ~5-8 GB — grab a coffee)..."
-    docker compose up -d clickhouse ollama 2>/dev/null
-    docker compose run --rm ollama-init 2>/dev/null || true   # no-op if already done
+    # Check if a local Ollama instance is already running on the host
+    if curl -s -I http://localhost:11434/ >/dev/null 2>&1; then
+        echo "Local Ollama detected running on host. Starting clickhouse only..."
+        docker compose up -d clickhouse 2>/dev/null
+    else
+        echo "Starting services (first run pulls gemma4 ~5-8 GB — grab a coffee)..."
+        docker compose up -d clickhouse ollama 2>/dev/null
+        docker compose run --rm ollama-init 2>/dev/null || true   # no-op if already done
+    fi
     docker compose run --rm -it mosaic chat
     exit 0
 fi

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,9 +20,12 @@ yfinance>=0.2.40                 # Yahoo Finance – free EOD/historical data (.
 pandas>=2.2.0                    # Data manipulation for financial time series
 numpy>=1.26.0                    # Numerical computations
 
-# ── Web Scraping (Quarterly Results) ──────────────────────────────────────────
-beautifulsoup4>=4.12.0           # HTML parsing for Screener.in / BSE / NSE
-requests>=2.32.0                 # HTTP requests for scraping
+# ── Web Scraping & Indian Market Data ─────────────────────────────────────────
+# Screener.in used via direct HTTP (no PyPI package):
+#   /company/{SYMBOL}/         — quarterly results, cashflow + symbol validation
+#   (search API blocked outside browser; only /company/ direct URLs accessible)
+beautifulsoup4>=4.12.0           # HTML parsing for Screener.in / BSE / NSE earnings
+requests>=2.32.0                 # HTTP — Screener.in, Yahoo Finance, BSE/NSE, COMEX
 lxml>=5.2.0                      # Faster HTML parser backend for BeautifulSoup
 fake-useragent>=1.5.0            # Rotate user-agents to avoid scraping blocks
 

--- a/src/agents/comex_agent.py
+++ b/src/agents/comex_agent.py
@@ -252,6 +252,7 @@ class ComexAgent:
                 api_key=settings.openai_api_key or "local",
                 temperature=0,
                 max_tokens=settings.llm_token_budget,
+                extra_body={"options": {"num_ctx": settings.llm_context_window}},
             )
 
         if settings.llm_provider.lower() == "anthropic":

--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -201,6 +201,7 @@ class MosaicFundAgent:
                 api_key=settings.openai_api_key or "local",
                 temperature=0,
                 max_tokens=settings.llm_token_budget,
+                extra_body={"options": {"num_ctx": settings.llm_context_window}},
             )
 
         # ── Anthropic cloud ────────────────────────────────────────────────────
@@ -283,6 +284,7 @@ class MosaicFundAgent:
                 api_key=settings.openai_api_key or "local",
                 temperature=0,
                 max_tokens=budget,
+                extra_body={"options": {"num_ctx": ctx}},
             )
 
         if provider == "anthropic":

--- a/src/agents/news_sentiment_agent.py
+++ b/src/agents/news_sentiment_agent.py
@@ -257,6 +257,7 @@ class NewsSentimentAgent:
                 api_key=settings.openai_api_key or "local",
                 temperature=0.1,
                 max_tokens=settings.llm_token_budget,
+                extra_body={"options": {"num_ctx": settings.llm_context_window}},
             )
 
         if settings.llm_provider.lower() == "anthropic":

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -281,21 +281,26 @@ class _SubAgent:
             self._llm = tmp._build_llm()
 
         from config.settings import settings
-        effective_window = getattr(self._llm, "_context_window", None) or settings.llm_context_window
-        if llm_override is None and settings.llm_context_window < 12000:
-            # Local model context too small for a ReAct loop — try cloud LLM instead.
+        if self._llm is None or (llm_override is None and settings.llm_context_window < 12000):
+            # Local model disabled or context too small for a ReAct loop — try cloud LLM instead.
             cloud_llm = tmp._build_cloud_llm()
             if cloud_llm is not None:
-                logger.info(
-                    "%s: local context_window=%d < 12000 — upgrading to cloud LLM",
-                    self.__class__.__name__, settings.llm_context_window,
-                )
+                if self._llm is None:
+                    logger.info("%s: local LLM disabled — upgrading to cloud LLM", self.__class__.__name__)
+                else:
+                    logger.info(
+                        "%s: local context_window=%d < 12000 — upgrading to cloud LLM",
+                        self.__class__.__name__, settings.llm_context_window,
+                    )
                 self._llm = cloud_llm
             else:
-                logger.info(
-                    "%s: local context_window=%d < 12000 and no cloud LLM configured — falling back",
-                    self.__class__.__name__, settings.llm_context_window,
-                )
+                if self._llm is None:
+                    logger.warning("%s: local LLM disabled and no cloud LLM configured — falling back", self.__class__.__name__)
+                else:
+                    logger.info(
+                        "%s: local context_window=%d < 12000 and no cloud LLM configured — falling back",
+                        self.__class__.__name__, settings.llm_context_window,
+                    )
                 return  # leave self._agent = None → _confirm_fallback() path
 
         try:

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -337,11 +337,11 @@ class _SubAgent:
             return self._confirm_fallback(question)
 
         from langchain_core.messages import HumanMessage, ToolMessage
-        config: dict = {}
+        config: dict = {"recursion_limit": 8}
         if callbacks:
             config["callbacks"] = callbacks
         try:
-            result = self._agent.invoke({"messages": [HumanMessage(content=question)]}, config=config or None)
+            result = self._agent.invoke({"messages": [HumanMessage(content=question)]}, config=config)
             msgs = result.get("messages", [])
 
             # Collect tool outputs; skip pure-plumbing calls (e.g. resolve_company

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -247,6 +247,10 @@ class _SubAgent:
     SYSTEM_PROMPT: str = "You are a helpful assistant."
     #: Override in subclass — property or class-level list
     TOOLS: list = []
+    #: Max LangGraph steps. Simple agents (news, signal) need ~8; equity/research
+    #: need more due to parallel tool batches + optional import steps.
+    #: None = LangGraph default (25). Override per subclass as needed.
+    RECURSION_LIMIT: int | None = 20
 
     def __init__(self) -> None:
         self._agent: Any = None
@@ -341,16 +345,48 @@ class _SubAgent:
         if self._agent is None:
             return self._confirm_fallback(question)
 
-        from langchain_core.messages import HumanMessage, ToolMessage
-        config: dict = {"recursion_limit": 8}
+        from langchain_core.messages import HumanMessage, ToolMessage, AIMessage
+        config: dict = (
+            {"recursion_limit": self.RECURSION_LIMIT}
+            if self.RECURSION_LIMIT is not None
+            else {}
+        )
         if callbacks:
             config["callbacks"] = callbacks
-        try:
-            result = self._agent.invoke({"messages": [HumanMessage(content=question)]}, config=config)
-            msgs = result.get("messages", [])
 
-            # Collect tool outputs; skip pure-plumbing calls (e.g. resolve_company
-            # which returns a symbol dict with no display value).
+        # Stream instead of invoke so we accumulate partial state at every step.
+        # If the recursion limit fires mid-run, we still have all tool outputs
+        # collected so far and can synthesise from them.
+        msgs: list = []
+        _recursion_hit = False
+        try:
+            for state in self._agent.stream(
+                {"messages": [HumanMessage(content=question)]},
+                config=config,
+                stream_mode="values",
+            ):
+                if isinstance(state, dict):
+                    msgs = state.get("messages", msgs)
+        except Exception as exc:
+            err = str(exc).lower()
+            if "recursion" in err:
+                _recursion_hit = True
+                logger.warning(
+                    "%s: recursion limit hit — synthesising from %d partial messages",
+                    self.__class__.__name__, len(msgs),
+                )
+            elif any(k in err for k in ("tool", "400", "invalid_request", "function", "tool_calls", "not support")):
+                logger.info(
+                    "%s: LLM tool-calling failed (%s), using programmatic fallback",
+                    self.__class__.__name__, type(exc).__name__,
+                )
+                return self._confirm_fallback(question)
+            else:
+                logger.error("%s.run() failed: %s", self.__class__.__name__, exc)
+                return f"Research incomplete: {exc}"
+
+        try:
+            # Collect tool outputs; skip pure-plumbing symbol-resolution calls.
             _SKIP_KEYS = ('"symbol"', '"nse_symbol"', '"yf_symbol"')
             tool_sections = []
             for m in msgs:
@@ -359,43 +395,57 @@ class _SubAgent:
                 content = str(m.content).strip()
                 if not content:
                     continue
-                # Skip symbol-resolution tool output (internal plumbing)
                 if content.startswith("{") and any(k in content for k in _SKIP_KEYS):
                     continue
                 tool_sections.append(content)
 
             if tool_sections:
-                # If the last message is a non-empty AIMessage, the LLM already
-                # produced a synthesis — prefer that over raw tool concatenation.
-                from langchain_core.messages import AIMessage
+                # Prefer a final LLM synthesis if it already exists.
                 last_ai = next(
                     (m for m in reversed(msgs) if isinstance(m, AIMessage) and str(m.content).strip()),
                     None,
                 )
-                if last_ai:
+                if last_ai and not _recursion_hit:
                     logger.info(
                         "%s: returning LLM synthesis (%d chars)",
                         self.__class__.__name__, len(str(last_ai.content)),
                     )
                     return str(last_ai.content)
 
-                logger.info(
-                    "%s: merged %d tool outputs programmatically",
-                    self.__class__.__name__, len(tool_sections),
-                )
+                # Recursion limit hit (or no final AI message) — synthesise now.
+                if self._llm:
+                    try:
+                        from langchain_core.messages import SystemMessage
+                        combined = "\n\n---\n\n".join(tool_sections[:10])
+                        synth = self._llm.invoke([
+                            SystemMessage(content=(
+                                self.SYSTEM_PROMPT + "\n\n"
+                                "PARTIAL DATA SYNTHESIS RULES (apply strictly):\n"
+                                "- Write ONLY the sections for which you have actual tool output data.\n"
+                                "- OMIT any section entirely if no tool data was collected for it.\n"
+                                "- NEVER write '(Data pending)', 'N/A', or placeholder text.\n"
+                                "- Do not mention step limits, recursion, or missing data.\n"
+                                "- Be concise and factual — only report what the tools returned."
+                            )),
+                            HumanMessage(content=f"Question: {question}\n\nData collected:\n{combined}"),
+                        ])
+                        logger.info(
+                            "%s: partial synthesis (%d tool outputs → %d chars)",
+                            self.__class__.__name__, len(tool_sections), len(str(synth.content)),
+                        )
+                        return str(synth.content)
+                    except Exception as synth_exc:
+                        logger.warning("%s: synthesis call failed: %s", self.__class__.__name__, synth_exc)
+
+                # Last resort — concatenate raw tool outputs.
+                logger.info("%s: merged %d tool outputs programmatically", self.__class__.__name__, len(tool_sections))
                 return "\n\n---\n\n".join(tool_sections)
 
-            # No tool calls — return the last AI message directly.
-            return msgs[-1].content if msgs else "No response from sub-agent."
+            # No tool calls — return the last AI message.
+            return str(msgs[-1].content) if msgs else "No response from sub-agent."
+
         except Exception as exc:
-            err = str(exc).lower()
-            if any(k in err for k in ("tool", "400", "invalid_request", "function", "tool_calls", "not support")):
-                logger.info(
-                    "%s: LLM tool-calling failed (%s), using programmatic fallback",
-                    self.__class__.__name__, type(exc).__name__,
-                )
-                return self._confirm_fallback(question)
-            logger.error("%s.run() failed: %s", self.__class__.__name__, exc)
+            logger.error("%s: message processing failed: %s", self.__class__.__name__, exc)
             return f"Research incomplete: {exc}"
 
     def _confirm_fallback(self, question: str) -> str:
@@ -640,42 +690,59 @@ class IndianEquityResearchSubAgent(_SubAgent):
     direct NSE symbol — ``resolve_company`` is always called first.
     """
 
+    # resolve(1) + optional check/import(2) + 7 parallel tools(1) + plot(1) + synthesis(1) = ~8-14 steps
+    RECURSION_LIMIT = 40
+
     SYSTEM_PROMPT = (
         "You are a senior Indian equity analyst covering NSE/BSE listed stocks. "
         "Research happens in exactly TWO rounds to maximise parallel execution:\n\n"
         "ROUND 1 — Resolve (single call):\n"
         "  Call `resolve_company(query)` to get `symbol` (e.g. ADANIENT), `exchange`, "
         "and `company_name`. Wait for the result before proceeding.\n\n"
-        "ROUND 2 — Parallel data fetch (call ALL seven tools simultaneously in one response):\n"
+        "ROUND 2 — Parallel data fetch (emit ALL in ONE response — never call them one by one):\n"
         "  • `get_yahoo_finance_data(\"SYMBOL:EXCHANGE\")` — price, P/E, P/B, 52-week range, market cap\n"
         "  • `get_price_momentum(\"SYMBOL:EXCHANGE\")` — 30d/90d returns, momentum signal\n"
         "  • `get_quarterly_results(\"SYMBOL:EXCHANGE\")` — revenue, net profit, EPS, YoY growth\n"
         "  • `get_stock_cashflow(\"SYMBOL:EXCHANGE\")` — 3yr FCF, operating CF, capex\n"
-        "  • `get_mf_holdings_for_stock(company_name)` — DSP fund holdings & weights\n"
+        "  • `get_shareholding_pattern(symbol)` — Promoter/FII/DII/Public holding % with QoQ delta\n"
+        "  • `get_mf_holdings_for_stock(company_name)` — DSP fund cross-ownership\n"
         "  • `get_stock_news(company_name)` AND `get_newsapi_stock_news(symbol)` — news & sentiment\n"
-        "  • `get_fii_dii_summary(7)` — 7-day FII/DII institutional flows\n\n"
-        "IMPORTANT: Emit all seven tool calls in a single response (not one at a time). "
-        "LangGraph will execute them concurrently.\n\n"
+        "  • `get_fii_dii_summary(7)` — 7-day aggregate FII/DII market flows\n\n"
+        "CRITICAL: All seven must appear in one AIMessage response as parallel tool calls. "
+        "Calling them one at a time wastes steps and will hit the recursion limit.\n\n"
+        "CHART/PLOT requests: If the user asks to plot a price chart, add "
+        "`plot_price_chart(SYMBOL, days)` to ROUND 2. If it returns 'No price data found', "
+        "call `check_and_refresh_symbol_data(SYMBOL)` once, then retry plot_price_chart.\n\n"
         "SYNTHESIS: After all results arrive, write a structured Markdown research note:\n"
         "(1) Company Snapshot  (2) Financials table  (3) Valuation vs sector  "
-        "(4) Cash Flow quality  (5) Institutional Ownership  (6) News Sentiment  "
+        "(4) Cash Flow quality  "
+        "(5) Institutional Ownership — use get_shareholding_pattern output: show Promoter/FII/DII/Public % "
+        "as of the latest quarter with QoQ delta arrows (↑↓) for each. "
+        "Also include DSP MF cross-ownership from get_mf_holdings_for_stock.  "
+        "(6) News Sentiment  "
         "(7) Key Risks  (8) Recommendation (BUY/HOLD/SELL/WATCH + one-line rationale)\n\n"
-        "RULES: All monetary values in ₹. Never invent figures."
+        "RULES: All monetary values in ₹. Never invent figures.\n\n"
+        "DATA AVAILABILITY: If a ClickHouse query returns 0 rows, or plot_price_chart "
+        "returns 'No price data found', call `check_and_refresh_symbol_data(symbol)` "
+        "to auto-import the data, then retry the query or chart tool."
     )
 
     def _get_tools(self) -> list:
         from src.tools.company_resolver import resolve_company
         from src.tools.yahoo_finance import YAHOO_TOOLS
-        from src.tools.earnings_scraper import EARNINGS_TOOLS
+        from src.tools.earnings_scraper import EARNINGS_TOOLS  # includes get_shareholding_pattern
         from src.tools.news_search import get_stock_news
         from src.tools.newsapi_search import get_newsapi_stock_news
-        from src.tools.skills_tools import query_clickhouse_db
+        from src.tools.skills_tools import query_clickhouse_db, import_symbol_data
         from src.tools.indian_equity_tools import INDIAN_EQUITY_TOOLS
+        from src.tools.chart_tools import plot_price_chart
+        from src.tools.agent_tools import check_and_refresh_symbol_data
         return (
             [resolve_company]
             + YAHOO_TOOLS
             + EARNINGS_TOOLS
-            + [get_stock_news, get_newsapi_stock_news, query_clickhouse_db]
+            + [get_stock_news, get_newsapi_stock_news, query_clickhouse_db,
+               import_symbol_data, check_and_refresh_symbol_data, plot_price_chart]
             + INDIAN_EQUITY_TOOLS
         )
 
@@ -725,6 +792,11 @@ class SignalSubAgent(_SubAgent):
         "CRITICAL: Never invent composite scores or labels like ACCUMULATE/STRONG BUY. "
         "Use regime_signal and blended_50 exactly as the pipeline outputs them. "
         "Format all signal tables in clean Markdown.\n\n"
+        "## iNAV / Premium freshness\n"
+        "iNAV data is automatically kept current. During market hours (IST 09:15–15:30) "
+        "the system fetches a live NSE snapshot if the DB copy is older than 10 minutes. "
+        "Tool output includes an `inav_source` field: 'db' = cached, 'nse_api_live' = just "
+        "fetched. Always report which source was used and the snapshot timestamp.\n\n"
         "## Charts\n"
         "Call chart tools when the user asks to visualise signals or weights:\n"
         "- `plot_signal_scores()` — overall composite scores for all ETFs\n"
@@ -740,6 +812,8 @@ class SignalSubAgent(_SubAgent):
             run_goldbees_pipeline,
             run_etf_news_sentiment,
             run_risk_governor_analysis,
+            run_premium_alerts,
+            get_live_inav,
             query_clickhouse_db,
         )
         from src.tools.chart_tools import (
@@ -752,6 +826,8 @@ class SignalSubAgent(_SubAgent):
             run_goldbees_pipeline,
             run_etf_news_sentiment,
             run_risk_governor_analysis,
+            run_premium_alerts,
+            get_live_inav,
             query_clickhouse_db,
             plot_price_chart,
             plot_signal_scores,
@@ -873,6 +949,15 @@ to show how much of each ETF's return is FX-driven vs index-driven.
 This agent is read-only. If the user asks to import, refresh, or update NAV/price data,
 tell them to use: `python src/main.py import --category etfs`
 or type: "import etfs" in the chat (routes to the main agent).
+
+## iNAV Freshness
+Premium data is automatically kept current:
+- **During market hours (IST 09:15–15:30)**: if the DB snapshot is older than 10 minutes
+  the tool fetches live iNAV from the NSE API and stores the result. The `inav_source`
+  field in tool output will show `"nse_api_live"` when this happens.
+- **Outside market hours**: last stored snapshot (up to 4 days old) is used.
+When reporting a premium, always mention the snapshot timestamp so the user knows
+whether they are seeing live or cached data.
 
 ## Rules
 - Never invent numbers — use only tool output.
@@ -1120,6 +1205,9 @@ class AutonomousResearchAgent(_SubAgent):
     news with agent-chosen date windows, MF holding pattern analysis,
     institutional flows, ClickHouse queries, and custom Python execution.
     """
+
+    # 10-layer framework + optional delegation calls + synthesis
+    RECURSION_LIMIT = 50
 
     SYSTEM_PROMPT = """\
 You are the Mosaic Autonomous Research Agent — a self-directed, multi-domain analyst

--- a/src/clients/mcp_client.py
+++ b/src/clients/mcp_client.py
@@ -35,12 +35,46 @@ class KiteMCPClient:
     We use the 'tools/call' method to invoke MCP tools.
     """
 
+    # Session file persists the session_id across restarts / new client instances.
+    _SESSION_FILE = "/tmp/.kite_mcp_session"
+
+    @classmethod
+    def _load_session(cls) -> str | None:
+        """Load persisted session_id from disk."""
+        import os, json as _json
+        try:
+            if os.path.exists(cls._SESSION_FILE):
+                data = _json.loads(open(cls._SESSION_FILE).read())
+                return data.get("session_id")
+        except Exception:
+            pass
+        return None
+
+    @classmethod
+    def _save_session(cls, session_id: str) -> None:
+        """Persist session_id to disk for reuse across instances."""
+        import json as _json
+        try:
+            open(cls._SESSION_FILE, "w").write(_json.dumps({"session_id": session_id}))
+        except Exception:
+            pass
+
+    @classmethod
+    def _clear_session(cls) -> None:
+        """Remove stale session file."""
+        import os
+        try:
+            os.remove(cls._SESSION_FILE)
+        except FileNotFoundError:
+            pass
+
     def __init__(self) -> None:
         # [NON-SENSITIVE] MCP endpoint URL (from config)
         self._base_url: str = settings.kite_mcp_url.rstrip("/")
         self._timeout: int = settings.kite_mcp_timeout
         self._client: httpx.AsyncClient | None = None
-        self._session_id: str | None = None
+        self._session_id: str | None = self._load_session()   # Kite OAuth session (legacy cookie)
+        self._mcp_session_id: str | None = self._load_session()  # MCP protocol session ID
         self._runner = CommandRunner(max_retries=3)
 
     # ── Context Manager ───────────────────────────────────────────────────────
@@ -51,7 +85,56 @@ class KiteMCPClient:
             headers={"Content-Type": "application/json"},
         )
         logger.info("KiteMCPClient connected to %s", self._base_url)
+        # Reuse persisted session if available — re-initialising would create a
+        # NEW unauthenticated session, discarding the one the user logged into.
+        if not self._mcp_session_id:
+            await self._mcp_initialize()
+        else:
+            logger.info(
+                "KiteMCPClient: reusing persisted mcp-session-id (%s…)",
+                self._mcp_session_id[:12],
+            )
         return self
+
+    async def _mcp_initialize(self) -> None:
+        """
+        Perform the MCP protocol handshake.
+
+        The Kite MCP server (mcp.kite.trade v0.3.1) requires:
+          1. POST initialize  → server returns mcp-session-id in response headers
+          2. POST notifications/initialized (with Mcp-Session-Id header)
+        All subsequent tool calls must carry this Mcp-Session-Id header.
+        """
+        if self._client is None:
+            return
+        try:
+            r = await self._client.post(
+                self._base_url,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 0,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {},
+                        "clientInfo": {"name": "mosaic-agent", "version": "1.0"},
+                    },
+                },
+            )
+            sid = r.headers.get("mcp-session-id")
+            if sid:
+                self._mcp_session_id = sid
+                self._save_session(sid)
+                logger.info("KiteMCPClient: mcp-session-id established (%s…)", sid[:12])
+            # Send initialized notification to complete handshake
+            if self._mcp_session_id:
+                await self._client.post(
+                    self._base_url,
+                    json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+                    headers={"Mcp-Session-Id": self._mcp_session_id},
+                )
+        except Exception as exc:
+            logger.warning("KiteMCPClient: MCP initialize failed: %s", exc)
 
     async def __aexit__(self, *_: Any) -> None:
         if self._client:
@@ -84,8 +167,11 @@ class KiteMCPClient:
             },
         }
 
-        # Attach session cookie if we have one from a previous login
+        # Every call must carry the MCP protocol session ID as a header.
         headers = {}
+        if self._mcp_session_id:
+            headers["Mcp-Session-Id"] = self._mcp_session_id
+        # Also send legacy Kite session cookie if captured from OAuth callback.
         if self._session_id:
             headers["Cookie"] = f"session_id={self._session_id}"
 
@@ -96,16 +182,29 @@ class KiteMCPClient:
             json=payload,
             headers=headers,
         )
+        if response.status_code == 400:
+            body = response.text[:200]
+            if tool_name != "login":
+                # Kite OAuth session expired — clear and prompt re-login.
+                self._session_id = None
+                self._clear_session()
+                raise RuntimeError(
+                    "Kite session expired. Run: initiate_kite_login() → "
+                    "open the URL in your browser → retry."
+                )
+            # login itself returning 400 means MCP session gone — fall through
+            logger.warning("KiteMCPClient: login 400 (%s) — MCP session may be stale", body[:80])
         response.raise_for_status()
 
         data = response.json()
 
-        # Capture Set-Cookie from Kite login if present
+        # Capture Set-Cookie from Kite login if present — persist to disk
         if "set-cookie" in response.headers:
             cookie = response.headers["set-cookie"]
             if "session_id=" in cookie:
                 self._session_id = cookie.split("session_id=")[1].split(";")[0]
-                logger.debug("MCP session_id captured")
+                self._save_session(self._session_id)
+                logger.info("KiteMCPClient: session_id captured and persisted")
 
         if "error" in data:
             raise RuntimeError(

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -184,15 +184,18 @@ AGENT GUIDE — read every entry before choosing
 
 ── signal ──────────────────────────────────────
 When: ETF composite scores, GOLDBEES ML pipeline, Kelly / blended position weights,
-      GARCH risk governor, iNAV premium alerts, ETF category news sentiment.
+      GARCH risk governor, live iNAV / NAV queries, premium alerts, ETF category news sentiment.
 Key tools: run_goldbees_pipeline · run_daily_signal_composite · run_risk_governor_analysis ·
-           run_etf_news_sentiment · run_premium_alerts · plot_signal_scores ·
+           get_live_inav(symbol) · run_etf_news_sentiment · run_premium_alerts · plot_signal_scores ·
            plot_signal_breakdown · plot_weight_recommendations · plot_garch_volatility_chart
 Examples:
   "GOLDBEES signal today"        → 1. run_goldbees_pipeline() — report prob_up, regime_signal, blended_50
   "composite scores all ETFs"    → 1. run_daily_signal_composite()  2. plot_signal_scores()
   "GOLDBEES position size"       → 1. run_risk_governor_analysis()  2. plot_garch_volatility_chart("GOLDBEES")
   "iNAV premium alerts"          → 1. run_premium_alerts()
+  "what is iNAV of SILVERBEES"   → 1. get_live_inav("SILVERBEES")
+  "GOLDBEES current NAV"         → 1. get_live_inav("GOLDBEES")
+  "is HNGSNGBEES at premium"     → 1. get_live_inav("HNGSNGBEES")
   "ETF news sentiment"           → 1. run_etf_news_sentiment()
 
 ── macro ────────────────────────────────────────
@@ -307,7 +310,8 @@ Examples:
   "import --category fii_dii"    → 1. Import FII/DII flows → run_data_engineering_importer(category="fii_dii")
   "import --category mf"         → 1. Import MF NAV data → run_data_engineering_importer(category="mf")
   "import --category cot"        → 1. Import COMEX COT positioning → run_data_engineering_importer(category="cot")
-  "import --full"                → 1. Full backfill → run_data_engineering_importer(category="etfs,stocks,mf,fii_dii,cot,fx_rates", full=True)
+  "import --full"                → 1. Full backfill → run_data_engineering_importer(category="etfs,stocks,mf,fii_dii,cot,fx_rates,inav", full=True)
+  "import inav"                  → 1. Live NSE iNAV snapshot → run_data_engineering_importer(category="inav")
   "refresh nav data"             → 1. run_data_engineering_importer(category="etfs")
   "sync fii dii"                 → 1. run_data_engineering_importer(category="fii_dii")
   "import all data"              → 1. run_data_engineering_importer(category="etfs,stocks,mf,fii_dii,cot,fx_rates")
@@ -340,7 +344,8 @@ ClickHouse schema (database = market_data, all tables use ReplacingMergeTree —
   signal_composite    : as_of(Date), etf_symbol, composite_score(Float32), action, macro_score, ml_score
   ml_predictions      : as_of(Date), expected_return_pct, regime_signal, cv_r2_mean, goldbees_close
   weight_checkpoints  : as_of(Date), symbol, method, recommended_weight, garch_vol_pct, regime
-  inav_snapshots      : symbol, snapshot_at(DateTime), inav, market_price, premium_discount_pct
+  inav_snapshots      : symbol, snapshot_at(DateTime), inav(Float64), market_price(Float64), premium_discount_pct(Float64), source(String)
+  -- NOTE: for current iNAV use get_live_inav(symbol) NOT raw SQL — it auto-refreshes from NSE if DB is stale
   cot_gold            : report_date(Date), mm_long, mm_short, mm_net, open_interest
   fx_rates            : trade_date(Date), symbol, close(Float64)
   macro_indicators    : ref_year, country_code, indicator_code, indicator_name, value

--- a/src/importer/fetchers/kite_inav_fetcher.py
+++ b/src/importer/fetchers/kite_inav_fetcher.py
@@ -1,0 +1,178 @@
+"""
+src/importer/fetchers/kite_inav_fetcher.py
+───────────────────────────────────────────
+Fetch live iNAV for Indian ETFs via Kite Connect's public instrument quote.
+
+NSE publishes iNAV as separate non-tradeable instruments (e.g. GOLDBEINAV,
+SILVERINAV, MON100INAV).  These are live, AMC-published values updated every
+~15 seconds during market hours — the true intraday iNAV, not the previous
+day's declared NAV returned by NSE's /api/etf endpoint.
+
+No Kite Connect subscription is needed for the instrument lookup.
+The quote API does require a valid Kite session (api_key + access_token).
+Falls back gracefully when Kite is not configured.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# NSE iNAV instrument symbols for every ETF we track.
+# Source: Kite instruments dump — https://api.kite.trade/instruments/NSE
+# Update this map when new ETFs are added.
+INAV_INSTRUMENT_MAP: dict[str, str] = {
+    # Domestic commodity ETFs
+    "GOLDBEES":    "GOLDBEINAV",
+    "SILVERBEES":  "SILVERINAV",
+    "SILVERCASE":  "SILVERINAV",     # same underlying silver
+    "GOLDCASE":    "GOLDBEINAV",     # same underlying gold
+
+    # Domestic equity / fixed-income ETFs
+    "NIFTYBEES":   "NIFTYBINAV",
+    "JUNIORBEES":  "MID150INAV",     # closest proxy
+    "BANKBEES":    "BANKBINAV",
+    # PSUBNKBEES has no dedicated Kite iNAV instrument
+    "LIQUIDBEES":  "LIQUIDINAV",
+    "MID150BEES":  "MID150INAV",
+    "PHARMABEES":  "PHARMAINAV",
+    "AUTOBEES":    "AUTOBEINAV",
+    "LTGILTBEES":  "LTGILTINAV",
+
+    # International ETFs (overseas market closed during Indian hours;
+    # prev-day NAV is the correct reference — no dedicated Kite iNAV instrument)
+    "MAFANG":      "MAFANGINAV",
+    "MON100":      "MON100INAV",
+    "MASPTOP50":   "MASPTOINAV",
+    "MAHKTECH":    "MAHKTEINAV",
+    "MONQ50":      "MONQ50INAV",
+    # HNGSNGBEES and PSUBNKBEES have no Kite iNAV instrument — fall back to NSE API
+}
+
+# Pre-resolved instrument tokens (avoids an instruments API call on every fetch).
+# Source: Kite /instruments/NSE dump.  Refresh if tokens ever change.
+INAV_TOKEN_MAP: dict[str, int] = {
+    "GOLDBEINAV":  2106113,
+    "SILVERINAV":  2108929,
+    "NIFTYBINAV":  5641473,
+    "BANKBINAV":   5629185,
+    "LIQUIDINAV":  2593793,
+    "MID150INAV":  2594305,
+    "PHARMAINAV":  2598145,
+    "AUTOBEINAV":  2598401,
+    "LTGILTINAV":  2594049,
+    "MAFANGINAV":  2590209,
+    "MON100INAV":  2593281,
+    "MASPTOINAV":  2590465,
+    "MAHKTEINAV":  2586881,
+    "MONQ50INAV":  2592769,
+}
+
+
+def _build_kite() -> Any | None:
+    """Return a KiteConnect instance using env/settings credentials, or None."""
+    try:
+        from kiteconnect import KiteConnect
+        from config.settings import settings
+        api_key     = getattr(settings, "kite_api_key",     None)
+        access_token = getattr(settings, "kite_access_token", None)
+        if not api_key or not access_token:
+            logger.debug("kite_inav_fetcher: Kite credentials not set — skipping")
+            return None
+        kite = KiteConnect(api_key=api_key)
+        kite.set_access_token(access_token)
+        return kite
+    except ImportError:
+        logger.debug("kite_inav_fetcher: kiteconnect package not installed")
+        return None
+    except Exception as exc:
+        logger.warning("kite_inav_fetcher: Kite init failed: %s", exc)
+        return None
+
+
+def fetch_inav_kite(symbols: list[str]) -> list[dict[str, Any]]:
+    """
+    Fetch live iNAV snapshots for *symbols* via Kite Connect quote API.
+
+    Each returned dict has the same schema as nse_inav_fetcher rows:
+        symbol, snapshot_at (naive UTC), inav, market_price,
+        premium_discount_pct, source
+
+    Returns an empty list if Kite is not configured or the API call fails.
+    """
+    kite = _build_kite()
+    if kite is None:
+        return []
+
+    clean   = {s.upper().replace(".NS", "") for s in symbols}
+    snapshot_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    # Build the list of iNAV instruments to quote
+    instrument_keys: list[str] = []
+    etf_for_inav:    dict[str, str] = {}   # inav_sym → etf_sym
+
+    for etf in clean:
+        inav_sym = INAV_INSTRUMENT_MAP.get(etf)
+        if inav_sym:
+            nse_key = f"NSE:{inav_sym}"
+            instrument_keys.append(nse_key)
+            etf_for_inav[inav_sym] = etf
+        else:
+            logger.debug("kite_inav_fetcher: no iNAV mapping for %s", etf)
+
+    if not instrument_keys:
+        return []
+
+    # Also quote the ETF market prices in one call
+    etf_keys = [f"NSE:{e}" for e in clean if e in INAV_INSTRUMENT_MAP]
+    all_keys  = instrument_keys + etf_keys
+
+    try:
+        quotes = kite.quote(all_keys)
+    except Exception as exc:
+        logger.warning("kite_inav_fetcher: quote API failed: %s", exc)
+        return []
+
+    # Build ETF → market_price lookup
+    ltp_map: dict[str, float] = {}
+    for etf in clean:
+        key = f"NSE:{etf}"
+        if key in quotes:
+            ltp_map[etf] = float(quotes[key].get("last_price", 0))
+
+    rows: list[dict[str, Any]] = []
+    for inav_sym, etf in etf_for_inav.items():
+        key = f"NSE:{inav_sym}"
+        if key not in quotes:
+            logger.debug("kite_inav_fetcher: no quote returned for %s", key)
+            continue
+
+        inav_val = float(quotes[key].get("last_price", 0))
+        if inav_val <= 0:
+            logger.debug("kite_inav_fetcher: zero iNAV for %s", inav_sym)
+            continue
+
+        market_price = ltp_map.get(etf, inav_val)
+        prem_disc    = ((market_price - inav_val) / inav_val * 100) if inav_val else 0.0
+
+        rows.append({
+            "symbol":               etf,
+            "snapshot_at":          snapshot_at,
+            "inav":                 round(inav_val, 4),
+            "market_price":         round(market_price, 4),
+            "premium_discount_pct": round(prem_disc, 4),
+            "source":               "Kite",
+        })
+        logger.debug(
+            "kite_inav_fetcher: %s iNAV=%.4f LTP=%.4f prem=%.4f%%",
+            etf, inav_val, market_price, prem_disc,
+        )
+
+    logger.info(
+        "kite_inav_fetcher: fetched %d iNAV snapshots via Kite at %s UTC",
+        len(rows), snapshot_at,
+    )
+    return rows

--- a/src/importer/fetchers/nse_inav_fetcher.py
+++ b/src/importer/fetchers/nse_inav_fetcher.py
@@ -90,14 +90,20 @@ def fetch_inav_snapshots(symbols: list[str]) -> list[dict[str, Any]]:
         if sym not in clean:
             continue
 
-        raw_inav = entry.get("nav") or entry.get("iNav")
+        # NSE's "nav" field is the PREVIOUS DAY's declared NAV (navDate in response header),
+        # not a live intraday iNAV. NSE does not expose real-time iNAV through public APIs.
+        # For international ETFs (HNGSNGBEES, MAFANG…) this is the correct reference
+        # since the overseas market is closed during Indian hours.
+        # For domestic commodity ETFs (GOLDBEES, SILVERBEES…) the true live iNAV would
+        # require computing from current MCX/COMEX prices.
+        raw_nav  = entry.get("nav") or entry.get("iNav")
         raw_ltp  = entry.get("ltP") or entry.get("lastPrice")
 
-        if raw_inav is None:
-            logger.debug("No iNAV value for %s in NSE response", sym)
+        if raw_nav is None:
+            logger.debug("No NAV value for %s in NSE response", sym)
             continue
 
-        inav         = _safe(raw_inav)
+        inav         = _safe(raw_nav)        # prev-day declared NAV used as reference
         market_price = _safe(raw_ltp) if raw_ltp is not None else inav
         prem_disc    = ((market_price - inav) / inav * 100) if inav else 0.0
 
@@ -129,5 +135,160 @@ def fetch_inav_snapshots(symbols: list[str]) -> list[dict[str, Any]]:
             "source":               "NSE",
         })
 
-    logger.info("NSE iNAV: captured %d snapshot(s) at %s UTC", len(rows), snapshot_at)
+    from src.utils.ist import utc_to_ist
+    _snap_ist = utc_to_ist(snapshot_at).strftime("%Y-%m-%d %H:%M:%S IST")
+    logger.info("NSE iNAV: captured %d snapshot(s) at %s", len(rows), _snap_ist)
     return rows
+
+
+def _is_market_open() -> bool:
+    """Return True if NSE is currently in its normal trading session (IST 09:15–15:30)."""
+    from datetime import datetime, timezone, timedelta
+    ist = datetime.now(timezone(timedelta(hours=5, minutes=30)))
+    if ist.weekday() >= 5:          # Saturday / Sunday
+        return False
+    open_t  = ist.replace(hour=9,  minute=15, second=0, microsecond=0)
+    close_t = ist.replace(hour=15, minute=30, second=0, microsecond=0)
+    return open_t <= ist <= close_t
+
+
+def get_latest_inav(
+    symbol: str,
+    max_age_days: int = 4,
+    max_age_minutes: int | None = None,
+    store_to_db: bool = True,
+) -> dict[str, Any] | None:
+    """
+    Return the latest iNAV snapshot for *symbol*.
+
+    During market hours (IST 09:15–15:30) freshness is evaluated against
+    *max_age_minutes* (default 10 min) — iNAV updates every ~15 s, so data
+    older than that is treated as stale and triggers a live NSE API call.
+    Outside market hours the coarser *max_age_days* threshold applies.
+
+    Resolution order:
+      1. ClickHouse ``inav_snapshots`` — if row is fresh enough
+      2. NSE API live fetch            — if DB is stale/empty
+         Stores the fresh snapshot to DB when ``store_to_db=True``.
+
+    Returns a dict with keys:
+        symbol, premium_discount_pct, inav, market_price, snapshot_at, source
+    or None if both DB and NSE API return nothing.
+    """
+    sym = symbol.strip().upper().replace(".NS", "")
+
+    # During market hours use a tight minute-level window; otherwise use days.
+    if max_age_minutes is None:
+        max_age_minutes = 2       # default: 2 min — iNAV updates every 15s, keep data fresh
+    if _is_market_open():
+        age_clause = f"snapshot_at >= now() - INTERVAL {max_age_minutes} MINUTE"
+        threshold_desc = f"{max_age_minutes} min"
+    else:
+        age_clause = f"snapshot_at >= now() - INTERVAL {max_age_days} DAY"
+        threshold_desc = f"{max_age_days} days"
+
+    # ── 1. Try ClickHouse ─────────────────────────────────────────────────
+    try:
+        from src.db.pool import get_pool
+        pool = get_pool()
+        rows_db = pool.query_df(
+            f"""
+            SELECT premium_discount_pct, inav, market_price, snapshot_at
+            FROM market_data.inav_snapshots FINAL
+            WHERE symbol = '{sym}'
+              AND {age_clause}
+            ORDER BY snapshot_at DESC
+            LIMIT 1
+            """
+        )
+        if not rows_db.empty:
+            r = rows_db.iloc[0]
+            logger.debug("get_latest_inav: %s found in DB (within %s)", sym, threshold_desc)
+            return {
+                "symbol":               sym,
+                "premium_discount_pct": float(r["premium_discount_pct"]),
+                "inav":                 float(r["inav"]),
+                "market_price":         float(r["market_price"]),
+                "snapshot_at":          r["snapshot_at"],
+                "source":               "db",
+            }
+        logger.info(
+            "get_latest_inav: %s DB snapshot older than %s — fetching live",
+            sym, threshold_desc,
+        )
+    except Exception as exc:
+        logger.warning("get_latest_inav: DB lookup failed for %s: %s", sym, exc)
+
+    # ── 2. Kite iNAV instrument (true live iNAV when Kite is configured) ─
+    # Kite exposes iNAV as non-tradeable NSE instruments (GOLDBEINAV, SILVERINAV…)
+    # These are the real AMC-published intraday iNAV values, updated every ~15s.
+    try:
+        from src.importer.fetchers.kite_inav_fetcher import fetch_inav_kite
+        kite_rows = fetch_inav_kite([sym])
+        if kite_rows:
+            row = kite_rows[0]
+            if store_to_db:
+                try:
+                    from config.settings import settings
+                    from src.importer.clickhouse import ClickHouseImporter
+                    ch = ClickHouseImporter(
+                        host=settings.clickhouse_host, port=settings.clickhouse_port,
+                        database=settings.clickhouse_database,
+                        username=settings.clickhouse_user, password=settings.clickhouse_password,
+                    )
+                    try:
+                        ch.insert_inav_snapshots([row])
+                    finally:
+                        ch.close()
+                except Exception:
+                    pass
+            return {
+                "symbol":               sym,
+                "premium_discount_pct": row["premium_discount_pct"],
+                "inav":                 row["inav"],
+                "market_price":         row["market_price"],
+                "snapshot_at":          row["snapshot_at"],
+                "source":               "kite_live",
+            }
+    except Exception as exc:
+        logger.debug("get_latest_inav: Kite iNAV unavailable for %s: %s", sym, exc)
+
+    # ── 3. Fallback: NSE /api/etf (returns PREVIOUS DAY's declared NAV) ──
+    # Note: NSE's public ETF API only exposes the prior day's AMC-declared NAV.
+    # The /api/quote-equity endpoint (true live iNAV) is Akamai-protected.
+    logger.info("get_latest_inav: %s not in DB or stale — calling NSE API (prev-day NAV)", sym)
+    live_rows = fetch_inav_snapshots([sym])
+    if not live_rows:
+        logger.warning("get_latest_inav: NSE API returned nothing for %s", sym)
+        return None
+
+    row = live_rows[0]
+
+    # ── 3. Persist snapshot so next caller finds it in DB ─────────────────
+    if store_to_db:
+        try:
+            from config.settings import settings
+            from src.importer.clickhouse import ClickHouseImporter
+            ch = ClickHouseImporter(
+                host=settings.clickhouse_host,
+                port=settings.clickhouse_port,
+                database=settings.clickhouse_database,
+                username=settings.clickhouse_user,
+                password=settings.clickhouse_password,
+            )
+            try:
+                ch.insert_inav_snapshots([row])
+                logger.info("get_latest_inav: stored fresh snapshot for %s", sym)
+            finally:
+                ch.close()
+        except Exception as exc:
+            logger.warning("get_latest_inav: failed to store snapshot for %s: %s", sym, exc)
+
+    return {
+        "symbol":               sym,
+        "premium_discount_pct": row["premium_discount_pct"],
+        "inav":                 row["inav"],
+        "market_price":         row["market_price"],
+        "snapshot_at":          row["snapshot_at"],
+        "source":               "nse_api_live",
+    }

--- a/src/plot_goldbees_returns.py
+++ b/src/plot_goldbees_returns.py
@@ -1,0 +1,90 @@
+import os
+import sys
+from pathlib import Path
+import clickhouse_connect
+import pandas as pd
+import numpy as np
+
+# Ensure config is importable (since cwd is /app inside container)
+sys.path.insert(0, "/app")
+
+from config.settings import settings
+
+def main():
+    try:
+        # Initialize ClickHouse connection
+        # Inside the docker container, host is 'clickhouse'
+        client = clickhouse_connect.get_client(
+            host="clickhouse",
+            port=8123,
+            username=settings.clickhouse_user,
+            password=settings.clickhouse_password,
+            database=settings.clickhouse_database
+        )
+        
+        # Query GOLDBEES prices for the last 90 trading days
+        query = """
+            SELECT trade_date,
+                   toFloat64(argMax(close, imported_at)) AS close
+            FROM market_data.daily_prices
+            WHERE symbol = 'GOLDBEES' AND category = 'etfs'
+            GROUP BY trade_date
+            ORDER BY trade_date DESC
+            LIMIT 90
+        """
+        df = client.query_df(query)
+        client.close()
+        
+        if df.empty:
+            print("Error: No price data found for GOLDBEES in ClickHouse.")
+            sys.exit(1)
+            
+        # Order chronologically (ascending)
+        df = df.sort_values("trade_date").reset_index(drop=True)
+        
+        # Calculate daily returns (%)
+        df['daily_return_pct'] = df['close'].pct_change() * 100
+        
+        # Calculate cumulative returns (%)
+        start_price = df['close'].iloc[0]
+        df['cum_return_pct'] = ((df['close'] / start_price) - 1) * 100
+        
+        # Plot using plotext
+        import plotext as plt
+        
+        # Setup data
+        dates = df['trade_date'].astype(str).tolist()
+        cum_returns = df['cum_return_pct'].tolist()
+        
+        # Configure plot
+        plt.clear_figure()
+        plt.plot(list(range(len(cum_returns))), cum_returns, label="GOLDBEES Cumulative Return", color="gold")
+        
+        # Decorate plot
+        latest_return = cum_returns[-1]
+        plt.title(f"GOLDBEES 90-Day Cumulative Return Trend ({dates[0]} to {dates[-1]}) | Latest: {latest_return:+.2f}%")
+        plt.xlabel("Trading Days")
+        plt.ylabel("Return (%)")
+        plt.grid(True)
+        plt.plot_size(90, 20)
+        
+        # Print chart
+        plt.show()
+        
+        # Print summary table
+        print("\n" + "="*50)
+        print(f"GOLDBEES 90-Day Return Metrics:")
+        print(f"  Start Date: {dates[0]} (Price: ₹{df['close'].iloc[0]:.2f})")
+        print(f"  End Date:   {dates[-1]} (Price: ₹{df['close'].iloc[-1]:.2f})")
+        print(f"  Cumulative Return: {latest_return:+.2f}%")
+        print(f"  Daily Return Volatility (Std Dev): {df['daily_return_pct'].std():.2f}%")
+        print(f"  Max 90d Price: ₹{df['close'].max():.2f}")
+        print(f"  Min 90d Price: ₹{df['close'].min():.2f}")
+        print("="*50)
+        
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/chart_tools.py
+++ b/src/tools/chart_tools.py
@@ -58,31 +58,33 @@ def _build(plt: Any) -> str:
 
 
 @tool
-def plot_price_chart(symbol: str, days: int = 60, category: str = "etfs") -> str:
+def plot_price_chart(symbol: str, days: int = 60, category: str = "") -> str:
     """
     Plot a price (close) trend chart for any NSE symbol from ClickHouse.
     Renders as an ASCII line chart directly in the terminal.
 
     Args:
-        symbol:   NSE symbol — e.g. GOLDBEES, NIFTYBEES, RELIANCE
+        symbol:   NSE symbol — e.g. GOLDBEES, NIFTYBEES, RELIANCE, LICI
         days:     Number of trading days to show (default 60)
-        category: 'etfs' or 'stocks' (default 'etfs')
+        category: 'etfs', 'stocks', 'indices', 'commodities' — leave blank to
+                  auto-detect from the database (recommended)
 
     Example: plot_price_chart("GOLDBEES", days=90)
     """
     try:
         from src.db.pool import query_df
+        cat_filter = f"AND category = '{category}'" if category else ""
         df = query_df(f"""
             SELECT trade_date,
                    toFloat64(argMax(close, imported_at)) AS close
             FROM market_data.daily_prices FINAL
-            WHERE symbol = '{symbol.upper()}' AND category = '{category}'
+            WHERE symbol = '{symbol.upper()}' {cat_filter}
               AND trade_date >= today() - {days}
             GROUP BY trade_date
             ORDER BY trade_date ASC
         """)
         if df.empty:
-            return f"No price data found for {symbol} (category={category})."
+            return f"No price data found for {symbol}. Call check_and_refresh_symbol_data('{symbol.upper()}') to import it first."
 
         dates  = df["trade_date"].astype(str).tolist()
         prices = df["close"].tolist()

--- a/src/tools/comex_fetcher.py
+++ b/src/tools/comex_fetcher.py
@@ -186,7 +186,8 @@ def _safe_timestamp(value: object) -> Optional[str]:
         if dt_str.endswith("Z"):
             dt_str = dt_str[:-1] + "+00:00"
         dt = datetime.fromisoformat(dt_str)
-        return dt.strftime("%Y-%m-%d %H:%M:%S UTC")
+        from src.utils.ist import utc_to_ist
+        return utc_to_ist(dt).strftime("%Y-%m-%d %H:%M:%S IST")
     except (TypeError, ValueError) as exc:
         logger.debug("[SECURITY] Invalid timestamp %r: %s", value, exc)
         return None

--- a/src/tools/company_resolver.py
+++ b/src/tools/company_resolver.py
@@ -35,7 +35,10 @@ from src.utils.symbol_mapper import SYMBOL_TO_COMPANY
 
 log = logging.getLogger(__name__)
 
-_YAHOO_SEARCH_URL = "https://query1.finance.yahoo.com/v1/finance/search"
+_YAHOO_SEARCH_URL   = "https://query1.finance.yahoo.com/v1/finance/search"
+_SCREENER_BASE      = "https://www.screener.in"
+# /company/{SYMBOL}/ is the only publicly accessible Screener.in URL pattern;
+# the /api/company/search/ JSON endpoint is blocked outside the browser.
 
 # ── LLM-powered symbol resolver ───────────────────────────────────────────────
 
@@ -163,6 +166,33 @@ _ALIAS: dict[str, str] = {
     "state bank": "SBIN",
     "sbi": "SBIN",
     "sbi life": "SBILIFE",
+    # New-age insurance / fintech
+    "godigit": "GODIGIT",
+    "go digit": "GODIGIT",
+    "digit insurance": "GODIGIT",
+    "digit general insurance": "GODIGIT",
+    "go digit general insurance": "GODIGIT",
+    "go digit insurance": "GODIGIT",
+    "policybazaar": "POLICYBZR",
+    "pb fintech": "POLICYBZR",
+    "paytm": "PAYTM",
+    "one97": "PAYTM",
+    "zomato": "ZOMATO",
+    "nykaa": "NYKAA",
+    "fss technologies": "FSS",
+    "delhivery": "DELHIVERY",
+    # Insurance
+    "lic": "LICI",
+    "lic india": "LICI",
+    "lic of india": "LICI",
+    "life insurance": "LICI",
+    "life insurance corporation": "LICI",
+    "life insurance corporation of india": "LICI",
+    "hdfc life insurance": "HDFCLIFE",
+    "sbi life insurance": "SBILIFE",
+    "icici lombard": "ICICOLOMB",
+    "new india assurance": "NIACL",
+    "star health": "STARHEALTH",
     # IT giants
     "tcs": "TCS",
     "tata consultancy services": "TCS",
@@ -351,19 +381,25 @@ def _local_indian_lookup(query: str) -> Optional[str]:
     if upper in SYMBOL_TO_COMPANY:
         return upper
 
-    # 4. Partial alias match — longest suffix match wins
+    # 4. Partial alias match — word-tokenized, longest word-count match wins.
+    # Uses word boundaries to avoid "lt" matching "ltd" inside "insurance ltd".
+    q_words = q.split()
     best: tuple[int, str] = (0, "")
     for alias, sym in _ALIAS.items():
-        if alias in q or q in alias:
-            if len(alias) > best[0]:
-                best = (len(alias), sym)
+        alias_words = alias.split()
+        n = len(alias_words)
+        # Alias must match a contiguous block of words in the query (not a substring)
+        for i in range(len(q_words) - n + 1):
+            if q_words[i : i + n] == alias_words and n > best[0]:
+                best = (n, sym)
+                break
     if best[1]:
         return best[1]
 
     # 5. Fuzzy match — catches typos like "adanai" → "adani"
     import difflib
     all_keys = list(_ALIAS.keys()) + list(_NAME_TO_NSE.keys())
-    matches = difflib.get_close_matches(q, all_keys, n=1, cutoff=0.75)
+    matches = difflib.get_close_matches(q, all_keys, n=1, cutoff=0.85)
     if matches:
         matched_key = matches[0]
         sym = _ALIAS.get(matched_key) or _NAME_TO_NSE.get(matched_key)
@@ -435,7 +471,20 @@ def resolve_company_info(query: str) -> dict:
             and not q.get("symbol", "").startswith("^")
         ]
 
-        for quote in quotes:
+        # Separate Indian vs US results and always prefer Indian first.
+        # This prevents a US OTC ticker (e.g. LICT) from shadowing an NSE
+        # listing (e.g. LICICORP.NS) just because Yahoo returns it earlier.
+        indian_quotes = []
+        us_quotes = []
+        for q in quotes:
+            s = q.get("symbol", "")
+            e = q.get("exchange", "")
+            if e in _INDIAN_CODES or s.endswith(".NS") or s.endswith(".BO"):
+                indian_quotes.append(q)
+            elif e in _US_CODES:
+                us_quotes.append(q)
+
+        for quote in indian_quotes + us_quotes:
             sym          = quote.get("symbol", "")
             exch_code    = quote.get("exchange", "")
             display_name = quote.get("shortname") or quote.get("longname") or sym
@@ -445,7 +494,6 @@ def resolve_company_info(query: str) -> dict:
                 or sym.endswith(".NS")
                 or sym.endswith(".BO")
             )
-            is_us = exch_code in _US_CODES and not is_indian
 
             clean = re.sub(r"\.(NS|BO|BSE)$", "", sym, flags=re.I)
 
@@ -462,7 +510,7 @@ def resolve_company_info(query: str) -> dict:
                     "currency":     "INR",
                     "source":       "yahoo_search",
                 }
-            elif is_us:
+            else:
                 return {
                     "symbol":       sym,
                     "nse_symbol":   None,
@@ -476,9 +524,70 @@ def resolve_company_info(query: str) -> dict:
     except Exception as exc:
         log.warning("Yahoo Finance search failed for %r: %s", query, exc)
 
-    # ── 3. Fallback — treat as NSE symbol ──────────────────────────────────
+    # ── 3. Yahoo Finance (India-focused re-query) ──────────────────────────
+    # Re-query with region=IN to surface Indian listings the US-region
+    # search may have missed. Only Screener.in's /company/{SYMBOL}/ URL
+    # pattern works (search API is blocked); symbol validation uses that.
+    try:
+        resp_in = requests.get(
+            _YAHOO_SEARCH_URL,
+            params={"q": _yahoo_query, "lang": "en-IN", "region": "IN", "quotesCount": 6},
+            headers=_HEADERS,
+            timeout=_TIMEOUT,
+        )
+        resp_in.raise_for_status()
+        for q_item in resp_in.json().get("quotes", []):
+            s = q_item.get("symbol", "")
+            e = q_item.get("exchange", "")
+            if (e in _INDIAN_CODES or s.endswith(".NS") or s.endswith(".BO")) \
+                    and q_item.get("quoteType") in ("EQUITY", "STOCK"):
+                clean = re.sub(r"\.(NS|BO)$", "", s, flags=re.I)
+                yf_sym = s if s.endswith((".NS", ".BO")) else f"{clean}.NS"
+                display = q_item.get("shortname") or q_item.get("longname") or clean
+                log.info("resolve_company: Yahoo-IN found %r → %s (%s)", query, clean, display)
+                return {
+                    "symbol":       clean,
+                    "nse_symbol":   clean,
+                    "yf_symbol":    yf_sym,
+                    "exchange":     "BSE" if s.endswith(".BO") else "NSE",
+                    "market":       "India",
+                    "company_name": display,
+                    "currency":     "INR",
+                    "source":       "yahoo_search_in",
+                }
+    except Exception as exc:
+        log.warning("Yahoo Finance (IN) search failed for %r: %s", query, exc)
+
+    # ── 4. Fallback — treat as NSE symbol, validate via Screener.in URL ────
+    # Only /company/{SYMBOL}/ works (search API is blocked in Docker).
+    # A 200 response confirms the symbol is a real NSE listing.
     upper = query.strip().upper().split()[0]    # first word as ticker
     log.info("resolve_company: falling back to NSE for %r → %s", query, upper)
+    try:
+        verify_url = f"{_SCREENER_BASE}/company/{upper}/"
+        resp = requests.get(verify_url, headers=_HEADERS, timeout=_TIMEOUT)
+        if resp.status_code == 200:
+            # Extract company name from page title: "Name | ... - Screener"
+            from bs4 import BeautifulSoup as _BS
+            soup = _BS(resp.text, "lxml")
+            title_tag = soup.find("title")
+            title_text = title_tag.get_text(strip=True) if title_tag else upper
+            # Title format: "Company Name share price | ... - Screener"
+            company_name = title_text.split(" share price")[0].split("|")[0].strip() or upper
+            log.info("resolve_company: Screener.in validated %r → %s (%s)", upper, upper, company_name)
+            return {
+                "symbol":       upper,
+                "nse_symbol":   upper,
+                "yf_symbol":    f"{upper}.NS",
+                "exchange":     "NSE",
+                "market":       "India",
+                "company_name": company_name,
+                "currency":     "INR",
+                "source":       "fallback",
+            }
+    except Exception:
+        pass
+    # Ticker not validated — still return best guess but flag it
     return {
         "symbol":       upper,
         "nse_symbol":   upper,
@@ -487,7 +596,7 @@ def resolve_company_info(query: str) -> dict:
         "market":       "India",
         "company_name": upper,
         "currency":     "INR",
-        "source":       "fallback",
+        "source":       "fallback_unverified",
     }
 
 

--- a/src/tools/earnings_scraper.py
+++ b/src/tools/earnings_scraper.py
@@ -69,33 +69,42 @@ def fetch_from_screener(symbol: str) -> QuarterlyResult | None:
     url = f"{SCREENER_BASE}/company/{symbol}/consolidated/"
     logger.info("Scraping Screener.in for %s: %s", symbol, url)
 
+    def _fetch_and_parse(page_url: str):
+        """Fetch a Screener.in URL and return (soup, rows) or (None, None)."""
+        try:
+            r = requests.get(page_url, headers=HEADERS, timeout=15)
+        except Exception as exc:
+            logger.warning("Screener.in request failed for %s: %s", page_url, exc)
+            return None, None
+        if r.status_code != 200:
+            return None, None
+        s = BeautifulSoup(r.text, "lxml")
+        qs = s.find("section", {"id": "quarters"})
+        if not qs:
+            return None, None
+        t = qs.find("table")
+        if not t:
+            return None, None
+        tr = t.find_all("tr")
+        # Guard: a valid table has data cells (>1 cell per row).
+        # Consolidated pages sometimes return 200 but contain only label
+        # cells with no data — treat that as a miss and fall through.
+        data_rows = [r for r in tr[1:] if len(r.find_all(["th", "td"])) > 1]
+        if not data_rows:
+            return None, None
+        return s, tr
+
     try:
-        resp = requests.get(url, headers=HEADERS, timeout=15)
+        soup, rows = _fetch_and_parse(url)
 
-        # Try standalone (non-consolidated) if consolidated not found
-        if resp.status_code == 404:
+        # Fall through to standalone URL if consolidated had no data
+        if rows is None:
             url = f"{SCREENER_BASE}/company/{symbol}/"
-            resp = requests.get(url, headers=HEADERS, timeout=15)
+            logger.info("Screener.in: consolidated empty for %s — trying standalone", symbol)
+            soup, rows = _fetch_and_parse(url)
 
-        if resp.status_code != 200:
-            logger.warning("Screener.in returned %d for %s", resp.status_code, symbol)
-            return None
-
-        soup = BeautifulSoup(resp.text, "lxml")
-
-        # ── Find quarterly results table ──────────────────────────────────────
-        # Screener uses a section with id="quarters"
-        quarters_section = soup.find("section", {"id": "quarters"})
-        if not quarters_section:
-            logger.warning("No quarterly section found on Screener.in for %s", symbol)
-            return None
-
-        table = quarters_section.find("table")
-        if not table:
-            return None
-
-        rows = table.find_all("tr")
-        if len(rows) < 2:
+        if rows is None:
+            logger.warning("No quarterly data found on Screener.in for %s", symbol)
             return None
 
         # Header row: Mar 2024, Jun 2024, Sep 2024, Dec 2024 ...
@@ -290,5 +299,94 @@ def get_quarterly_results(input_str: str) -> dict[str, Any]:
     }
 
 
+@tool
+def get_shareholding_pattern(symbol: str) -> dict:
+    """
+    Fetch the latest quarterly shareholding pattern for an Indian NSE/BSE stock
+    from Screener.in. Returns Promoter, FII, DII, Government, and Public/Retail
+    holding percentages plus QoQ change for each category.
+
+    Args:
+        symbol: NSE symbol — e.g. "HDFCBANK", "RELIANCE", "LICI"
+
+    Returns:
+        Dict with latest_quarter, promoter_pct, fii_pct, dii_pct,
+        government_pct, public_pct, num_shareholders, and QoQ deltas.
+    """
+    sym = symbol.strip().upper()
+    for path in (f"/company/{sym}/consolidated/", f"/company/{sym}/"):
+        try:
+            resp = requests.get(
+                f"{SCREENER_BASE}{path}",
+                headers=HEADERS,
+                timeout=15,
+            )
+            if resp.status_code != 200:
+                continue
+
+            soup = BeautifulSoup(resp.text, "lxml")
+            sh_section = soup.find("section", {"id": "shareholding"})
+            if not sh_section:
+                continue
+
+            div = sh_section.find("div", {"id": "quarterly-shp"})
+            if not div:
+                continue
+
+            table = div.find("table")
+            if not table:
+                continue
+
+            rows = table.find_all("tr")
+            if len(rows) < 2:
+                continue
+
+            headers = [th.get_text(strip=True) for th in rows[0].find_all(["th", "td"])]
+            latest_quarter = headers[-1] if headers else ""
+
+            def _pct(text: str) -> float:
+                cleaned = text.replace("%", "").strip()
+                try:
+                    return round(float(cleaned), 2)
+                except ValueError:
+                    return 0.0
+
+            result: dict = {"symbol": sym, "latest_quarter": latest_quarter, "source": f"{SCREENER_BASE}{path}"}
+            label_map = {
+                "promoters":     "promoter_pct",
+                "fiis":          "fii_pct",
+                "diis":          "dii_pct",
+                "government":    "government_pct",
+                "public":        "public_pct",
+            }
+            for row in rows[1:]:
+                cells = row.find_all(["th", "td"])
+                if len(cells) < 2:
+                    continue
+                raw_label = cells[0].get_text(strip=True).lower().replace("+", "").strip()
+                # Number of shareholders — store separately
+                if "shareholders" in raw_label or "no. of" in raw_label:
+                    result["num_shareholders"] = cells[-1].get_text(strip=True)
+                    continue
+                for key, field in label_map.items():
+                    if key in raw_label:
+                        latest_val = _pct(cells[-1].get_text(strip=True))
+                        prev_val   = _pct(cells[-2].get_text(strip=True)) if len(cells) > 2 else 0.0
+                        result[field]               = latest_val
+                        result[f"{field}_prev"]     = prev_val
+                        result[f"{field}_qoq_delta"] = round(latest_val - prev_val, 2)
+                        break
+
+            if any(k in result for k in ("fii_pct", "dii_pct", "public_pct")):
+                logger.info("Shareholding fetched for %s: FII=%.2f%% DII=%.2f%% Public=%.2f%%",
+                            sym, result.get("fii_pct", 0), result.get("dii_pct", 0), result.get("public_pct", 0))
+                return result
+
+        except Exception as exc:
+            logger.warning("Shareholding scrape failed for %s at %s: %s", sym, path, exc)
+
+    return {"symbol": sym, "error": "Shareholding data not found on Screener.in"}
+
+
 # Convenience list
-EARNINGS_TOOLS = [get_quarterly_results]
+EARNINGS_TOOLS = [get_quarterly_results, get_shareholding_pattern]

--- a/src/tools/intl_etf_tools.py
+++ b/src/tools/intl_etf_tools.py
@@ -65,6 +65,10 @@ def get_intl_etf_premium(symbol: str = "") -> str:
     RBI's overseas investment cap creates persistent premiums — buying when
     premium is negative (discount) has historically been profitable.
 
+    iNAV freshness: during market hours (IST 09:15–15:30) the latest iNAV is
+    fetched live from NSE if the DB snapshot is older than 10 minutes.
+    Outside market hours the last stored snapshot is used.
+
     Args:
         symbol: specific ETF symbol (e.g. 'MAFANG') — blank = all ETFs
 

--- a/src/tools/premium_alerts.py
+++ b/src/tools/premium_alerts.py
@@ -114,23 +114,17 @@ def check_premium_alerts(
         }
 
         try:
-            # ── Latest premium: absolute latest row in DB (no date filter) ────
-            latest_rows = ch_client.query(
-                """
-                SELECT argMax(premium_discount_pct, snapshot_at) AS premium
-                FROM market_data.inav_snapshots
-                WHERE symbol = {sym:String}
-                """,
-                parameters={"sym": sym},
-            ).result_rows
-
-            if not latest_rows or latest_rows[0][0] is None:
-                result["error"] = "No snapshot found"
+            # ── Latest premium: DB first, NSE API fallback ─────────────────
+            from src.importer.fetchers.nse_inav_fetcher import get_latest_inav
+            live = get_latest_inav(sym, max_age_days=7, store_to_db=True)
+            if live is None:
+                result["error"] = "No snapshot found in DB or NSE API"
                 results.append(result)
                 continue
 
-            latest_prem = float(latest_rows[0][0])
+            latest_prem = live["premium_discount_pct"]
             result["latest_premium"] = round(latest_prem, 4)
+            result["inav_source"]    = live["source"]  # "db" or "nse_api_live"
 
             # ── Historical premium: deduplicated into hourly buckets ───────────
             hist_rows = ch_client.query(

--- a/src/tools/quant_scorecard.py
+++ b/src/tools/quant_scorecard.py
@@ -369,24 +369,21 @@ def compute_gold_scorecard(
 
         # ── Valuation: latest iNAV premium/discount ───────────────────────────
         try:
-            inav_row = client.query(f"""
-                SELECT premium_discount_pct, toDate(snapshot_at) AS snap_date
-                FROM market_data.inav_snapshots
-                WHERE symbol = 'GOLDBEES'
-                  AND snapshot_at >= now() - INTERVAL {_INAV_MAX_AGE_DAYS} DAY
-                ORDER BY snapshot_at DESC
-                LIMIT 1
-            """).result_rows
-            if inav_row:
-                disc_pct = float(inav_row[0][0])
+            from src.importer.fetchers.nse_inav_fetcher import get_latest_inav
+            inav_data = get_latest_inav("GOLDBEES", max_age_days=_INAV_MAX_AGE_DAYS)
+            if inav_data:
+                disc_pct = inav_data["premium_discount_pct"]
                 signals["inav_disc_pct"] = round(disc_pct, 3)
+                signals["inav_source"]   = inav_data["source"]
                 valuation_score = _score_valuation(disc_pct)
-                if as_of is None and inav_row[0][1]:
-                    as_of = inav_row[0][1]
+                if as_of is None:
+                    snap_dt = inav_data.get("snapshot_at")
+                    if snap_dt is not None:
+                        import pandas as _pd
+                        as_of = _pd.Timestamp(snap_dt).date()
             else:
                 errors.append(
-                    f"iNAV data is stale (no row within {_INAV_MAX_AGE_DAYS}d) "
-                    "— valuation pillar unavailable"
+                    f"iNAV data unavailable — DB stale and NSE API unreachable"
                 )
         except Exception as exc:
             errors.append(f"iNAV query failed: {exc}")
@@ -721,24 +718,21 @@ def compute_silver_scorecard(
 
         # Valuation: SILVERBEES iNAV premium/discount
         try:
-            inav_row = client.query(f"""
-                SELECT premium_discount_pct, toDate(snapshot_at) AS snap_date
-                FROM market_data.inav_snapshots
-                WHERE symbol = 'SILVERBEES'
-                  AND snapshot_at >= now() - INTERVAL {_INAV_MAX_AGE_DAYS} DAY
-                ORDER BY snapshot_at DESC
-                LIMIT 1
-            """).result_rows
-            if inav_row:
-                disc_pct = float(inav_row[0][0])
+            from src.importer.fetchers.nse_inav_fetcher import get_latest_inav
+            inav_data = get_latest_inav("SILVERBEES", max_age_days=_INAV_MAX_AGE_DAYS)
+            if inav_data:
+                disc_pct = inav_data["premium_discount_pct"]
                 signals["inav_disc_pct"] = round(disc_pct, 3)
+                signals["inav_source"]   = inav_data["source"]
                 valuation_score = _score_valuation(disc_pct)
-                if as_of is None and inav_row[0][1]:
-                    as_of = inav_row[0][1]
+                if as_of is None:
+                    snap_dt = inav_data.get("snapshot_at")
+                    if snap_dt is not None:
+                        import pandas as _pd
+                        as_of = _pd.Timestamp(snap_dt).date()
             else:
                 errors.append(
-                    f"SILVERBEES iNAV data is stale (no row within {_INAV_MAX_AGE_DAYS}d) "
-                    "— valuation unavailable"
+                    "SILVERBEES iNAV unavailable — DB stale and NSE API unreachable"
                 )
         except Exception as exc:
             errors.append(f"SILVERBEES iNAV query failed: {exc}")

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -9,6 +9,7 @@ ETF news sentiment, DSP Multi-Asset imports, and risk governor calculations.
 from __future__ import annotations
 
 import os
+import re
 import sys
 import subprocess
 from typing import Any
@@ -191,14 +192,16 @@ def run_dsp_multi_asset_importer() -> str:
 
 
 @tool
-def run_data_engineering_importer(category: str = "etfs,stocks,mf,fii_dii,cot,fx_rates", full: bool = False) -> str:
+def run_data_engineering_importer(category: str = "etfs,stocks,mf,fii_dii,cot,fx_rates,inav", full: bool = False) -> str:
     """
     Trigger the historical ClickHouse data engineering pipeline to import and sync data from external APIs.
     Streams live progress to the terminal as each symbol is fetched and inserted.
     Use this when asked to sync/import/refresh general market data or specific categories.
     Args:
-        category: Comma-separated list of categories to import (etfs, stocks, mf, fii_dii, cot, fx_rates).
-        full: If True, performs a full backfill ignoring watermarks.
+        category: Comma-separated list of categories to import.
+                  Valid values: etfs, stocks, mf, fii_dii, cot, fx_rates, inav.
+                  inav = live NSE iNAV snapshot for all tracked ETFs (updates every ~15s during market hours).
+        full: If True, performs a full backfill ignoring watermarks (not applicable for inav).
     """
     args = ["src/main.py", "import"]
     if full:
@@ -244,14 +247,43 @@ def import_symbol_data(symbol: str, days: int = 365) -> str:
         return f"Registry load error: {exc}"
 
     if sym not in _lookup:
-        known_etfs = ", ".join(nse for nse, _ in ETFS[:8]) + "…"
-        return (
-            f"UNKNOWN_SYMBOL: {sym} — not found in ETF, stock, commodity, or index registry.\n"
-            f"Known ETFs: {known_etfs}\n"
-            f"For a full category refresh: run_data_engineering_importer(category='etfs')"
-        )
-
-    yahoo_ticker, category = _lookup[sym]
+        # Fall back to Yahoo Finance search via resolve_company_info
+        sys.stdout.write(f"  {sym} not in static registry — searching Yahoo Finance...\n")
+        sys.stdout.flush()
+        try:
+            from src.tools.company_resolver import resolve_company_info
+            info = resolve_company_info(sym)
+            yf_sym = info.get("yf_symbol", "")
+            market = info.get("market", "")
+            source = info.get("source", "")
+            if yf_sym and market == "India" and source != "fallback_unverified":
+                yahoo_ticker = yf_sym
+                category = "stocks"
+                nse_sym = info.get("nse_symbol") or re.sub(r"\.(NS|BO)$", "", yf_sym, flags=re.I)
+                sym = nse_sym  # use the resolved NSE symbol going forward
+                sys.stdout.write(
+                    f"  Resolved → {sym} ({yahoo_ticker}) on {info.get('exchange', 'NSE')}\n"
+                )
+                sys.stdout.flush()
+            elif source == "fallback_unverified":
+                return (
+                    f"SYMBOL_NOT_FOUND: '{sym}' could not be verified on Yahoo Finance. "
+                    f"Possible causes: typo, delisted stock, or symbol not yet on NSE. "
+                    f"Try the exact NSE symbol (e.g. 'GODIGIT' for Go Digit, 'LICI' for LIC)."
+                )
+            else:
+                cname = info.get("company_name", "unknown")
+                return (
+                    f"UNKNOWN_SYMBOL: Yahoo search found '{cname}' ({market}) for '{sym}', "
+                    f"not an Indian listing. Try the exact NSE symbol (e.g. LICICORP, HNGSNGBEES)."
+                )
+        except Exception as exc:
+            return (
+                f"UNKNOWN_SYMBOL: '{sym}' not in registry and Yahoo search failed: {exc}.\n"
+                f"Try the exact NSE symbol directly."
+            )
+    else:
+        yahoo_ticker, category = _lookup[sym]
 
     sys.stdout.write(
         f"  Importing {sym} ({yahoo_ticker}) | {from_date} → {to_date} ({days} days)\n"
@@ -525,10 +557,104 @@ def run_comex_analysis() -> str:
 
 
 @tool
+def get_live_inav(symbol: str) -> str:
+    """
+    Get the previous-day declared NAV, current last traded price, and the
+    price-vs-NAV spread for any NSE-listed ETF.
+
+    IMPORTANT — what "NAV" means here:
+      NSE's public ETF API only exposes the PREVIOUS DAY's declared NAV (the value
+      AMC computes at end-of-day). The true real-time iNAV (updated every 15 seconds)
+      is only accessible through NSE's Akamai-protected /api/quote-equity endpoint
+      which requires a real browser session and is not available programmatically.
+
+      For INTERNATIONAL ETFs (HNGSNGBEES, MAFANG, MON100…): prev-day NAV IS the
+      correct reference since the overseas market is closed during Indian trading hours.
+
+      For DOMESTIC COMMODITY ETFs (GOLDBEES, SILVERBEES…): the true live iNAV tracks
+      MCX gold/silver prices (which include ~8–9% import duty + GST premium over COMEX).
+      The prev-day NAV is a reasonable reference but may differ from the true intraday
+      iNAV by 1–2% when commodity prices move significantly during the session.
+
+      For DOMESTIC EQUITY ETFs (NIFTYBEES, BANKBEES…): the true live iNAV tracks the
+      current index level; prev-day NAV is a close approximation.
+
+    Use this tool (NOT query_clickhouse_db) whenever a user asks:
+      "what is the NAV of GOLDBEES / SILVERBEES / HNGSNGBEES"
+      "current NAV", "ETF premium vs NAV", "is it trading at discount"
+
+    Args:
+        symbol: NSE ETF symbol — e.g. "GOLDBEES", "SILVERBEES", "HNGSNGBEES", "NIFTYBEES"
+
+    Returns:
+        Formatted string with: prev-day declared NAV, current LTP, spread %, snapshot time,
+        and data source.
+    """
+    from src.importer.fetchers.nse_inav_fetcher import get_latest_inav
+    from src.utils.ist import fmt_ist
+    data = get_latest_inav(symbol.strip().upper(), store_to_db=True)
+    if data is None:
+        return (
+            f"No iNAV data available for {symbol.upper()}. "
+            f"NSE API may be unreachable (check market hours: IST 09:15–15:30)."
+        )
+    from datetime import datetime, timezone, timedelta
+    prem = data["premium_discount_pct"]
+    direction = "PREMIUM" if prem > 0 else "DISCOUNT"
+
+    # Compute age of snapshot in seconds
+    snap_dt = data.get("snapshot_at")
+    age_str = ""
+    if snap_dt is not None:
+        try:
+            snap_utc = snap_dt if snap_dt.tzinfo else snap_dt.replace(tzinfo=timezone.utc)
+            age_sec = int((datetime.now(timezone.utc) - snap_utc).total_seconds())
+            if age_sec < 60:
+                age_str = f", {age_sec}s ago"
+            else:
+                age_str = f", {age_sec // 60}m {age_sec % 60}s ago"
+        except Exception:
+            pass
+
+    src_map = {
+        "kite_live":    "live iNAV via Kite",
+        "nse_api_live": "live from NSE (prev-day NAV)",
+        "db":           f"cached (DB{age_str})",
+    }
+    src_label = src_map.get(data["source"], data["source"])
+    snap_ist = fmt_ist(snap_dt)
+    nav_note = (
+        "⚠ NSE API only publishes the previous day's declared NAV — "
+        "not a real-time intraday iNAV. For domestic commodity ETFs (GOLDBEES, SILVERBEES) "
+        "the true live iNAV tracks current MCX/COMEX prices. "
+        "For international ETFs (HNGSNGBEES, MAFANG etc.) prev-day NAV is correct "
+        "since the overseas market is closed during Indian hours."
+    )
+    is_live_inav = data["source"] == "kite_live"
+    nav_label = "iNAV (live)" if is_live_inav else "Prev-Day Declared NAV"
+    note = "" if is_live_inav else f"\n\n_{nav_note}_"
+    return (
+        f"**{data['symbol']} iNAV Snapshot** ({src_label}, {snap_ist})\n"
+        f"- {nav_label}: ₹{data['inav']}\n"
+        f"- Market Price (LTP): ₹{data['market_price']}\n"
+        f"- {direction}: {prem:+.4f}%\n"
+        f"  {'→ ETF trades above iNAV (expensive)' if prem > 0 else '→ ETF trades below iNAV (discount)'}"
+        f"{note}"
+    )
+
+
+@tool
 def run_premium_alerts(lookback: int = 30, z_threshold: float = -1.5, symbols: str = "", min_snapshots: int = 5) -> str:
     """
     Scarcity Premium/Discount Alerts for international Indian ETFs (MAFANG, HNGSNGBEES, etc.).
     Trades the premium created by RBI's overseas investment cap.
+
+    iNAV data freshness:
+      - During market hours (IST 09:15–15:30): DB snapshot must be ≤ 10 min old.
+        If stale, the NSE API is called live and the fresh snapshot is stored to DB.
+      - Outside market hours: last available DB snapshot (up to 4 days old) is used.
+    The 'inav_source' field in results indicates "db" (cached) or "nse_api_live".
+
     Args:
         lookback: Days of iNAV history used to compute mean/std (default 30).
         z_threshold: Z-score at or below which SCREAMING BUY fires (default -1.5).
@@ -624,6 +750,7 @@ SKILLS_TOOLS = [
     run_dsp_multi_asset_importer,
     run_data_engineering_importer,
     import_symbol_data,
+    get_live_inav,
     run_risk_governor_analysis,
     query_clickhouse_db,
     run_whale_tracker,

--- a/src/tools/zerodha_mcp_tools.py
+++ b/src/tools/zerodha_mcp_tools.py
@@ -180,10 +180,145 @@ def initiate_kite_login(_: str = "") -> str:
     return f"Please open this URL in your browser to authenticate with Kite:\n{url}"
 
 
+@tool
+def kite_get_ltp(instruments: str) -> dict[str, Any]:
+    """
+    Get the latest traded price (LTP) for one or more instruments from Zerodha Kite.
+
+    Args:
+        instruments: Comma-separated list of instrument identifiers in EXCHANGE:SYMBOL format.
+                     Examples: "NSE:RELIANCE", "NSE:GOLDBEES,NSE:NIFTYBEES,BSE:SENSEX"
+    """
+    async def _fetch() -> dict:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_ltp", {
+                "instruments": [i.strip() for i in instruments.split(",")]
+            })
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_get_quotes(instruments: str) -> dict[str, Any]:
+    """
+    Get full market data quotes (LTP, OHLC, depth, volume) for instruments from Kite.
+
+    Args:
+        instruments: Comma-separated instrument identifiers, e.g. "NSE:RELIANCE,NSE:TCS"
+    """
+    async def _fetch() -> dict:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_quotes", {
+                "instruments": [i.strip() for i in instruments.split(",")]
+            })
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_get_historical_data(
+    instrument: str,
+    from_date: str,
+    to_date: str,
+    interval: str = "day",
+) -> list[dict]:
+    """
+    Get historical OHLCV price data for an instrument from Zerodha Kite.
+
+    Args:
+        instrument: Instrument in EXCHANGE:SYMBOL format, e.g. "NSE:GOLDBEES"
+        from_date:  Start date in YYYY-MM-DD format
+        to_date:    End date in YYYY-MM-DD format
+        interval:   Candle interval — minute, 3minute, 5minute, 10minute, 15minute,
+                    30minute, 60minute, day, week, month (default: day)
+    """
+    async def _fetch() -> list:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_historical_data", {
+                "instrument": instrument,
+                "from_date": from_date,
+                "to_date": to_date,
+                "interval": interval,
+            })
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_get_mf_holdings(_: str = "") -> dict[str, Any]:
+    """
+    Get all mutual fund holdings from Zerodha Kite (Coin MF portfolio).
+    Returns scheme name, folio, units, average NAV, current value, P&L.
+    """
+    async def _fetch() -> dict:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_mf_holdings", {})
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_search_instruments(query: str, exchange: str = "NSE") -> list[dict]:
+    """
+    Search for tradeable instruments on Zerodha Kite by name or symbol.
+    Use this to find the correct instrument identifier before fetching quotes or history.
+
+    Args:
+        query:    Search string — company name, ETF name, or partial symbol
+        exchange: Exchange to search — NSE, BSE, MCX (default: NSE)
+    """
+    async def _fetch() -> list:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("search_instruments", {
+                "query": query, "exchange": exchange
+            })
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_get_orders(_: str = "") -> dict[str, Any]:
+    """
+    Get all orders placed today from Zerodha Kite.
+    Returns order status, instrument, quantity, price, product type, and timestamps.
+    """
+    async def _fetch() -> dict:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_orders", {})
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_get_trades(_: str = "") -> dict[str, Any]:
+    """
+    Get trading history (executed trades) from Zerodha Kite.
+    Returns fill price, quantity, instrument, and trade timestamp.
+    """
+    async def _fetch() -> dict:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_trades", {})
+    return asyncio.run(_fetch())
+
+
+@tool
+def kite_get_margins(_: str = "") -> dict[str, Any]:
+    """
+    Get account margins and available funds from Zerodha Kite.
+    Returns equity and commodity margins: available cash, used margin, net value.
+    """
+    async def _fetch() -> dict:
+        async with KiteMCPClient() as client:
+            return await client._call_tool("get_margins", {})
+    return asyncio.run(_fetch())
+
+
 # Convenience list of all Zerodha tools for the agent
 ZERODHA_TOOLS = [
     initiate_kite_login,
     fetch_account_profile,
     fetch_portfolio_holdings,
     fetch_open_positions,
+    kite_get_ltp,
+    kite_get_quotes,
+    kite_get_historical_data,
+    kite_get_mf_holdings,
+    kite_search_instruments,
+    kite_get_orders,
+    kite_get_trades,
+    kite_get_margins,
 ]

--- a/src/utils/ist.py
+++ b/src/utils/ist.py
@@ -1,0 +1,63 @@
+"""
+src/utils/ist.py
+────────────────
+IST (Indian Standard Time, UTC+5:30) helpers for display-facing timestamps.
+
+Data is stored in ClickHouse as naive UTC datetimes.  All user-visible
+date/time strings should pass through this module so the display layer
+is consistently in IST.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta, date
+from typing import Union
+
+_IST = timezone(timedelta(hours=5, minutes=30))
+_IST_OFFSET_SECONDS = 19800   # 5h30m in seconds
+
+
+def now_ist() -> datetime:
+    """Return the current datetime in IST (aware)."""
+    return datetime.now(_IST)
+
+
+def utc_to_ist(dt: datetime) -> datetime:
+    """
+    Convert a datetime to IST.
+
+    Accepts:
+    - naive UTC datetime  (assumed to be UTC, as stored by ClickHouse)
+    - aware UTC datetime  (any tzinfo — converted via UTC)
+    Returns an aware IST datetime.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_IST)
+
+
+def fmt_ist(dt: datetime | None, fmt: str = "%Y-%m-%d %H:%M:%S IST") -> str:
+    """
+    Format a datetime as an IST string.
+
+    Args:
+        dt:  naive UTC or aware datetime; None → empty string
+        fmt: strftime format (default "YYYY-MM-DD HH:MM:SS IST")
+    """
+    if dt is None:
+        return ""
+    return utc_to_ist(dt).strftime(fmt)
+
+
+def fmt_date_ist(d: date | datetime | None) -> str:
+    """Format a date or datetime as a plain IST date string (YYYY-MM-DD)."""
+    if d is None:
+        return ""
+    if isinstance(d, datetime):
+        return utc_to_ist(d).strftime("%Y-%m-%d")
+    return d.isoformat()
+
+
+def ist_date_today() -> date:
+    """Return today's date in IST."""
+    return now_ist().date()

--- a/src/utils/sanity_checker.py
+++ b/src/utils/sanity_checker.py
@@ -13,12 +13,16 @@ import sys
 # Constants for anomaly detection
 MAX_YOY_RETURN_SAFE_ASSET = 0.80  # 80% (e.g., Gold, Nifty 50 in bull markets)
 MAX_DAILY_RETURN = 0.20          # 20% (standard NSE circuit limit)
+MAX_DAILY_RETURN_HIGH_VOL = 0.65 # 65% (for highly volatile commodities like Natural Gas)
 
 # Assets considered "safe/stable" for lower thresholds
 SAFE_ASSETS = ["GOLDBEES", "NIFTYBEES", "BANKBEES", "LIQUIDBEES", "MON100"]
 
 # FX rate symbols — excluded from YoY return anomaly checks (non-equity price range)
 RATE_SYMBOLS = ["USDINR", "USDCNY", "USDAED", "USDSAR", "USDKWD"]
+
+# Highly volatile commodities with wider circuit thresholds
+HIGH_VOL_COMMODITIES = ["NGAS"]
 
 def detect_yoy_anomalies(client: Any, symbols: List[str] = None) -> List[Dict[str, Any]]:
     """


### PR DESCRIPTION
This Pull Request consolidates and merges all active feature branches and bugfixes:

### 1. iNAV / Live NAV
- Add `kite_inav_fetcher.py`: map 17 ETFs to Kite iNAV instruments
- `get_latest_inav()` now resolves: DB cache → Kite live → NSE fallback
- Market-hours freshness: re-fetch if snapshot >2 min old (IST 09:15–15:30)
- NSE `/api/etf` nav field correctly labelled as prev-day declared NAV
- `premium_alerts` and `quant_scorecard` use `get_latest_inav()` with auto-refresh
- New `get_live_inav` @tool for agents with clear source labels

### 2. Company Resolver
- India-first sorting: NSE/BSE quotes ranked before US OTC in Yahoo results
- Word-boundary partial match: "lt" no longer matches inside "ltd" suffix
- Screener.in Tier 3: validate guessed symbols via `/company/{SYM}/` URL
- `fallback_unverified` source flag when symbol cannot be confirmed
- 15+ new aliases: Go Digit, LIC, Paytm, Zomato, Nykaa, PolicyBazaar, etc.

### 3. Earnings Scraper
- Fix zero revenue/profit for GODIGIT: consolidated page returns 200 with no data cells; now falls through to standalone URL
- New `get_shareholding_pattern` @tool: scrapes Promoter/FII/DII/Public % + QoQ delta from Screener.in `#shareholding` section

### 4. Agents & Sub-agents
- Per-agent `RECURSION_LIMIT`: default 20, equity 40, research 50
- `run()` switches to `agent.stream(stream_mode="values")` so partial tool outputs are preserved when recursion limit fires
- Synthesis prompt on partial data: omit sections with no data, never placeholder

### 5. Kite MCP
- MCP initialize handshake: capture `mcp-session-id` header, send on all calls
- Persist session to `/tmp/.kite_mcp_session`; reuse across `KiteMCPClient` instances
- 8 new Kite tools: `kite_get_ltp`, `kite_get_quotes`, `kite_get_historical_data`, `kite_get_mf_holdings`, `kite_search_instruments`, `kite_get_orders`, `kite_get_trades`, `kite_get_margins`

### 6. Local Ollama & Recursion Limit Fixes
- Support host Ollama and fix sanity checker constants
- Configure local LLM context window size via `num_ctx` option
- Respect `settings.llm_local_disabled` in subagents build logic
- Add recursion limit guard to subagents and add GOLDBEES plot script

### 7. Utilities
- `src/utils/ist.py`: shared IST timezone helpers (`now_ist`, `fmt_ist`, `utc_to_ist`)
- All user-visible timestamps converted to IST (iNAV snapshots, COMEX prices)
- `requirements.txt`: document Screener.in HTTP usage