### PR TITLE
fix(tools): call import_symbol_data_impl to bypass StructuredTool error

### DIFF
--- a/src/tools/company_resolver.py
+++ b/src/tools/company_resolver.py
@@ -439,8 +439,8 @@ def resolve_company_info(query: str, auto_import: bool = True) -> dict:
                     import sys
                     sys.stdout.write(f"Symbol {sym} not found in DB. Executing auto-import...\n")
                     sys.stdout.flush()
-                    from src.tools.skills_tools import import_symbol_data
-                    import_res = import_symbol_data(sym)
+                    from src.tools.skills_tools import import_symbol_data_impl
+                    import_res = import_symbol_data_impl(sym)
                     sys.stdout.write(f"Auto-import result: {import_res}\n")
                     sys.stdout.flush()
             except Exception as e:

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -211,19 +211,9 @@ def run_data_engineering_importer(category: str = "etfs,stocks,mf,fii_dii,cot,fx
     return _run_cmd_streaming(args)
 
 
-@tool
-def import_symbol_data(symbol: str, days: int = 365) -> str:
+def import_symbol_data_impl(symbol: str, days: int = 365) -> str:
     """
-    Import price history for a specific NSE symbol over a custom date range.
-    Use when the user wants to import/refresh ONE specific symbol — e.g.
-    "import HNGSNGBEES 1 year", "import GOLDBEES last 6 months", "import RELIANCE 2 years".
-    For bulk category imports (all ETFs, all stocks), use run_data_engineering_importer instead.
-
-    Args:
-        symbol: NSE symbol to import (e.g. "HNGSNGBEES", "GOLDBEES", "RELIANCE", "NIFTY50").
-                Uppercased automatically. Covers ETFs, stocks, commodities, and indices.
-        days:   Calendar days of history back from today.
-                365=1 year · 730=2 years · 180=6 months · 90=3 months · 30=1 month
+    Core implementation to import price history for a specific symbol.
     """
     from datetime import date, timedelta
 
@@ -330,6 +320,23 @@ def import_symbol_data(symbol: str, days: int = 365) -> str:
 
 
 @tool
+def import_symbol_data(symbol: str, days: int = 365) -> str:
+    """
+    Import price history for a specific NSE symbol over a custom date range.
+    Use when the user wants to import/refresh ONE specific symbol — e.g.
+    "import HNGSNGBEES 1 year", "import GOLDBEES last 6 months", "import RELIANCE 2 years".
+    For bulk category imports (all ETFs, all stocks), use run_data_engineering_importer instead.
+
+    Args:
+        symbol: NSE symbol to import (e.g. "HNGSNGBEES", "GOLDBEES", "RELIANCE", "NIFTY50").
+                Uppercased automatically. Covers ETFs, stocks, commodities, and indices.
+        days:   Calendar days of history back from today.
+                365=1 year · 730=2 years · 180=6 months · 90=3 months · 30=1 month
+    """
+    return import_symbol_data_impl(symbol, days)
+
+
+@tool
 def run_risk_governor_analysis() -> str:
     """
     Compute GARCH-based position sizing and volatility targeting decision for GOLDBEES.
@@ -425,7 +432,7 @@ def query_clickhouse_db(sql_query: str) -> str:
                     import sys
                     sys.stdout.write(f"Symbol {sym} not found in DB. Executing auto-import...\n")
                     sys.stdout.flush()
-                    import_res = import_symbol_data(sym)
+                    import_res = import_symbol_data_impl(sym)
                     sys.stdout.write(f"Auto-import result: {import_res}\n")
                     sys.stdout.flush()
     except Exception as exc:

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -570,7 +570,7 @@ def test_auto_import_missing_symbol():
     mock_df_missing = pd.DataFrame([{"cnt": 0}])
 
     with patch("src.db.pool.query_df", return_value=mock_df_exists) as mock_query, \
-         patch("src.tools.skills_tools.import_symbol_data") as mock_import:
+         patch("src.tools.skills_tools.import_symbol_data_impl") as mock_import:
         # Resolve a known company, e.g. "RELIANCE"
         resolve_company_info("RELIANCE", auto_import=True)
         # Should NOT trigger import because cnt is 100
@@ -578,7 +578,7 @@ def test_auto_import_missing_symbol():
         print("  ✓ When symbol exists in DB, auto-import is NOT triggered")
 
     with patch("src.db.pool.query_df", return_value=mock_df_missing) as mock_query, \
-         patch("src.tools.skills_tools.import_symbol_data") as mock_import:
+         patch("src.tools.skills_tools.import_symbol_data_impl") as mock_import:
         # Resolve a company, e.g. "RELIANCE"
         resolve_company_info("RELIANCE", auto_import=True)
         # Should trigger import because cnt is 0


### PR DESCRIPTION
Extracts core import logic into an undecorated function import_symbol_data_impl so it can be called cleanly from company resolver and SQL query tools without raising 'StructuredTool object is not callable'.