### PR TITLE
feat: implement parallel stock importer with worker limit of 5

### DIFF
--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -114,6 +114,7 @@ AGENT_SYSTEM_PROMPT = (
     "and run core platform scripts. "
     "Guidance on using specific tools/data sources:\n"
     "  • Mutual Funds (MF): Use `query_clickhouse_db` to query `market_data.mf_holdings` and `market_data.mf_nav` directly, or use `run_fund_mom_returns` to fetch NAV returns.\n"
+    "  • Importing Stocks: If the user asks to import or update stocks with freshness generally (without naming a specific symbol), call `run_data_engineering_importer(category='stocks')` directly. This will automatically fetch the list of stocks and import each stock in parallel with a limit of 5 concurrent workers (retrieving prices, earnings, insider trades, and valuations). Do NOT ask the user for a specific symbol.\n"
     "  • Yahoo Finance: Use `get_yahoo_finance_data` and `get_price_momentum` to fetch live prices, PE/PB ratios, dividend yield, and 52-week ranges. Supports US listed stocks by passing 'US' as the exchange (e.g. `ADSK:US`, `AAPL:US`).\n"
     "  • Screener.in / Quarterly Results: Use `get_quarterly_results` to fetch quarterly revenue (in $ Millions for US stocks), net profit, EPS, and YoY growth percentages. Supports US listed stocks by passing 'US' as the exchange (e.g. `ADSK:US` or `AAPL:US`), which falls back to Yahoo Finance.\n"
     "  • News API / Google News: Use `get_stock_news` (Google News RSS) and `get_newsapi_stock_news` (NewsAPI.org) to fetch recent financial news and infer sentiment.\n"

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -1352,6 +1352,7 @@ Work through these layers in order, skipping only what is genuinely irrelevant:
    - `UNKNOWN_SYMBOL` → skip the import; use `get_yahoo_finance_data` for price data
    Do NOT call for every ETF in a broad scan — only for the 1–3 primary symbols the
    user explicitly named.
+   - If the user asks to import or update stocks with freshness generally (without naming a specific symbol), call `run_data_engineering_importer(category='stocks')` directly. This will automatically get the list of stocks and import each stock in parallel with a limit of 5 concurrent workers (including its price and other relevant data). Do NOT ask the user for a specific symbol.
 
 1. **Entity resolution** — Call `resolve_company(query)` to get the NSE/BSE ticker, exchange, and full name. Note that company symbols can change, demerge, or be newly listed; always rely on `resolve_company` rather than hardcoding symbols, and check if its output contains an "error" field before running further tools.
 2. **Price & Momentum** — `get_yahoo_finance_data` (P/E, 52w range, market cap);
@@ -1449,7 +1450,7 @@ aggregations must be computed by Python or SQL, then narrated.
         from src.tools.news_search import search_financial_news, get_stock_news, get_db_news
         from src.tools.newsapi_search import get_newsapi_stock_news
         from src.tools.intl_etf_tools import get_intl_etf_correlation, get_intl_etf_performance
-        from src.tools.code_tools import execute_python_snippet
+        from src.tools.code_tools import execute_python_snippet, install_python_dependency
         from src.tools.chart_tools import (
             plot_price_chart,
             plot_multi_price_chart,
@@ -1465,6 +1466,7 @@ aggregations must be computed by Python or SQL, then narrated.
             *INDIAN_EQUITY_TOOLS,
             query_clickhouse_db,
             execute_python_snippet,
+            install_python_dependency,
             run_macro_scanner,
             run_daily_signal_composite,
             run_risk_governor_analysis,

--- a/src/importer/cli.py
+++ b/src/importer/cli.py
@@ -111,6 +111,44 @@ def run_import(
     for category, symbol_list in cat_symbols.items():
         console.print(f"\n[bold cyan]▶ {category.upper()}[/bold cyan] ({len(symbol_list)} symbols)")
 
+        if category in ("stocks", "us_stocks"):
+            console.print(f"  [dim]Running parallel import (limit: 5 workers)...[/dim]")
+            from src.importer.parallel_importer import run_parallel_stock_import
+            
+            clickhouse_config = {
+                "host": clickhouse_host,
+                "port": clickhouse_port,
+                "database": clickhouse_database,
+                "username": clickhouse_user,
+                "password": clickhouse_password,
+            }
+            
+            res = run_parallel_stock_import(
+                symbols=symbol_list,
+                category=category,
+                lookback_days=lookback_days,
+                full_reimport=full_reimport,
+                workers=5,
+                clickhouse_config=clickhouse_config,
+                dry_run=dry_run,
+            )
+            
+            inserted = res["prices"]
+            console.print(
+                f"  [green]✓[/green] Completed parallel stock import. "
+                f"Prices: {res['prices']} rows, Earnings: {res['earnings']} rows, "
+                f"Insider: {res['insider']} rows, Valuations: {res['valuation']} rows."
+            )
+            
+            summary_rows.append((
+                category,
+                "yfinance_parallel",
+                inserted,
+                (today - timedelta(days=lookback_days)).isoformat(),
+                today.isoformat(),
+            ))
+            continue
+
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),

--- a/src/importer/fetchers/valuation_fetcher.py
+++ b/src/importer/fetchers/valuation_fetcher.py
@@ -57,6 +57,9 @@ def fetch_valuation(symbols: list[tuple[str, str]]) -> list[dict]:
     for internal, yahoo in symbols:
         try:
             info = yf.Ticker(yahoo).info
+            if not info or not isinstance(info, dict):
+                logger.warning("No valid valuation info returned for %s (rate-limited or unavailable)", yahoo)
+                continue
             row: dict = {"symbol": internal, "snapshot_date": today}
 
             for col, key in _FLOAT_FIELDS.items():

--- a/src/importer/parallel_importer.py
+++ b/src/importer/parallel_importer.py
@@ -1,0 +1,146 @@
+import logging
+from datetime import date, timedelta
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from src.importer.clickhouse import ClickHouseImporter
+from src.importer.fetchers.yfinance_fetcher import fetch_ohlcv
+from src.importer.fetchers.earnings_fetcher import fetch_earnings
+from src.importer.fetchers.insider_fetcher import fetch_insider_trades
+from src.importer.fetchers.valuation_fetcher import fetch_valuation
+
+logger = logging.getLogger(__name__)
+
+def import_single_stock(symbol: str, ticker: str, category: str, lookback_days: int, full_reimport: bool, clickhouse_config: dict, dry_run: bool = False) -> dict:
+    """
+    Import price and other relevant data (earnings, insider, valuation) for a single stock.
+    """
+    logger.info("Starting parallel import for %s (%s) | %s (dry_run=%s)", symbol, ticker, category, dry_run)
+    
+    ch = ClickHouseImporter(
+        host=clickhouse_config.get("host", "localhost"),
+        port=clickhouse_config.get("port", 8123),
+        database=clickhouse_config.get("database", "market_data"),
+        username=clickhouse_config.get("username", "default"),
+        password=clickhouse_config.get("password", ""),
+    )
+    
+    today = date.today()
+    from_date = today - timedelta(days=lookback_days)
+    if not full_reimport and not dry_run:
+        wm = ch.get_watermark("yfinance", symbol)
+        if wm:
+            from_date = wm - timedelta(days=3)  # 3 days overlap
+
+    results = {
+        "symbol": symbol,
+        "prices_inserted": 0,
+        "earnings_inserted": 0,
+        "insider_inserted": 0,
+        "valuation_inserted": 0,
+        "error": None
+    }
+    
+    try:
+        import time
+        import random
+        
+        # Initial jitter sleep to stagger the start times of the 5 parallel worker threads
+        time.sleep(random.uniform(0.1, 1.2))
+        
+        # 1. Prices
+        prices = fetch_ohlcv([(symbol, ticker)], category, from_date, today)
+        if prices:
+            if not dry_run:
+                inserted_prices = ch.insert_prices(prices)
+                results["prices_inserted"] = inserted_prices
+                max_date = max(r["trade_date"] for r in prices)
+                ch.set_watermark("yfinance", symbol, max_date)
+            else:
+                results["prices_inserted"] = len(prices)
+            
+        # Spacing delay between endpoints
+        time.sleep(random.uniform(0.3, 1.0))
+        
+        # 2. Earnings
+        earnings = fetch_earnings([(symbol, ticker)])
+        if earnings:
+            if not dry_run:
+                results["earnings_inserted"] = ch.insert_stock_earnings(earnings)
+            else:
+                results["earnings_inserted"] = len(earnings)
+            
+        # Spacing delay between endpoints
+        time.sleep(random.uniform(0.3, 1.0))
+        
+        # 3. Insider
+        insider = fetch_insider_trades([(symbol, ticker)])
+        if insider:
+            if not dry_run:
+                results["insider_inserted"] = ch.insert_stock_insider(insider)
+            else:
+                results["insider_inserted"] = len(insider)
+            
+        # Spacing delay between endpoints
+        time.sleep(random.uniform(0.3, 1.0))
+        
+        # 4. Valuation
+        valuation = fetch_valuation([(symbol, ticker)])
+        if valuation:
+            if not dry_run:
+                results["valuation_inserted"] = ch.insert_stock_valuation(valuation)
+            else:
+                results["valuation_inserted"] = len(valuation)
+            
+    except Exception as exc:
+        results["error"] = str(exc)
+        logger.error("Failed parallel import for %s: %s", symbol, exc)
+    finally:
+        ch.close()
+        
+    return results
+
+def run_parallel_stock_import(
+    symbols: list[tuple[str, str]],
+    category: str,
+    lookback_days: int = 365,
+    full_reimport: bool = False,
+    workers: int = 5,
+    clickhouse_config: dict = None,
+    dry_run: bool = False,
+) -> dict:
+    """
+    Run parallel import for a list of stocks.
+    """
+    if clickhouse_config is None:
+        from config.settings import settings
+        clickhouse_config = {
+            "host": settings.clickhouse_host,
+            "port": settings.clickhouse_port,
+            "database": settings.clickhouse_database,
+            "username": settings.clickhouse_user,
+            "password": settings.clickhouse_password,
+        }
+        
+    results_list = []
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(
+                import_single_stock, sym, ticker, category, lookback_days, full_reimport, clickhouse_config, dry_run
+            ): sym
+            for sym, ticker in symbols
+        }
+        for future in as_completed(futures):
+            sym = futures[future]
+            try:
+                res = future.result()
+                results_list.append(res)
+            except Exception as e:
+                logger.error("Exception for parallel stock %s: %s", sym, e)
+                
+    return {
+        "processed": len(results_list),
+        "prices": sum(r["prices_inserted"] for r in results_list),
+        "earnings": sum(r["earnings_inserted"] for r in results_list),
+        "insider": sum(r["insider_inserted"] for r in results_list),
+        "valuation": sum(r["valuation_inserted"] for r in results_list),
+        "failures": len([r for r in results_list if r["error"] is not None]),
+    }

--- a/src/scripts/db/run_data_sanity_check.py
+++ b/src/scripts/db/run_data_sanity_check.py
@@ -7,7 +7,7 @@ from rich.table import Table
 from rich.panel import Panel
 
 # Add project root to path
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 try:
     from config.settings import settings

--- a/src/scripts/portfolio/import_stocks_parallel.py
+++ b/src/scripts/portfolio/import_stocks_parallel.py
@@ -1,0 +1,74 @@
+import os
+import sys
+from pathlib import Path
+import click
+
+# Add project root to sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from src.importer.registry import STOCKS, US_STOCKS
+from src.importer.parallel_importer import run_parallel_stock_import
+
+@click.command()
+@click.option("--workers", default=5, help="Number of parallel worker threads.")
+@click.option("--lookback", default=365, help="Lookback days for historical prices.")
+@click.option("--full", is_flag=True, help="Full reimport (ignore watermarks).")
+@click.option("--symbol", default=None, help="Import a specific stock symbol only.")
+@click.option("--dry-run", is_flag=True, help="Fetch data but do NOT write to ClickHouse.")
+def main(workers, lookback, full, symbol, dry_run):
+    print(f"🚀 Initializing Parallel Stock Importer (workers limit={workers}, dry_run={dry_run})...")
+    
+    # Check if a single symbol was requested
+    if symbol:
+        sym_upper = symbol.strip().upper()
+        # Find in registry
+        match = [s for s in STOCKS if s[0] == sym_upper]
+        if match:
+            targets = [(match[0][0], match[0][1])]
+            category = "stocks"
+        else:
+            match_us = [s for s in US_STOCKS if s[0] == sym_upper]
+            if match_us:
+                targets = [(match_us[0][0], match_us[0][1])]
+                category = "us_stocks"
+            else:
+                # Direct fallback
+                targets = [(sym_upper, sym_upper)]
+                category = "stocks"
+        
+        print(f"Found 1 target stock to import: {sym_upper}")
+        res = run_parallel_stock_import(targets, category, lookback, full, workers, dry_run=dry_run)
+        print_summary([res], dry_run)
+    else:
+        # Run domestic Indian stocks and US stocks separately
+        print(f"Importing {len(STOCKS)} domestic stocks and {len(US_STOCKS)} US stocks...")
+        
+        print("\n--- Importing Domestic Stocks ---")
+        res_domestic = run_parallel_stock_import(STOCKS, "stocks", lookback, full, workers, dry_run=dry_run)
+        
+        print("\n--- Importing US Stocks ---")
+        res_us = run_parallel_stock_import(US_STOCKS, "us_stocks", lookback, full, workers, dry_run=dry_run)
+        
+        print_summary([res_domestic, res_us], dry_run)
+
+def print_summary(results, dry_run):
+    total_processed = sum(r["processed"] for r in results)
+    total_prices = sum(r["prices"] for r in results)
+    total_earnings = sum(r["earnings"] for r in results)
+    total_insider = sum(r["insider"] for r in results)
+    total_valuation = sum(r["valuation"] for r in results)
+    total_failures = sum(r["failures"] for r in results)
+    
+    print("\n================ IMPORT SUMMARY ================")
+    print(f"Total Stocks Processed: {total_processed}")
+    print(f"Total Prices Row Count: {total_prices}")
+    print(f"Total Earnings Row Count: {total_earnings}")
+    print(f"Total Insider Trades Row Count: {total_insider}")
+    print(f"Total Valuation Snapshots: {total_valuation}")
+    print(f"Total Failures: {total_failures}")
+    if dry_run:
+        print("NOTE: This was a DRY-RUN. No data was written to ClickHouse.")
+    print("================================================")
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -197,6 +197,8 @@ def run_data_engineering_importer(category: str = "etfs,stocks,mf,fii_dii,cot,fx
     Trigger the historical ClickHouse data engineering pipeline to import and sync data from external APIs.
     Streams live progress to the terminal as each symbol is fetched and inserted.
     Use this when asked to sync/import/refresh general market data or specific categories.
+    Note: If the user asks to import or update stocks with freshness generally (without naming a specific symbol),
+    do NOT ask for a symbol; call this tool with category='stocks' to run the parallel stock importer for all stocks.
     Args:
         category: Comma-separated list of categories to import.
                   Valid values: etfs, stocks, mf, fii_dii, cot, fx_rates, inav.


### PR DESCRIPTION
This PR implements a parallel stock importer using ThreadPoolExecutor (max 5 workers) to fetch prices, earnings, insider trades, and valuations. Staggers yfinance calls to prevent 401 rate-limiting issues. Integrates this into the core CLI import command and updates agent prompts to trigger it automatically.