### PR TITLE
docs: document parallel stock importer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,7 +104,8 @@ CLI (src/main.py)
 ### Data Import Pipeline
 ```
 CLI import command
-  → src/importer/cli.py  (legacy orchestrator, still active)
+  → src/importer/cli.py  (orchestrates imports; intercepts stocks & us_stocks categories)
+      ↳ Redirects to src/importer/parallel_importer.py (5 parallel worker threads with staggered jitter delays)
       → src/importer/fetchers/<name>_fetcher.py  (external API → DataFrame)
       → src/importer/clickhouse.py               (watermark check → bulk insert)
           ReplacingMergeTree: re-importing same date is safe / idempotent
@@ -260,6 +261,6 @@ Coverage: 62 DSP funds Sep 2023–Mar 2026; Top 10 funds back to Jun 2022.
   - `fund_imports/` — Factory-pattern AMC importers; run via `python src/scripts/fund_imports/run.py <icici|nippon|icici-index|all> [--dry-run] [--test]`. `base.py` has the `BaseFundImporter` ABC; `importers/` has one class per AMC; `factory.py` has `create_importer(name)`.
   - `etf/` — ETF comparison, CAGR validation, risk analysis
   - `ml/` — ML prediction backfill and evaluation
-  - `portfolio/` — portfolio tracking, health checks, opportunity scan
+  - `portfolio/` — portfolio tracking, health checks, opportunity scan, parallel stock import (`import_stocks_parallel.py`)
   - `market/` — macro themes, FII/DII, metals, sentiment, whale tracker
   - `db/` — ClickHouse backup, restore, and sanity checks

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,8 @@ docker-compose.yml
 
 All importers are **watermark-based delta-sync**: each fetcher reads `import_watermarks.(source, symbol).last_date`, fetches only new rows, and writes back the watermark after a successful insert. Safe for repeated runs — `ReplacingMergeTree` handles duplicate dates.
 
+For `stocks` and `us_stocks` categories, the import manager redirects standard sequential download to a high-concurrency pipeline ([parallel_importer.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/importer/parallel_importer.py)). This pipeline concurrently processes each stock symbol using a thread pool (capped at 5 workers) to fetch prices, quarterly earnings, insider transactions, and valuation snapshots. Requests are staggered using random jitter delays to bypass Yahoo Finance rate-limiting defenses (401 Unauthorized).
+
 | Fetcher | External Source | ClickHouse Table(s) | Cadence |
 |---|---|---|---|
 | `yfinance_fetcher` | Yahoo Finance | `daily_prices` | Daily |

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -181,6 +181,11 @@ Because macro signals rely on cross-asset correlations, you must sync database s
 python src/main.py import --category etfs,stocks,mf,fii_dii,cot,fx_rates
 ```
 
+*Note: For `stocks` and `us_stocks` categories, the importer automatically switches to a high-concurrency mode, running parallel symbol fetches (up to 5 concurrent workers) that pull prices, earnings, insider trades, and valuations. This parallel run is staggered with random jitter delays to avoid rate-limiting blocks. You can also invoke the dedicated parallel script directly:*
+```bash
+python src/scripts/portfolio/import_stocks_parallel.py --workers 5
+```
+
 ---
 
 ## 🔌 Running Locally with Ollama


### PR DESCRIPTION
Documents the design, CLI script, and core integration of the parallel stock importer in CLAUDE.md, docs/architecture.md, and docs/user_guide.md.