### PR TITLE
docs: update parallel stock importer documentation

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -27,6 +27,7 @@ python src/main.py config                   # show masked config
 ```bash
 python src/scripts/portfolio/fund_mom_returns.py --scheme 152056   # MoM NAV returns
 python src/scripts/portfolio/portfolio_health_check.py
+python src/scripts/portfolio/import_stocks_parallel.py --workers 5  # parallel stock import
 python src/scripts/portfolio/inr_hedge_report.py
 python src/scripts/dsp/import_all_dsp_equity.py                    # DSP holdings import
 python src/scripts/dsp/import_latest_dsp.py                        # latest month only
@@ -126,7 +127,7 @@ All use `ReplacingMergeTree` — always query with `FINAL` to deduplicate.
 - **Scraping fallbacks:** Screener.in is primary for earnings; BSE/Yahoo Finance are fallbacks. `fake-useragent` rotates user-agents.
 - **Caching:** NewsAPI/COMEX responses cached to `output/.cache/` with 1-hour TTL.
 - **Output files:** Reports written to `./output/` as JSON/HTML.
-- **Scripts subdirs:** `dsp/` (DSP AMC import + analysis), `fund_imports/` (factory-pattern AMC importers), `etf/` (ETF comparison, CAGR, risk), `ml/` (prediction backfill/eval), `portfolio/` (health checks, opportunity scan, MoM returns), `market/` (macro, FII/DII, metals, sentiment), `db/` (ClickHouse backup/restore/sanity).
+- **Scripts subdirs:** `dsp/` (DSP AMC import + analysis), `fund_imports/` (factory-pattern AMC importers), `etf/` (ETF comparison, CAGR, risk), `ml/` (prediction backfill/eval), `portfolio/` (health checks, opportunity scan, MoM returns, parallel stock import), `market/` (macro, FII/DII, metals, sentiment), `db/` (ClickHouse backup/restore/sanity).
 
 ## Critical: Grounding Rules — DO NOT Hallucinate
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ python src/main.py import --category etfs --category mf
 python src/main.py import --category fii_dii    # FII/DII flows
 ```
 
+*Note: For the `stocks` and `us_stocks` categories, the importer automatically switches to a high-concurrency mode running parallel symbol fetches (up to 5 concurrent workers) that pull prices, earnings, insider trades, and valuations. This parallel run is staggered with random jitter delays to avoid rate-limiting blocks. You can also invoke the parallel script directly:*
+```bash
+python src/scripts/portfolio/import_stocks_parallel.py --workers 5
+```
+
 > [!IMPORTANT]  
 > **Mandatory Data Freshness:** Quantitative signals (Macro, ML, Composite) rely on cross-asset correlations (e.g., Gold vs USDINR vs US10Y). If any category is stale, the signals are mathematically invalid. **Always run an import at the start of your session.**
 
@@ -328,6 +333,7 @@ src/
   ui/app.py                     Streamlit data hub (Import / Query / Explorer / Kite Dashboard)
   scripts/
     goldbees_report.py          GOLDBEES investment pipeline report with LLM recommendation
+    portfolio/import_stocks_parallel.py  High-concurrency parallel stock data importer
 scripts/
   save_portfolio_holdings.py         Backup CNC holdings to ClickHouse
   backup_zerodha_account.py          Backup profile, margins, and orders

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -6,7 +6,7 @@ All data sources used by Mosaic Fund Agent are free unless noted.
 
 | What | Source | Notes |
 |---|---|---|
-| Stock / ETF / commodity OHLCV | Yahoo Finance `.NS`, `GC=F`, etc. | Free, no rate limit |
+| Stock / ETF / commodity OHLCV | Yahoo Finance `.NS`, `GC=F`, etc. | Free, subject to rate-limiting on high concurrency (handled via staggered jitter delays in the parallel stock importer) |
 | ETF iNAV — live | NSE API | Free, 15-second refresh (9:15 AM – 3:30 PM IST) |
 | ETF iNAV — historic / NAV | MFAPI.in (AMFI official) | Free |
 | COMEX spot prices | gold-api.com | Free with API key |

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -29,6 +29,21 @@ python src/main.py import --category commodities --full   # full re-import
 python src/main.py import --category etfs --dry-run       # preview, no DB writes
 ```
 
+### High-Concurrency & Parallel Stock Imports
+
+For `stocks` and `us_stocks` categories, the sequential importer is automatically intercepted and routed to a high-concurrency parallel pipeline ([parallel_importer.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/importer/parallel_importer.py)).
+
+This pipeline concurrently processes each stock symbol using a thread pool to fetch pricing history (`daily_prices`), quarterly earnings, insider transactions, and valuation snapshots.
+- **Worker Limit:** Capped at 5 concurrent worker threads to balance speed and stability.
+- **Anti-Rate-Limiting Jitter:** Staggers worker execution using randomized initial delays (`0.1s` to `1.2s`) and spacing delays (`0.3s` to `1.0s`) between fetches. This prevents Yahoo Finance from blocking requests with `HTTP Error 401: Unauthorized` or rate-limiting.
+- **Auto-Routing:** Agent LLM loops and standard CLI calls like `python src/main.py import --category stocks` are automatically routed through this parallel importer.
+
+You can also invoke the script directly from the project root:
+```bash
+python src/scripts/portfolio/import_stocks_parallel.py --workers 5 [--dry-run] [--full]
+```
+
+
 ### Fetcher Adapter Pattern
 
 Five core categories have typed **Fetcher adapters** (`src/importer/fetchers/adapters.py`):


### PR DESCRIPTION
Documents the new high-concurrency parallel stock importer script (`import_stocks_parallel.py`) and its rate-limiting protections across README.md, GEMINI.md, docs/import-schema.md, and docs/data-sources.md.