### PR TITLE
fix: use configured cloud model for Anthropic router fallback

### DIFF
--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -116,7 +116,7 @@ def _get_router_llm() -> Any | None:
             try:
                 from langchain_anthropic import ChatAnthropic
                 return ChatAnthropic(
-                    model="claude-3-5-haiku-20241022",
+                    model=settings.llm_cloud_model or "claude-3-5-haiku-20241022",
                     api_key=settings.anthropic_api_key,
                     temperature=0,
                     max_tokens=50,


### PR DESCRIPTION
Uses settings.llm_cloud_model to avoid 404 on hardcoded claude-3-5-haiku-20241022