### PR TITLE
fix: trigger interactive confirmation prompt inside chat REPL

### DIFF
--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -1216,6 +1216,10 @@ def run_chat_loop(console: Console | None = None) -> None:
     if console is None:
         console = Console()
 
+    # Set environment variable to indicate interactive session for resolver prompts
+    import os
+    os.environ["MOSAIC_INTERACTIVE_CHAT"] = "1"
+
     # Build agent with in-session memory
     from langgraph.checkpoint.memory import MemorySaver
     from src.agents.mosaic_fund_agent import MosaicFundAgent

--- a/src/tools/company_resolver.py
+++ b/src/tools/company_resolver.py
@@ -530,7 +530,8 @@ def resolve_company_info(query: str, auto_import: bool = True) -> dict:
 
     # Interactive confirmation loop
     import sys
-    if sys.stdin.isatty() and 'pytest' not in sys.modules and 'unittest' not in sys.modules and info and not info.get("error"):
+    import os
+    if (sys.stdin.isatty() or os.environ.get("MOSAIC_INTERACTIVE_CHAT") == "1") and 'pytest' not in sys.modules and 'unittest' not in sys.modules and info and not info.get("error"):
         company_desc = f"{info['company_name']} ({info['symbol']} on {info['exchange']})"
         sys.stdout.write(f"\n[Resolver] Resolved '{query}' to '{company_desc}'. Is this correct? [Y/n]: ")
         sys.stdout.flush()


### PR DESCRIPTION
This PR fixes the issue where the interactive confirmation prompt did not trigger inside the chat REPL loop (particularly inside Docker containers) by setting and checking a dedicated  environment variable.