### PR TITLE
fix: resolve docker compose environment variable interpolation for passwords

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -277,6 +277,11 @@ class Settings(BaseSettings):
     # [NON-SENSITIVE] NSE regular session close time (IST, 24h HH:MM)
     market_close: str = Field(default="15:30", description="NSE market close time IST")
 
+    def __init__(self, **values):
+        super().__init__(**values)
+        if "$$" in self.shoonya_password:
+            self.shoonya_password = self.shoonya_password.replace("$$", "$")
+
     def validate_sensitive_fields(self) -> list[str]:
         """
         Returns a list of warnings for any SENSITIVE fields that are missing.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -164,6 +164,11 @@ def test_config_masking():
     for w in warnings2:
         print(f"    [SENSITIVE warning] {w[:70]}...")
 
+    # Verify Shoonya password escaping unescapes double-dollar signs
+    s3 = Settings(shoonya_password="my_pass$$word")
+    assert s3.shoonya_password == "my_pass$word"
+    print("  ✓ Shoonya password unescapes double-dollar signs successfully")
+
 
 def test_inav_fetcher():
     print("\n" + "="*60)


### PR DESCRIPTION
This PR resolves the issue where docker-compose warns and strips dollar signs in the .env file due to environment variable interpolation. It escapes the dollar sign as double dollars and adds constructor-level unescaping inside Settings for non-Docker execution.