### PR TITLE
feat(chat): improve follow-up routing for confirmation/negation responses and increase Ollama think timeout

### DIFF
--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -318,6 +318,8 @@ class MosaicFundAgent:
             extra_body: dict = {"options": {"num_ctx": settings.llm_context_window}}
             if settings.llm_think:
                 extra_body["think"] = True
+            # Thinking mode needs a longer timeout — qwen3 reasoning can take 60-120s
+            request_timeout = 300 if settings.llm_think else 120
             return ChatOpenAI(
                 model=settings.llm_model,
                 base_url=settings.llm_base_url,
@@ -326,6 +328,7 @@ class MosaicFundAgent:
                 temperature=0,
                 max_tokens=settings.llm_token_budget,
                 extra_body=extra_body,
+                timeout=request_timeout,
             )
 
         # ── Anthropic cloud ────────────────────────────────────────────────────

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -61,6 +61,12 @@ _FOLLOWUP_RE = re.compile(
     re.I,
 )
 
+# Short positive/negative confirmations responding to agent prompts/questions.
+_CONFIRMATION_RE = re.compile(
+    r"^(?:yes|y|no|n|sure|please|ok|okay|yeah|yep|nah|yup|go\s+ahead|do\s+it|indeed|fine|cancel|nevermind|of\s+course|sure\s+thing)\b",
+    re.I,
+)
+
 
 # ── prompt_toolkit input session ──────────────────────────────────────────────
 
@@ -1583,7 +1589,22 @@ def run_chat_loop(console: Console | None = None) -> None:
             # Short follow-up phrases like "compare with HDFC", "vs ICICI",
             # "what about SBIN" should stay on the same agent as the last turn
             # instead of falling through to main.
-            if _intent == "main" and _FOLLOWUP_RE.match(raw.strip()) and _conv_history:
+            # ALSO: Short answers/responses (like "yes", "no", "y", "n", "sure", "ok")
+            # or any response when the previous assistant message ended with a question
+            # should stay on the previous agent.
+            _is_followup = False
+            if _intent == "main" and _conv_history:
+                if _FOLLOWUP_RE.match(raw.strip()):
+                    _is_followup = True
+                elif _CONFIRMATION_RE.match(raw.strip()) and len(raw.split()) <= 4:
+                    _is_followup = True
+                else:
+                    _prev_raw, _prev_answer, _prev_intent = _conv_history[-1]
+                    _cleaned_answer = _prev_answer.strip().rstrip("`").strip().rstrip("*").strip()
+                    if _cleaned_answer.endswith("?") and len(raw.split()) <= 8:
+                        _is_followup = True
+
+            if _is_followup:
                 for _, _, _prev_intent in reversed(_conv_history):
                     if _prev_intent not in ("main", ""):
                         logger.info(
@@ -1641,7 +1662,7 @@ def run_chat_loop(console: Console | None = None) -> None:
                     os.environ["VERBOSE"] = _prev_verbose
 
             # Persist this turn — store the intent so follow-up routing can reuse it.
-            _conv_history.append((raw, answer[:600] + "…" if len(answer) > 600 else answer, _intent))
+            _conv_history.append((raw, answer, _intent))
 
             _print_answer(console, answer)
 

--- a/tests/test_chat_followup.py
+++ b/tests/test_chat_followup.py
@@ -1,0 +1,48 @@
+"""
+tests/test_chat_followup.py
+────────────────────────────
+Unit tests for the follow-up routing logic in chat_cmd.py.
+"""
+import unittest
+import re
+
+from src.commands.chat_cmd import _FOLLOWUP_RE, _CONFIRMATION_RE
+
+class TestChatFollowupRouting(unittest.TestCase):
+    def test_followup_regex(self):
+        """Test that _FOLLOWUP_RE correctly matches standard follow-up prefixes."""
+        self.assertTrue(_FOLLOWUP_RE.match("compare with HDFC"))
+        self.assertTrue(_FOLLOWUP_RE.match("vs RELIANCE"))
+        self.assertTrue(_FOLLOWUP_RE.match("what about TCS"))
+        self.assertTrue(_FOLLOWUP_RE.match("how about INFY"))
+        self.assertTrue(_FOLLOWUP_RE.match("now show goldbees"))
+        self.assertTrue(_FOLLOWUP_RE.match("also check KOTAKGOLD"))
+        
+        self.assertFalse(_FOLLOWUP_RE.match("yes"))
+        self.assertFalse(_FOLLOWUP_RE.match("no"))
+        self.assertFalse(_FOLLOWUP_RE.match("show composite signals"))
+
+    def test_confirmation_regex(self):
+        """Test that _CONFIRMATION_RE correctly matches confirmation/negation words."""
+        self.assertTrue(_CONFIRMATION_RE.match("yes"))
+        self.assertTrue(_CONFIRMATION_RE.match("no"))
+        self.assertTrue(_CONFIRMATION_RE.match("y"))
+        self.assertTrue(_CONFIRMATION_RE.match("n"))
+        self.assertTrue(_CONFIRMATION_RE.match("sure"))
+        self.assertTrue(_CONFIRMATION_RE.match("please"))
+        self.assertTrue(_CONFIRMATION_RE.match("ok"))
+        self.assertTrue(_CONFIRMATION_RE.match("okay"))
+        self.assertTrue(_CONFIRMATION_RE.match("yeah"))
+        self.assertTrue(_CONFIRMATION_RE.match("yep"))
+        self.assertTrue(_CONFIRMATION_RE.match("nah"))
+        self.assertTrue(_CONFIRMATION_RE.match("go ahead"))
+        self.assertTrue(_CONFIRMATION_RE.match("do it"))
+        self.assertTrue(_CONFIRMATION_RE.match("sure thing"))
+        self.assertTrue(_CONFIRMATION_RE.match("yes please"))
+
+        self.assertFalse(_CONFIRMATION_RE.match("yesterday's volume"))
+        self.assertFalse(_CONFIRMATION_RE.match("nifty index close"))
+        self.assertFalse(_CONFIRMATION_RE.match("not sure"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Implements follow-up routing in the interactive chat loop to correctly route confirmation/negation responses (e.g. 'yes', 'no') or answers to questions back to the previous specialist agent, keeping conversation context intact. Also increases Ollama thinking timeout to 300s.