### PR TITLE
perf(ollama): increase router and planner timeouts to 120s to accommodate model switches

### DIFF
--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -150,7 +150,8 @@ def _get_router_llm() -> Any | None:
                     api_key=settings.openai_api_key,
                     temperature=0,
                     max_tokens=50,
-                    request_timeout=30,
+                    request_timeout=120,
+                    timeout=120,
                 )
             else:
                 return ChatOpenAI(

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -417,7 +417,8 @@ def _get_plan_llm() -> "Any":
                 model=settings.llm_model,
                 base_url=settings.llm_base_url,
                 api_key=settings.openai_api_key or "local",
-                request_timeout=30,  # Prevent permanent hangs on local endpoint
+                request_timeout=120,  # Prevent permanent hangs on local endpoint
+                timeout=120,
                 **kw,
             )
         elif settings.llm_provider == "anthropic":


### PR DESCRIPTION
Increases intent router and planner LLM timeouts to 120s for local Ollama endpoints. This prevents requests from failing or triggering retries when switching models or loading a large model into VRAM.