### PR TITLE
feat: convert paths section into targeted user personas

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -904,30 +904,30 @@
   </div>
 </section>
 
-<!-- ── PICK YOUR PATH ─────────────────────────────────────────────── -->
+<!-- ── WHO IT'S FOR ───────────────────────────────────────────────── -->
 <section class="section paths-section" id="paths">
   <div class="container">
-    <div class="section-label">Three ways to use it</div>
-    <h2 class="section-title">However you like to work</h2>
+    <div class="section-label">Who it's for</div>
+    <h2 class="section-title">Three users, one platform</h2>
 
     <div class="paths-grid">
-      <a href="#quickstart" class="path-card">
-        <div class="path-num">1</div>
-        <h3>🖥️ Visual Dashboard</h3>
-        <p>One-click Docker launch opens a Streamlit hub — charts, data syncs, and signal summaries. No code, no setup.</p>
-        <span class="path-go">Start with Docker →</span>
+      <a href="#dashboard" class="path-card">
+        <div class="path-num">🧑‍💻</div>
+        <h3>Retail investor</h3>
+        <p>"What should I buy today? Am I overexposed?" One-click dashboard + plain-English ask. Composite 0–100 scores, premium alerts, and clear BUY / HOLD / AVOID — no spreadsheets, no jargon.</p>
+        <span class="path-go">Launch the dashboard →</span>
+      </a>
+      <a href="#features" class="path-card">
+        <div class="path-num">🏦</div>
+        <h3>Fund manager / AMC treasurer</h3>
+        <p>Track institutional flows, reverse-engineer DSP / Nippon / ICICI conviction, map macro themes to positioning, and size with the GARCH Risk Governor. The signal design was shaped by a working AMC treasurer.</p>
+        <span class="path-go">See institutional signals →</span>
       </a>
       <a href="#quickstart" class="path-card">
-        <div class="path-num">2</div>
-        <h3>💬 Just ask</h3>
-        <p>Type plain-English questions. An intent router sends them to the right specialist agent and narrates a grounded answer.</p>
-        <span class="path-go">See example questions →</span>
-      </a>
-      <a href="#quickstart" class="path-card">
-        <div class="path-num">3</div>
-        <h3>⚡ ./mosaic.sh CLI</h3>
-        <p>Run any command or script inside Docker — signals, imports, backtests, GARCH sizing. No local Python needed.</p>
-        <span class="path-go">See the commands →</span>
+        <div class="path-num">⚡</div>
+        <h3>Quant engineer</h3>
+        <p>Walk-forward LightGBM, GARCH + Isolation Forest, Kelly sizing, raw ClickHouse SQL. Add a signal pillar in one class, backtest it, ship it — all via <code style="background:var(--bg3);padding:1px 5px;border-radius:4px">./mosaic.sh</code>.</p>
+        <span class="path-go">See the CLI &amp; architecture →</span>
       </a>
     </div>
   </div>


### PR DESCRIPTION
- Section: Rename the "Three ways to use it" block to "Who it's for" ("Three users, one platform").
- Personas: Replace generic tool usage steps with three dedicated cards:
  1. Retail Investor: Plain-English ask, dashboard, simple buy/hold signals.
  2. Fund Manager / AMC Treasurer: Institutional flows, DSP conviction, GARCH risk governor.
  3. Quant Engineer: LightGBM ML models, GARCH conditional volatility, and raw ClickHouse integrations.
- Anchors: Link cards to respective sections (#dashboard, #features, #quickstart).
