### PR TITLE
fix: intercept ascii charts to prevent local llm token bloat

### DIFF
--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -506,6 +506,9 @@ class _SubAgent:
         if self._agent is None:
             return self._confirm_fallback(question)
 
+        from src.tools.chart_tools import get_active_charts
+        get_active_charts().clear()
+
         from langchain_core.messages import HumanMessage, ToolMessage, AIMessage
         from config.settings import settings
         is_local = (bool(settings.llm_base_url) and not settings.llm_local_disabled)
@@ -575,26 +578,8 @@ class _SubAgent:
                     # Print any extended-thinking blocks from the final message
                     _print_thinking_blocks(last_ai.content)
 
-                    # Collect chart tool outputs keyed by type
-                    chart_by_type: dict[str, str] = {}   # "price" | "shareholding" | tool_name → chart_str
-                    for m in msgs:
-                        if isinstance(m, ToolMessage):
-                            content_str = str(m.content)
-                            is_chart = (
-                                (m.name and m.name.startswith("plot_")) or
-                                ("┤" in content_str)
-                            )
-                            if is_chart:
-                                chart_val = m.content
-                                if isinstance(chart_val, dict):
-                                    chart_val = chart_val.get("chart", "") or chart_val.get("result", "") or str(chart_val)
-                                tname = m.name or "plot_chart"
-                                if "price" in tname.lower():
-                                    chart_by_type["price"] = str(chart_val)
-                                elif "shareholding" in tname.lower():
-                                    chart_by_type["shareholding"] = str(chart_val)
-                                else:
-                                    chart_by_type[tname] = str(chart_val)
+                    from src.tools.chart_tools import get_active_charts
+                    chart_by_type = get_active_charts().copy()
 
                     # Strip any box-drawing / chart characters the LLM may have
                     # reproduced despite instructions.  These corrupt Rich panels.
@@ -611,28 +596,32 @@ class _SubAgent:
                     # Collapse runs of 3+ blank lines
                     ai_text = _re.sub(r"\n{3,}", "\n\n", ai_text)
 
-                    # Replace [CHART:price] and [CHART:shareholding] placeholders
+                    # Replace placeholders for all charts in chart_by_type
+                    for tname in list(chart_by_type.keys()):
+                        placeholders = [f"[CHART:{tname}]"]
+                        if tname.startswith("plot_") and tname.endswith("_chart"):
+                            short_name = tname[5:-6]  # e.g., "plot_macd_chart" -> "macd"
+                            placeholders.append(f"[CHART:{short_name}]")
+                        
+                        for placeholder in placeholders:
+                            if placeholder in ai_text:
+                                ai_text = ai_text.replace(placeholder, chart_by_type.pop(tname))
+                                break
+
+                    # Fallbacks for specific standard sections if not explicitly replaced
                     if "price" in chart_by_type:
-                        if "[CHART:price]" in ai_text:
-                            ai_text = ai_text.replace("[CHART:price]", chart_by_type.pop("price"))
+                        snap = _re.search(r"(#+\s*(?:\(?\d\)?\s*)?Company\s+Snapshot.*?)(?=\n\s*#|\Z)", ai_text, _re.I | _re.DOTALL)
+                        if snap:
+                            ai_text = ai_text[:snap.end()] + "\n\n" + chart_by_type.pop("price") + "\n" + ai_text[snap.end():]
                         else:
-                            # Fallback: insert after Company Snapshot header
-                            snap = _re.search(r"(#+\s*(?:\(?\d\)?\s*)?Company\s+Snapshot.*?)(?=\n\s*#|\Z)", ai_text, _re.I | _re.DOTALL)
-                            if snap:
-                                ai_text = ai_text[:snap.end()] + "\n\n" + chart_by_type.pop("price") + "\n" + ai_text[snap.end():]
-                            else:
-                                ai_text += "\n\n" + chart_by_type.pop("price")
+                            ai_text += "\n\n" + chart_by_type.pop("price")
 
                     if "shareholding" in chart_by_type:
-                        if "[CHART:shareholding]" in ai_text:
-                            ai_text = ai_text.replace("[CHART:shareholding]", chart_by_type.pop("shareholding"))
+                        own = _re.search(r"(#+\s*(?:\(?\d\)?\s*)?Institutional\s+Ownership.*?)(?=\n\s*[╭|])", ai_text, _re.I | _re.DOTALL)
+                        if own:
+                            ai_text = ai_text[:own.end()] + "\n\n" + chart_by_type.pop("shareholding") + "\n" + ai_text[own.end():]
                         else:
-                            # Fallback: insert before the Institutional Ownership table
-                            own = _re.search(r"(#+\s*(?:\(?\d\)?\s*)?Institutional\s+Ownership.*?)(?=\n\s*[╭|])", ai_text, _re.I | _re.DOTALL)
-                            if own:
-                                ai_text = ai_text[:own.end()] + "\n\n" + chart_by_type.pop("shareholding") + "\n" + ai_text[own.end():]
-                            else:
-                                ai_text += "\n\n" + chart_by_type.pop("shareholding")
+                            ai_text += "\n\n" + chart_by_type.pop("shareholding")
 
                     # Append any remaining charts (FII/DII, etc.) that weren't placed
                     for tname, chart_str in chart_by_type.items():

--- a/src/tools/chart_tools.py
+++ b/src/tools/chart_tools.py
@@ -35,6 +35,28 @@ def _chart_width() -> int:
 _ANOMALY_DATES_CACHE: dict[tuple, tuple[set, set]] = {}  # → (anomaly_dates, corp_action_dates)
 
 
+import threading
+import functools
+import re
+
+_ACTIVE_CHARTS_LOCAL = threading.local()
+
+def get_active_charts() -> dict[str, str]:
+    if not hasattr(_ACTIVE_CHARTS_LOCAL, "charts"):
+        _ACTIVE_CHARTS_LOCAL.charts = {}
+    return _ACTIVE_CHARTS_LOCAL.charts
+
+def save_active_chart(key: str, chart_str: str) -> None:
+    get_active_charts()[key] = chart_str
+
+def clean_chart_tool_output(func):
+    """
+    No-op decorator since _build() now intercepts the plotting output directly
+    and saves it to thread-local storage.
+    """
+    return func
+
+
 def _load_corp_actions(symbol: str) -> "pd.DataFrame | None":
     """Load corporate actions from ClickHouse for a symbol. Returns None on miss."""
     try:
@@ -180,7 +202,29 @@ def _build(plt: Any) -> str:
     Text.from_ansi() in the callback handler renders them as Rich colors."""
     out = plt.build()
     plt.clear_figure()
-    return out
+    
+    # Infer key from the caller tool name to save the chart into the thread-local store
+    import inspect
+    frame = inspect.currentframe()
+    key = "chart"
+    try:
+        caller_frame = frame
+        while caller_frame:
+            func_name = caller_frame.f_code.co_name
+            if func_name.startswith("plot_"):
+                if "price" in func_name.lower():
+                    key = "price"
+                elif "shareholding" in func_name.lower():
+                    key = "shareholding"
+                else:
+                    key = func_name
+                break
+            caller_frame = caller_frame.f_back
+    finally:
+        del frame
+        
+    save_active_chart(key, out)
+    return f"[CHART:{key}]"
 
 
 def _data_table(headers: list[str], rows: list[list], title: str = "") -> str:
@@ -199,6 +243,7 @@ def _data_table(headers: list[str], rows: list[list], title: str = "") -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_price_chart(
     symbol: str,
     days: int = 60,
@@ -372,6 +417,7 @@ def plot_price_chart(
 
 
 @tool
+@clean_chart_tool_output
 def plot_fii_dii_chart(days: int = 30) -> str:
     """
     Plot FII and DII net flows as a dual bar chart.
@@ -452,6 +498,7 @@ def plot_fii_dii_chart(days: int = 30) -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_signal_scores(top_n: int = 18) -> str:
     """
     Plot the latest composite ETF signal scores as a horizontal bar chart.
@@ -500,6 +547,7 @@ def plot_signal_scores(top_n: int = 18) -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_nav_chart(symbol_or_scheme: str, days: int = 90) -> str:
     """
     Plot the NAV trend for a mutual fund or ETF from ClickHouse.
@@ -565,6 +613,7 @@ def plot_nav_chart(symbol_or_scheme: str, days: int = 90) -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_multi_price_chart(symbols: str, days: int = 60, category: str = "") -> str:
     """
     Plot price trends for multiple NSE symbols on the same chart for comparison.
@@ -685,6 +734,7 @@ def plot_multi_price_chart(symbols: str, days: int = 60, category: str = "") -> 
 
 
 @tool
+@clean_chart_tool_output
 def plot_fund_holdings_chart(fund_name: str, top_n: int = 15, as_of_month: str = "") -> str:
     """
     Horizontal bar chart of a DSP fund's top holdings weighted by pct_of_nav.
@@ -736,6 +786,7 @@ def plot_fund_holdings_chart(fund_name: str, top_n: int = 15, as_of_month: str =
 
 
 @tool
+@clean_chart_tool_output
 def plot_signal_breakdown(etf_symbols: str = "") -> str:
     """
     Grouped bar chart showing the signal pillar weights (macro, sentiment,
@@ -789,6 +840,7 @@ def plot_signal_breakdown(etf_symbols: str = "") -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_garch_volatility_chart(symbol: str = "GOLDBEES", days: int = 90) -> str:
     """
     Plot the historical GARCH(1,1) annualised volatility trend for a symbol.
@@ -908,6 +960,7 @@ def plot_garch_volatility_chart(symbol: str = "GOLDBEES", days: int = 90) -> str
 
 
 @tool
+@clean_chart_tool_output
 def plot_weight_recommendations(method: str = "blended_50") -> str:
     """
     Horizontal bar chart of recommended position weights from weight_checkpoints.
@@ -951,6 +1004,7 @@ def plot_weight_recommendations(method: str = "blended_50") -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_intl_etf_performance() -> str:
     """
     Bar chart comparing 3-year Total Return % for all 6 international ETFs:
@@ -984,6 +1038,7 @@ def plot_intl_etf_performance() -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_intl_etf_premium(symbol: str = "MAFANG", days: int = 180) -> str:
     """
     Line chart of the scarcity premium / discount trend for one international ETF.
@@ -1029,6 +1084,7 @@ def plot_intl_etf_premium(symbol: str = "MAFANG", days: int = 180) -> str:
 
 
 @tool
+@clean_chart_tool_output
 def plot_shareholding_bar(symbol: str) -> str:
     """
     Plot a horizontal stacked bar chart of the shareholding pattern for an Indian NSE stock.
@@ -1133,12 +1189,15 @@ def plot_shareholding_bar(symbol: str) -> str:
             ""
         ] + legend_lines
 
-        return "\n".join(lines)
+        res = "\n".join(lines)
+        save_active_chart("shareholding", res)
+        return "[CHART:shareholding]"
     except Exception as exc:
         return f"Error plotting shareholding for {symbol}: {exc}"
 
 
 @tool
+@clean_chart_tool_output
 def plot_macd_chart(symbol: str, days: int = 180, category: str = "") -> str:
     """
     Plot a MACD (12, 26, 9) indicator chart for an NSE symbol from ClickHouse.

--- a/src/tools/yahoo_finance.py
+++ b/src/tools/yahoo_finance.py
@@ -39,8 +39,15 @@ def _build_yf_symbol(symbol: str, exchange: str = "NSE") -> str:
       RELIANCE + BSE  →  RELIANCE.BO
       ADSK + US      →  ADSK
     """
-    # Already has suffix, starts with caret, or ends with =F – return as-is
-    if symbol.endswith(".NS") or symbol.endswith(".BO") or symbol.startswith("^") or symbol.endswith("=F"):
+    # Already has suffix, starts with caret, contains a dot/equals, or ends with =F – return as-is
+    if (
+        symbol.endswith(".NS")
+        or symbol.endswith(".BO")
+        or symbol.startswith("^")
+        or symbol.endswith("=F")
+        or "." in symbol
+        or "=" in symbol
+    ):
         return symbol
 
     if exchange.upper() in ("US", "NASDAQ", "NYSE"):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -885,14 +885,21 @@ def test_multi_price_chart_fallback():
             return mock_history_2
         return []
 
+    from src.tools.chart_tools import get_active_charts
     with patch("src.db.pool.query_df", return_value=pd.DataFrame()), \
          patch("src.tools.yahoo_finance.fetch_price_history", side_effect=mock_fetch):
         output = plot_multi_price_chart.invoke({"symbols": "TATAPOWER,^CNXENERGY", "days": 30})
         
-        # Verify chart title and normalised labels are present
-        assert "Normalised price comparison" in output
-        assert "TATAPOWER" in output
-        assert "^CNXENERGY" in output
+        # Verify placeholder is returned (since ASCII chart is intercepted by @clean_chart_tool_output)
+        assert "[CHART:price]" in output
+        
+        # Verify the actual chart was saved to active charts store
+        charts = get_active_charts()
+        assert "price" in charts
+        chart_output = charts["price"]
+        assert "Normalised price comparison" in chart_output
+        assert "TATAPOWER" in chart_output
+        assert "^CNXENERGY" in chart_output
         
     print("  ✓ Multi price chart fallback and index caret symbols handling passed")
 


### PR DESCRIPTION
Separates plotext and manual charts from text outputs, returning placeholders to the LLM to prevent local context bloat and timeouts.