### PR TITLE
feat: attach context trimmer to main agent and optimize thresholds

### DIFF
--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -544,6 +544,13 @@ class MosaicFundAgent:
         )
         if self._checkpointer is not None:
             kwargs["checkpointer"] = self._checkpointer
+
+        # Attach context trimmer for local models to prevent token-overflow
+        if not settings.llm_local_disabled and settings.is_local_model:
+            from src.agents.sub_agents import _make_context_trimmer
+            kwargs["pre_model_hook"] = _make_context_trimmer(effective_window)
+            logger.info("MosaicFundAgent: context trimmer attached (window=%d tokens)", effective_window)
+
         return create_react_agent(**kwargs)
 
     # ── Public API ────────────────────────────────────────────────────────────

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -47,8 +47,8 @@ def _make_context_trimmer(context_window: int):
 
     Only attached when running a local model; cloud models skip this.
     """
-    max_input_chars = int(context_window * 0.60 * 4)   # 60 % of ctx for input
-    max_tool_chars  = int(context_window * 0.20 * 4)   # 20 % per tool output
+    max_input_chars = int(context_window * 0.50 * 4)   # 50 % of ctx for input
+    max_tool_chars  = int(context_window * 0.10 * 4)   # 10 % per tool output
 
     def _hook(state: dict) -> dict:
         from langchain_core.messages import ToolMessage, AIMessage


### PR DESCRIPTION
Attaches the context trimmer to the main MosaicFundAgent and tightens the trimmer limits (50% input, 10% tool outputs) to reduce local LLM context bloat.