### PR TITLE
chore: set default LLM context window to 16k

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ LLM_BASE_URL=
 #   Local 8-bit models:            8192
 #   GPT-4o-mini / GPT-4o:         32768
 #   Claude 3.5 Sonnet:           200000
-LLM_CONTEXT_WINDOW=4096
+LLM_CONTEXT_WINDOW=16384
 
 # ── Zerodha Kite MCP ──────────────────────────────────────────────────────────
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -184,7 +184,7 @@ class Settings(BaseSettings):
     #   GPT-4o / GPT-4o-mini (OpenAI cloud):   32768
     #   Claude 3.5 Sonnet (Anthropic cloud):   200000
     llm_context_window: int = Field(
-        default=4096,
+        default=16384,
         description="Model input context window in tokens",
     )
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   # ── One-time model initialiser ───────────────────────────────────────────────
   # Pulls gemma4:latest into the ollama service and creates the mosaic-gemma4
-  # variant from ollama/Modelfile (num_ctx=32768, temperature=0).
+  # variant from ollama/Modelfile (num_ctx=16384, temperature=0).
   # FIRST RUN: downloads ~5-8 GB — runs once, then the volume cache is reused.
   ollama-init:
     image: ollama/ollama:latest

--- a/ollama/Modelfile.qwen25-think
+++ b/ollama/Modelfile.qwen25-think
@@ -1,7 +1,7 @@
 FROM qwen2.5:14b
 
 # ── Context window ───────────────────────────────────────────────────────────
-PARAMETER num_ctx 32768
+PARAMETER num_ctx 16384
 
 # ── Sampling ─────────────────────────────────────────────────────────────────
 # Temperature 0 = deterministic, important for structured tool JSON


### PR DESCRIPTION
Sets the default LLM context window to 16384 (16k) in the project settings, environment template, Qwen Modelfile, and docker-compose comments.