### PR TITLE
feat(signals): rebalance composite weights, add anomaly scoring and auditable breakdown

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,12 +15,16 @@ OPENAI_API_KEY=your_openai_api_key_here
 # Leave blank if using OpenAI
 ANTHROPIC_API_KEY=
 
-# [NON-SENSITIVE] LLM provider to use: "openai" or "anthropic"
+# [SENSITIVE] OpenRouter API key – get from https://openrouter.ai/keys
+OPENROUTER_API_KEY=
+
+# [NON-SENSITIVE] LLM provider to use: "openai", "anthropic", or "openrouter"
 LLM_PROVIDER=openai
 
 # [NON-SENSITIVE] Model name to use
-# OpenAI options:    gpt-4o, gpt-4o-mini, gpt-4-turbo
-# Anthropic options: claude-3-5-sonnet-20241022, claude-3-haiku-20240307
+# OpenAI options:     gpt-4o, gpt-4o-mini, gpt-4-turbo
+# Anthropic options:  claude-3-5-sonnet-20241022, claude-3-haiku-20240307
+# OpenRouter options: openrouter/auto, google/gemini-2.5-flash, anthropic/claude-3.5-sonnet, etc.
 # Local / Ollama:     deepseek-r1:7b, llama3.2, mistral, etc.
 LLM_MODEL=gpt-4o-mini
 
@@ -33,11 +37,13 @@ LLM_MODEL=gpt-4o-mini
 LLM_BASE_URL=
 
 # [NON-SENSITIVE] Input context window size in tokens.
-#   Local 4-bit quantized models:  4096
-#   Local 8-bit models:            8192
-#   GPT-4o-mini / GPT-4o:         32768
-#   Claude 3.5 Sonnet:           200000
-LLM_CONTEXT_WINDOW=16384
+#   Set to 0 to enable dynamic auto-detection depending on the type of model.
+#   Recommended values (if overriding manually):
+#     Local 4-bit quantized models:  4096
+#     Local 8-bit models:            8192
+#     GPT-4o-mini / GPT-4o:         32768
+#     Claude 3.5 Sonnet:           200000
+LLM_CONTEXT_WINDOW=0
 
 # ── Zerodha Kite MCP ──────────────────────────────────────────────────────────
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -34,10 +34,13 @@ class Settings(BaseSettings):
     # [SENSITIVE] Anthropic API key – https://console.anthropic.com/
     anthropic_api_key: str = Field(default="", description="Anthropic API key")
 
+    # [SENSITIVE] OpenRouter API key – https://openrouter.ai/keys
+    openrouter_api_key: str = Field(default="", description="OpenRouter API key")
+
     # [SENSITIVE] NVIDIA NIM API key – https://integrate.api.nvidia.com/
     nvidia_api_key: str = Field(default="", description="NVIDIA NIM API key (nvapi-...)")
 
-    # [NON-SENSITIVE] Which LLM provider to use: "openai" or "anthropic"
+    # [NON-SENSITIVE] Which LLM provider to use: "openai", "anthropic", or "openrouter"
     llm_provider: str = Field(default="openai", description="LLM provider")
 
     # [NON-SENSITIVE] Model name to use (gpt-4o-mini, claude-3-haiku, deepseek-r1:7b, etc.)
@@ -91,8 +94,12 @@ class Settings(BaseSettings):
     code_llm_model: str = Field(default="", description="Code agent LLM model name")
     # [NON-SENSITIVE] Optional custom base URL (Ollama / LM Studio) for the code agent
     code_llm_base_url: str = Field(default="", description="Code agent custom base URL")
-    # [NON-SENSITIVE] Context window for the code agent's LLM (0 = inherit from llm_context_window)
-    code_llm_context_window: int = Field(default=0, description="Code agent context window (0 = inherit)")
+    # [NON-SENSITIVE] Context window for the code agent's LLM (0 = auto-detect / inherit)
+    code_llm_context_window_configured: int = Field(
+        default=0,
+        alias="code_llm_context_window",
+        description="Code agent context window (0 = inherit)",
+    )
 
     # [SENSITIVE] Google / Gemini API key — https://aistudio.google.com/app/apikey
     google_api_key: str = Field(default="", description="Google Gemini API key")
@@ -109,8 +116,12 @@ class Settings(BaseSettings):
     llm_cloud_provider: str = Field(default="", description="Cloud LLM provider (openai|anthropic); blank = disabled")
     # [NON-SENSITIVE] Cloud model name
     llm_cloud_model: str = Field(default="claude-3-5-haiku-20241022", description="Cloud LLM model name")
-    # [NON-SENSITIVE] Context window of the cloud model (tokens)
-    llm_cloud_context_window: int = Field(default=200000, description="Cloud model context window")
+    # [NON-SENSITIVE] Context window of the cloud model (tokens) (0 = auto-detect)
+    llm_cloud_context_window_configured: int = Field(
+        default=0,
+        alias="llm_cloud_context_window",
+        description="Cloud model context window (0 = auto-detect)",
+    )
     # ── Zerodha Kite MCP ─────────────────────────────────────────────────────
 
     # [NON-SENSITIVE] Hosted Kite MCP endpoint – no auth needed for hosted version
@@ -177,16 +188,110 @@ class Settings(BaseSettings):
         description="LLM cache TTL in hours (0 = no expiry)",
     )
 
-    # [NON-SENSITIVE] Input context window of the model in tokens.
-    # Recommended values:
-    #   DeepSeek-R1-14B local (LM Studio, Q4):  4096
-    #   DeepSeek-R1-14B local (LM Studio, Q8):  8192
-    #   GPT-4o / GPT-4o-mini (OpenAI cloud):   32768
-    #   Claude 3.5 Sonnet (Anthropic cloud):   200000
-    llm_context_window: int = Field(
-        default=16384,
-        description="Model input context window in tokens",
+    # [NON-SENSITIVE] Configured input context window in tokens.
+    # Set to 0 to auto-detect based on model.
+    llm_context_window_configured: int = Field(
+        default=0,
+        alias="llm_context_window",
+        description="Model input context window in tokens (0 = auto-detect)",
     )
+
+    def _resolve_context_window(self, model_name: str, provider: str, base_url: str) -> int:
+        """Dynamically resolve the context window size based on model type and provider."""
+        model_lower = model_name.lower() if model_name else ""
+        prov_lower = provider.lower() if provider else ""
+        
+        # 1. Local models via base URL (Ollama, LM Studio)
+        if base_url and "openrouter" not in base_url and "nvidia" not in base_url:
+            if "gemma4" in model_lower or "3.1" in model_lower or "3.2" in model_lower or "3.3" in model_lower:
+                return 32768
+            return 16384
+            
+        # 2. OpenRouter (can run any model)
+        if prov_lower == "openrouter" or "openrouter.ai" in base_url:
+            if "openrouter/auto" in model_lower or "auto" == model_lower:
+                return 128000
+            if "gemini-2.5" in model_lower or "gemini-2.0" in model_lower or "gemini-1.5" in model_lower:
+                return 1000000
+            if "claude-3" in model_lower:
+                return 200000
+            if "gpt-4o" in model_lower or "gpt-4-turbo" in model_lower:
+                return 128000
+            if "llama-3.1" in model_lower or "llama-3.2" in model_lower or "llama-3.3" in model_lower:
+                return 128000
+            if "deepseek-r1" in model_lower or "deepseek-v3" in model_lower:
+                return 64000
+            if "gemini" in model_lower:
+                return 1000000
+            if "claude" in model_lower:
+                return 200000
+            if "gpt-4" in model_lower:
+                return 128000
+            if "llama-3" in model_lower:
+                return 8192
+            return 16384
+
+        # 3. Direct Google / Gemini
+        if prov_lower == "google" or "gemini" in model_lower:
+            return 1000000
+
+        # 4. Direct Anthropic
+        if prov_lower == "anthropic" or "claude" in model_lower:
+            return 200000
+
+        # 5. Direct OpenAI
+        if prov_lower == "openai":
+            if "gpt-4o" in model_lower or "gpt-4-turbo" in model_lower:
+                return 128000
+            if "gpt-4" in model_lower:
+                return 8192
+            if "gpt-3.5" in model_lower:
+                return 16385
+            return 128000
+
+        # 6. NVIDIA NIM
+        if base_url and "nvidia" in base_url.lower():
+            if "deepseek" in model_lower or "llama-3.1" in model_lower or "llama-3.3" in model_lower:
+                return 16384
+            return 16384
+
+        return 16384
+
+    @property
+    def llm_context_window(self) -> int:
+        """Dynamic model input context window in tokens."""
+        if self.llm_context_window_configured > 0:
+            return self.llm_context_window_configured
+        return self._resolve_context_window(
+            model_name=self.llm_model,
+            provider=self.llm_provider,
+            base_url=self.llm_base_url,
+        )
+
+    @property
+    def code_llm_context_window(self) -> int:
+        """Dynamic code agent context window."""
+        if self.code_llm_context_window_configured > 0:
+            return self.code_llm_context_window_configured
+        model = self.code_llm_model or self.llm_model
+        provider = self.code_llm_provider or self.llm_provider
+        base_url = self.code_llm_base_url or self.llm_base_url
+        return self._resolve_context_window(
+            model_name=model,
+            provider=provider,
+            base_url=base_url,
+        )
+
+    @property
+    def llm_cloud_context_window(self) -> int:
+        """Dynamic cloud model context window."""
+        if self.llm_cloud_context_window_configured > 0:
+            return self.llm_cloud_context_window_configured
+        return self._resolve_context_window(
+            model_name=self.llm_cloud_model,
+            provider=self.llm_cloud_provider,
+            base_url="",
+        )
 
     @property
     def llm_token_budget(self) -> int:
@@ -336,9 +441,9 @@ class Settings(BaseSettings):
         using_local = bool(self.llm_base_url)
 
         if not using_local:
-            if not self.openai_api_key and not self.anthropic_api_key:
+            if not self.openai_api_key and not self.anthropic_api_key and not self.openrouter_api_key:
                 warnings.append(
-                    "[SENSITIVE] Neither OPENAI_API_KEY nor ANTHROPIC_API_KEY is set. "
+                    "[SENSITIVE] Neither OPENAI_API_KEY, ANTHROPIC_API_KEY, nor OPENROUTER_API_KEY is set. "
                     "Set at least one in your .env file."
                 )
 
@@ -350,6 +455,11 @@ class Settings(BaseSettings):
             if self.llm_provider == "anthropic" and not self.anthropic_api_key:
                 warnings.append(
                     "[SENSITIVE] LLM_PROVIDER=anthropic but ANTHROPIC_API_KEY is not set."
+                )
+
+            if self.llm_provider == "openrouter" and not self.openrouter_api_key:
+                warnings.append(
+                    "[SENSITIVE] LLM_PROVIDER=openrouter but OPENROUTER_API_KEY is not set."
                 )
 
         if not self.newsapi_key:

--- a/src/agents/comex_agent.py
+++ b/src/agents/comex_agent.py
@@ -238,10 +238,21 @@ class ComexAgent:
     def _build_llm(self) -> Any:
         """
         Build LLM with same priority as MosaicFundAgent and NewsSentimentAgent:
-          1. Local OpenAI-compatible server (LLM_BASE_URL)
-          2. Anthropic cloud
-          3. OpenAI cloud
+          1. OpenRouter cloud
+          2. Local OpenAI-compatible server (LLM_BASE_URL)
+          3. Anthropic cloud
+          4. OpenAI cloud
         """
+        if settings.llm_provider.lower() == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=settings.llm_model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0,
+                max_tokens=settings.llm_token_budget,
+            )
+
         if settings.llm_base_url:
             from langchain_openai import ChatOpenAI
             logger.info(

--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -135,6 +135,20 @@ def _get_router_llm() -> Any | None:
                 )
             except Exception as exc:
                 logger.debug("Router LLM (OpenAI Cloud) build failed: %s", exc)
+        elif cloud_provider == "openrouter" and _real_key(settings.openrouter_api_key):
+            try:
+                from langchain_openai import ChatOpenAI
+                return ChatOpenAI(
+                    model=settings.llm_cloud_model or "google/gemini-2.5-flash",
+                    api_key=settings.openrouter_api_key,
+                    base_url="https://openrouter.ai/api/v1",
+                    temperature=0,
+                    max_tokens=50,
+                    request_timeout=10,
+                    timeout=10,
+                )
+            except Exception as exc:
+                logger.debug("Router LLM (OpenRouter Cloud) build failed: %s", exc)
 
     # 2. NVIDIA NIM — use the same endpoint/key as the main LLM
     nvidia_key = getattr(settings, "nvidia_api_key", "")
@@ -154,6 +168,21 @@ def _get_router_llm() -> Any | None:
 
     # 3. Otherwise fall back to local/default API key providers
     # Prefer a small fast model for routing — gpt-4o-mini costs ~$0.0001 per call
+    if settings.llm_provider.lower() == "openrouter" and _real_key(settings.openrouter_api_key):
+        try:
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=settings.llm_model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0,
+                max_tokens=50,
+                request_timeout=10,
+                timeout=10,
+            )
+        except Exception as exc:
+            logger.debug("Router LLM (OpenRouter) build failed: %s", exc)
+
     if _real_key(settings.openai_api_key):
         try:
             from langchain_openai import ChatOpenAI

--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -65,15 +65,22 @@ def _make_daemon_thread() -> None:
 class RichConsoleCallbackHandler(BaseCallbackHandler):
     """Callback handler to print intermediate LLM steps and tool calls beautifully in the console."""
 
-    def __init__(self) -> None:
+    def __init__(self, agent_name: str | None = None) -> None:
         self.console = Console()
+        self.agent_name = agent_name
         self._llm_start_time = None
         self._reasoning_started = False
         self._reasoning_ended   = False
 
     def on_llm_start(self, serialized: dict[str, Any], prompts: list[str], **kwargs: Any) -> None:
         import time
-        self.console.print("\n[bold cyan]🤖 Thinking...[/bold cyan]")
+        if self.agent_name:
+            agent_label = self.agent_name.replace("_", " ").title()
+            if not agent_label.lower().endswith("agent"):
+                agent_label += " Agent"
+            self.console.print(f"\n[bold cyan]🤖 Thinking ({agent_label})...[/bold cyan]")
+        else:
+            self.console.print("\n[bold cyan]🤖 Thinking...[/bold cyan]")
         self._llm_start_time    = time.time()
         self._reasoning_started = False
         self._reasoning_ended   = False
@@ -343,6 +350,18 @@ class MosaicFundAgent:
 
         provider = settings.llm_provider.lower()
 
+        # ── OpenRouter cloud ───────────────────────────────────────────────────
+        if provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=settings.llm_model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0,
+                max_tokens=settings.llm_token_budget,
+                timeout=settings.cloud_llm_request_timeout,
+            )
+
         # ── Local / custom OpenAI-compatible endpoint (Ollama, LM Studio, etc.) ──
         if settings.llm_base_url:
             from langchain_openai import ChatOpenAI
@@ -437,6 +456,16 @@ class MosaicFundAgent:
                 extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
             )
 
+        if provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=settings.llm_cloud_model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0,
+                max_tokens=cloud_budget,
+            )
+
         from langchain_openai import ChatOpenAI
         return ChatOpenAI(
             model=settings.llm_cloud_model,
@@ -490,6 +519,16 @@ class MosaicFundAgent:
                 google_api_key=settings.google_api_key,
                 temperature=0,
                 max_output_tokens=budget,
+            )
+
+        if provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0,
+                max_tokens=budget,
             )
 
         from langchain_openai import ChatOpenAI
@@ -830,7 +869,7 @@ class MosaicFundAgent:
             messages = [HumanMessage(content=question)]
             config = {}
             if os.getenv("VERBOSE") == "1" or settings.llm_think:
-                config["callbacks"] = [RichConsoleCallbackHandler()]
+                config["callbacks"] = [RichConsoleCallbackHandler(agent_name="main")]
 
             agent_timeout = settings.agent_timeout
             with concurrent.futures.ThreadPoolExecutor(max_workers=1, initializer=_make_daemon_thread) as _ex:
@@ -1057,7 +1096,7 @@ class MosaicFundAgent:
 
         config: dict = {"configurable": {"thread_id": thread_id}}
         if os.getenv("VERBOSE") == "1" or settings.llm_think:
-            config["callbacks"] = [RichConsoleCallbackHandler()]
+            config["callbacks"] = [RichConsoleCallbackHandler(agent_name="main")]
 
         # Clean up incomplete tool calls in history if any
         if self._checkpointer is not None:

--- a/src/agents/news_sentiment_agent.py
+++ b/src/agents/news_sentiment_agent.py
@@ -249,10 +249,21 @@ class NewsSentimentAgent:
     def _build_llm(self) -> Any:
         """
         Build LLM with same priority as MosaicFundAgent:
-          1. Local OpenAI-compatible server (LLM_BASE_URL)
-          2. Anthropic cloud
-          3. OpenAI cloud
+          1. OpenRouter cloud
+          2. Local OpenAI-compatible server (LLM_BASE_URL)
+          3. Anthropic cloud
+          4. OpenAI cloud
         """
+        if settings.llm_provider.lower() == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=settings.llm_model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0.1,
+                max_tokens=settings.llm_token_budget,
+            )
+
         if settings.llm_base_url:
             from langchain_openai import ChatOpenAI
             logger.info(

--- a/src/agents/signal_aggregator.py
+++ b/src/agents/signal_aggregator.py
@@ -22,14 +22,35 @@ from src.agents.signal_sources import SIGNAL_ETFS  # noqa: E402
 # ── Weights for each pillar ───────────────────────────────────────────────────
 
 WEIGHTS = {
-    "macro":     0.25,
+    "macro":     0.20,
     "sentiment": 0.15,
-    "valuation": 0.15,
-    "flow":      0.15,
-    "ml":        0.15,
-    "anomaly":   0.05,
+    "valuation": 0.25,
+    "flow":      0.10,
+    "ml":        0.20,
+    "anomaly":   0.10,
 }
-# Remaining 0.10 is distributed to flow (FII/DII component)
+# Weights sum to 1.00.  Valuation, ML, and Anomaly are prioritised over Flow
+# because FII/DII net-flow is a single scalar applied uniformly to equity vs.
+# haven buckets — it currently adds zero cross-ETF ranking power when the
+# 5-day net is flat.  When per-ETF AUM flow data is added, Flow weight can
+# be revisited.
+
+# ── Anomaly regime → numeric score ───────────────────────────────────────────
+# Regime labels from the GARCH+IF+PELT anomaly pipeline are mapped to 0-100
+# scores that participate in the weighted composite.  "Strong Trend (HODL)"
+# maps to 70 (moderately bullish) rather than neutral 50 — the *Risk Governor*
+# handles sizing (1.0× multiplier), but the composite should acknowledge that
+# a trending regime is mildly positive for the held asset.
+ANOMALY_REGIME_SCORES: dict[str, float] = {
+    "Strong Trend (HODL)":           70.0,
+    "Normal":                        50.0,
+    "Volatile Breakout":             40.0,
+    "🔀 Regime Shift (Change Point)": 35.0,
+    "Flash Crash (Contrarian BUY)":  25.0,
+    "Blow-off Top":                  30.0,
+    "Panic":                         20.0,
+    "🏦 Corporate Action":            50.0,   # mechanical — neutral
+}
 
 
 @dataclass
@@ -42,9 +63,10 @@ class ETFSignal:
     flow_score: float = 50.0
     ml_score: float = 50.0
     anomaly_flag: str = "Normal"
+    anomaly_score: float = 50.0       # numeric regime score (0–100)
     composite_score: float = 50.0
     action: str = "HOLD"
-    rationale: str = ""
+    rationale: str = ""               # human-readable pillar breakdown
 
 
 @dataclass
@@ -57,35 +79,74 @@ class SignalReport:
 
 # ── Composite scoring ─────────────────────────────────────────────────────────
 
+def _anomaly_to_score(flag: str) -> float:
+    """Convert an anomaly regime label to a 0–100 numeric score."""
+    # Exact match first, then substring fallback
+    if flag in ANOMALY_REGIME_SCORES:
+        return ANOMALY_REGIME_SCORES[flag]
+    flag_lower = flag.lower()
+    for key, score in ANOMALY_REGIME_SCORES.items():
+        if key.lower() in flag_lower:
+            return score
+    return 50.0  # unknown → neutral
+
+
+def _build_breakdown(scores: dict[str, float]) -> str:
+    """
+    Build a human-readable, auditable per-pillar breakdown.
+
+    Each line shows the pillar, its effective weight, its raw 0–100 score,
+    and its *weighted contribution* (score × weight).  The sum of contributions
+    equals the composite score.
+
+    Example output:
+        Macro=75 ×0.20=+15.0 | Sent.=40 ×0.15=+6.0 | Val.=60 ×0.25=+15.0
+        Flow=55 ×0.10=+5.5 | ML=52 ×0.20=+10.4 | Anom.=70 ×0.10=+7.0
+    """
+    parts = []
+    for label, key in [
+        ("Macro", "macro"), ("Sent.", "sentiment"), ("Val.", "valuation"),
+        ("Flow", "flow"), ("ML", "ml"), ("Anom.", "anomaly"),
+    ]:
+        raw = scores[key]
+        w = WEIGHTS[key]
+        parts.append(f"{label}={raw:.0f} ×{w:.2f}={raw * w:+.1f}")
+
+    # Split into two lines of 3 for readability
+    return " | ".join(parts[:3]) + "\n" + " | ".join(parts[3:])
+
+
 def _compute_composite(
     macro: dict, sentiment: dict, valuation: dict,
     flow: dict, ml: dict, anomaly: dict,
 ) -> list[ETFSignal]:
-    """Compute weighted composite score and action for each ETF."""
+    """Compute weighted composite score and action for each ETF.
+
+    All six pillars (including anomaly) are weighted numerically.
+    The anomaly regime label is converted to a 0–100 score via
+    ANOMALY_REGIME_SCORES and participates in the weighted sum.
+    Weights sum to 1.00 — no extra allocation hacks.
+    """
     signals = []
     for etf in SIGNAL_ETFS:
-        m = macro.get(etf, 50)
-        s = sentiment.get(etf, 50)
-        v = valuation.get(etf, 50)
-        f = flow.get(etf, 50)
-        ml_s = ml.get(etf, 50)
+        m      = macro.get(etf, 50)
+        s      = sentiment.get(etf, 50)
+        v      = valuation.get(etf, 50)
+        f      = flow.get(etf, 50)
+        ml_s   = ml.get(etf, 50)
         a_flag = anomaly.get(etf, "Normal")
+        a_score = _anomaly_to_score(a_flag)
 
-        # Weighted composite
+        # Fully weighted composite — all 6 pillars, weights sum to 1.00
         composite = (
-            m * WEIGHTS["macro"]
-            + s * WEIGHTS["sentiment"]
-            + v * WEIGHTS["valuation"]
-            + f * (WEIGHTS["flow"] + 0.10)  # flow gets extra 10% from the remaining
-            + ml_s * WEIGHTS["ml"]
+            m       * WEIGHTS["macro"]
+            + s     * WEIGHTS["sentiment"]
+            + v     * WEIGHTS["valuation"]
+            + f     * WEIGHTS["flow"]
+            + ml_s  * WEIGHTS["ml"]
+            + a_score * WEIGHTS["anomaly"]
         )
 
-        # Anomaly override: boost contrarian if Flash Crash
-        if "Flash Crash" in a_flag and composite < 40:
-            composite = min(composite + 15, 60)
-        # Blow-off top: dampen bullish signal
-        elif "Blow-off" in a_flag and composite > 60:
-            composite = max(composite - 10, 55)
 
         composite = round(composite, 1)
 
@@ -101,6 +162,13 @@ def _compute_composite(
         else:
             action = "AVOID"
 
+        # Build auditable breakdown string
+        pillar_scores = {
+            "macro": m, "sentiment": s, "valuation": v,
+            "flow": f, "ml": ml_s, "anomaly": a_score,
+        }
+        breakdown = _build_breakdown(pillar_scores)
+
         signals.append(ETFSignal(
             etf=etf,
             macro_score=m,
@@ -109,8 +177,10 @@ def _compute_composite(
             flow_score=f,
             ml_score=ml_s,
             anomaly_flag=a_flag,
+            anomaly_score=a_score,
             composite_score=composite,
             action=action,
+            rationale=breakdown,
         ))
 
     signals.sort(key=lambda s: s.composite_score, reverse=True)
@@ -239,7 +309,8 @@ def print_signal_report(report: SignalReport) -> None:
     table.add_column("Val.", justify="right", width=7)
     table.add_column("Flow", justify="right", width=7)
     table.add_column("ML", justify="right", width=7)
-    table.add_column("Anomaly", width=12)
+    table.add_column("Anom.", justify="right", width=7)
+    table.add_column("Regime", width=16)
     table.add_column("Score", justify="right", style="bold", width=7)
     table.add_column("Action", width=12)
 
@@ -266,12 +337,27 @@ def print_signal_report(report: SignalReport) -> None:
             _score_color(s.valuation_score),
             _score_color(s.flow_score),
             _score_color(s.ml_score),
+            _score_color(s.anomaly_score),
             s.anomaly_flag,
             _score_color(s.composite_score),
             ACTION_STYLE.get(s.action, s.action),
         )
 
     console.print(table)
+
+    # ── Score Breakdown panel (verbose detail for top 5 ETFs) ─────────────
+    if report.signals:
+        breakdown_lines = []
+        for s in report.signals[:5]:
+            breakdown_lines.append(
+                f"[bold]{s.etf}[/bold] = {s.composite_score:.0f}\n"
+                f"  {s.rationale}"
+            )
+        console.print(Panel(
+            "\n\n".join(breakdown_lines),
+            title="Score Breakdown (Top 5)",
+            border_style="dim cyan",
+        ))
 
     # Top picks
     buys = [s for s in report.signals if s.action in ("BUY", "ACCUMULATE")]

--- a/src/agents/signal_sources.py
+++ b/src/agents/signal_sources.py
@@ -171,11 +171,40 @@ class MacroSignalSource(SignalSource):
                 base    = 50 + (clamped / 8) * 50
                 delta   = self._fundamentals_delta(mf, etf)
                 scores[etf] = round(max(0.0, min(100.0, base + delta)), 1)
-            log.info(
-                "Macro: %d themes, %d ETF signals, fundamentals=%s",
-                len(report.themes_detected), len(scores),
-                "ok" if mf.gdp_growth_pct is not None else "unavailable",
-            )
+            
+            # Compute macro theme breakdown for GOLDBEES and SILVERBEES for debugging/logging
+            from collections import defaultdict
+            theme_mapping = {
+                "Geopolitical / War": "Geopolitics",
+                "Trade War / Tariffs": "Geopolitics",
+                "Central Bank Policy (Fed / RBI)": "CentralBanks",
+                "Currency / INR Move": "USD",
+                "Crude Oil Shock": "Inflation",
+                "Gold / Commodity Specific": "Inflation",
+                "Global Risk-Off / Equity Sell-Off": "Geopolitics"
+            }
+            breakdown_gold = defaultdict(int)
+            breakdown_silver = defaultdict(int)
+            
+            for event in report.events:
+                theme_cat = theme_mapping.get(event.theme, "Geopolitics")
+                # Re-classify as RealRates if keyword indicators exist
+                hl = event.headline.lower()
+                if "real rate" in hl or "real yield" in hl or "interest rate" in hl:
+                    theme_cat = "RealRates"
+                
+                breakdown_gold[theme_cat] += event.impact.get("GOLDBEES", 0)
+                breakdown_silver[theme_cat] += event.impact.get("SILVERBEES", 0)
+
+            log.info("Macro: %d themes, %d ETF signals, fundamentals=%s",
+                     len(report.themes_detected), len(scores),
+                     "ok" if mf.gdp_growth_pct is not None else "unavailable")
+            
+            log.info("GOLDBEES Macro Breakdown: USD: %d | RealRates: %d | CentralBanks: %d | Geopolitics: %d | Inflation: %d",
+                     breakdown_gold["USD"], breakdown_gold["RealRates"], breakdown_gold["CentralBanks"], breakdown_gold["Geopolitics"], breakdown_gold["Inflation"])
+            log.info("SILVERBEES Macro Breakdown: USD: %d | RealRates: %d | CentralBanks: %d | Geopolitics: %d | Inflation: %d",
+                     breakdown_silver["USD"], breakdown_silver["RealRates"], breakdown_silver["CentralBanks"], breakdown_silver["Geopolitics"], breakdown_silver["Inflation"])
+            
             return scores
         except Exception as exc:
             log.warning("MacroSignalSource failed: %s", exc)
@@ -254,21 +283,26 @@ class FlowSignalSource(SignalSource):
     International ETFs: neutral.
     """
     name   = "flow"
-    weight = 0.25  # 0.15 base + 0.10 extra allocated in aggregator
+    weight = 0.10
 
-    _EQUITY_ETFS = {"NIFTYBEES", "BANKBEES", "ITBEES", "JUNIORBEES", "CPSEETF",
-                    "AUTOBEES", "PHARMABEES", "PSUBNKBEES", "MID150BEES", "SMALL250"}
-    _HAVEN_ETFS  = {"GOLDBEES", "SILVERBEES", "LIQUIDBEES", "LIQUIDCASE", "GILT5YBEES"}
-    _INTL_ETFS   = {"MON100", "MAFANG", "HNGSNGBEES"}
+    _EQUITY_ETFS    = {"NIFTYBEES", "BANKBEES", "ITBEES", "JUNIORBEES", "CPSEETF",
+                        "AUTOBEES", "PHARMABEES", "PSUBNKBEES", "MID150BEES", "SMALL250"}
+    _HAVEN_ETFS     = {"LIQUIDBEES", "LIQUIDCASE", "GILT5YBEES"}   # money-market/gilt: inverse equity flows
+    _COMMODITY_ETFS = {"GOLDBEES", "SILVERBEES"}                   # commodity-backed: FII/DII equity flows don't apply
+    _INTL_ETFS      = {"MON100", "MAFANG", "HNGSNGBEES"}
 
     def collect(self, repo) -> dict[str, float]:
         try:
-            fii_5d, dii_5d = repo.fii_dii_5d()
+            result = repo.fii_dii_5d()
+            if result is None:
+                log.warning("Flow: ⚠ No FII/DII data in last 5 days — returning neutral scores")
+                return self.neutral()
+            fii_5d, dii_5d = result
             net         = fii_5d + dii_5d
             clamped     = max(-15000, min(15000, net))
             eq_score    = round(50 + (clamped / 15000) * 50, 1)
-            log.info("Flow: FII 5d=%.0f Cr, DII 5d=%.0f Cr, eq_score=%.1f",
-                     fii_5d, dii_5d, eq_score)
+            log.info("Flow: FII 5d=%.0f Cr, DII 5d=%.0f Cr, net=%.0f Cr, eq_score=%.1f",
+                     fii_5d, dii_5d, net, eq_score)
             scores = {}
             for etf in SIGNAL_ETFS:
                 if etf in self._EQUITY_ETFS:

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -1944,9 +1944,10 @@ def run_subagent_for(intent: str, question: str, callbacks: list | None = None) 
     budget = BudgetCallbackHandler()
     if callbacks is None:
         callbacks = []
-        if os.getenv("VERBOSE") == "1":
+        from config.settings import settings
+        if os.getenv("VERBOSE") == "1" or settings.llm_think:
             from src.agents.mosaic_fund_agent import RichConsoleCallbackHandler
-            callbacks.append(RichConsoleCallbackHandler())
+            callbacks.append(RichConsoleCallbackHandler(agent_name=intent))
     callbacks.extend([tracer, budget])
 
     # Log the routing decision itself

--- a/src/agents/sub_agents.py
+++ b/src/agents/sub_agents.py
@@ -981,6 +981,9 @@ class DeepDiveSubAgent(_SubAgent):
         "immediately reply: \"This stock is listed in India (NSE/BSE). "
         "Please use the Indian equity research path.\".  "
         "For US tickers: use `run_deepdive_analysis` to fetch SEC filings. "
+        "If you need to summarize an existing deep-dive report, or if the user asks "
+        "follow-up questions about a previously generated deep-dive report, "
+        "use `read_deepdive_report` to load the full report content first. "
         "Use `query_clickhouse_db` to read deepdive_* tables in ClickHouse "
         "(always add FINAL). "
         "Use `get_yahoo_finance_data` for live price and valuation multiples. "
@@ -990,10 +993,10 @@ class DeepDiveSubAgent(_SubAgent):
     def _get_tools(self) -> list:
         from src.tools.yahoo_finance import YAHOO_TOOLS
         from src.tools.earnings_scraper import EARNINGS_TOOLS
-        from src.tools.skills_tools import run_deepdive_analysis, query_clickhouse_db
+        from src.tools.skills_tools import run_deepdive_analysis, query_clickhouse_db, read_deepdive_report
         from src.tools.company_resolver import resolve_company
         return [resolve_company] + YAHOO_TOOLS + EARNINGS_TOOLS + [
-            run_deepdive_analysis, query_clickhouse_db,
+            run_deepdive_analysis, query_clickhouse_db, read_deepdive_report,
         ]
 
 
@@ -1928,7 +1931,7 @@ def run_subagent_for(intent: str, question: str, callbacks: list | None = None) 
     import time
 
     cloud_llm = None
-    if _needs_cloud(question):
+    if _needs_cloud(question) or intent in ("deepdive", "research"):
         try:
             from src.agents.mosaic_fund_agent import MosaicFundAgent
             tmp = object.__new__(MosaicFundAgent)

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -436,7 +436,17 @@ def _get_plan_llm() -> "Any":
         from config.settings import settings
         budget = settings.llm_token_budget
         kw = dict(temperature=0, max_tokens=budget)
-        if settings.llm_base_url:
+        if settings.llm_provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            _plan_llm = ChatOpenAI(
+                model=settings.llm_model,
+                base_url="https://openrouter.ai/api/v1",
+                api_key=settings.openrouter_api_key,
+                request_timeout=30,
+                timeout=30,
+                **kw,
+            )
+        elif settings.llm_base_url:
             from langchain_openai import ChatOpenAI
             _plan_llm = ChatOpenAI(
                 model=settings.llm_model,

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -1280,6 +1280,7 @@ _HELP_MD = """
 | `/cache` | Show LLM cache stats; `/cache clear` wipes cached responses |
 | `/telemetry` | View telemetry; `/telemetry on` or `off` toggles turn overlay |
 | `/clear` | Reset session memory — next question starts a fresh thread |
+| `/list thread` | List all previous conversation threads with summaries |
 | `/help` | This help text |
 | `quit` / `exit` / `q` | Exit the chat |
 
@@ -1358,6 +1359,84 @@ def _dispatch_slash(
             conv_history.clear()
         console.print(f"[yellow]Memory cleared — new conversation thread started:[/yellow] [bold cyan]{new_id}[/bold cyan]")
         return "", new_id
+
+    # ── /list thread / /threads ───────────────────────────────────────────
+    if name in ("threads", "thread") or (name == "list" and len(parts) > 1 and parts[1].lower() in ("thread", "threads")):
+        checkpointer = getattr(agent, "_checkpointer", None)
+        if checkpointer is None:
+            console.print("[yellow]No checkpoints database found (thread history is unavailable).[/yellow]")
+            return "", thread_id
+
+        from rich.table import Table
+        table = Table(title="[bold cyan]Conversation Threads[/bold cyan]", border_style="cyan")
+        table.add_column("Thread ID", style="cyan", no_wrap=True)
+        table.add_column("Last Active", style="green")
+        table.add_column("Messages", style="magenta")
+        table.add_column("Initial Query / Summary", style="white")
+
+        threads = {}
+        try:
+            for cp_tuple in checkpointer.list(None):
+                cfg = cp_tuple.config
+                tid = cfg.get("configurable", {}).get("thread_id")
+                if not tid:
+                    continue
+                
+                msgs = cp_tuple.checkpoint.get("channel_values", {}).get("messages", [])
+                ts = cp_tuple.checkpoint.get("ts")
+                
+                if tid not in threads or len(msgs) > len(threads[tid]["messages"]):
+                    threads[tid] = {
+                        "ts": ts,
+                        "messages": msgs
+                    }
+        except Exception as exc:
+            console.print(f"[bold red]Error loading thread history:[/bold red] {exc}")
+            return "", thread_id
+
+        if not threads:
+            console.print("[yellow]No conversation history found.[/yellow]")
+            return "", thread_id
+
+        # Sort threads by timestamp descending
+        def get_sort_key(item):
+            val = item[1]["ts"]
+            return str(val) if val is not None else ""
+
+        sorted_threads = sorted(threads.items(), key=get_sort_key, reverse=True)
+
+        for tid, data in sorted_threads:
+            ts_val = data["ts"]
+            ts_str = ""
+            if ts_val:
+                if hasattr(ts_val, "strftime"):
+                    ts_str = ts_val.strftime("%Y-%m-%d %H:%M:%S")
+                else:
+                    ts_str = str(ts_val).split(".")[0].replace("T", " ")
+                    
+            msgs = data["messages"]
+            num_msgs = len(msgs)
+            
+            first_human = None
+            for m in msgs:
+                if m.__class__.__name__ == "HumanMessage" or getattr(m, "type", None) == "human":
+                    first_human = m.content
+                    break
+                    
+            if first_human:
+                summary = first_human.strip()
+                if "[End of context]\n" in summary:
+                    summary = summary.split("[End of context]\n", 1)[1].strip()
+                if len(summary) > 80:
+                    summary = summary[:77] + "..."
+            else:
+                summary = "[No user queries]"
+                
+            table.add_row(tid, ts_str, f"{num_msgs} msgs", summary)
+
+        console.print(table)
+        console.print(f"\n[dim]To resume a thread, restart the chat with: [cyan]--thread-id <id>[/cyan] or [cyan]-t <id>[/cyan][/dim]")
+        return "", thread_id
 
     # ── /analyze [--max N] ─────────────────────────────────────────────────
     if name == "analyze":

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -67,6 +67,13 @@ _CONFIRMATION_RE = re.compile(
     re.I,
 )
 
+# Report-specific follow-up keywords/phrases (e.g. for deepdive, research, equity reports)
+_REPORT_FOLLOWUP_RE = re.compile(
+    r"\b(?:summarise|summarize|summary|takeaway|takeaways|risk|risks|red\s*flags?|competitor|competitors|financial|financials|valuation|multiple|multiples|sec|filing|filings|detail|details|elaborate|explain|narrative|key|outlook|highlight|highlights)\b"
+    r"|\b(?:this|it|its|the|that)\s+(?:report|analysis|company|stock|ticker|filing|filings)\b",
+    re.I,
+)
+
 
 # ── prompt_toolkit input session ──────────────────────────────────────────────
 
@@ -1734,12 +1741,15 @@ def _run_chat_loop_inner(console: Console, checkpointer: Any, thread_id: str | N
             # should stay on the previous agent.
             _is_followup = False
             if _intent == "main" and _conv_history:
+                _prev_raw, _prev_answer, _prev_intent = _conv_history[-1]
                 if _FOLLOWUP_RE.match(raw.strip()):
                     _is_followup = True
                 elif _CONFIRMATION_RE.match(raw.strip()) and len(raw.split()) <= 4:
                     _is_followup = True
+                elif _prev_intent in ("deepdive", "research", "india_equity"):
+                    if _REPORT_FOLLOWUP_RE.search(raw.strip()):
+                        _is_followup = True
                 else:
-                    _prev_raw, _prev_answer, _prev_intent = _conv_history[-1]
                     _cleaned_answer = _prev_answer.strip().rstrip("`").strip().rstrip("*").strip()
                     if _cleaned_answer.endswith("?") and len(raw.split()) <= 8:
                         _is_followup = True
@@ -1776,7 +1786,10 @@ def _run_chat_loop_inner(console: Console, checkpointer: Any, thread_id: str | N
                     "[Session context — prior turns in this conversation]"
                 ]
                 for _u, _a, _i in recent:
-                    _a_short = _a[:400] + "…" if len(_a) > 400 else _a
+                    if _i in ("deepdive", "research", "india_equity"):
+                        _a_short = _a
+                    else:
+                        _a_short = _a[:400] + "…" if len(_a) > 400 else _a
                     ctx_lines.append(f"User ({_i}): {_u}")
                     ctx_lines.append(f"Assistant: {_a_short}")
                 ctx_lines.append("[End of context]\n")

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -84,16 +84,20 @@ class MarketDataRepository:
 
     # ── FII / DII ─────────────────────────────────────────────────────────────
 
-    def fii_dii_5d(self) -> tuple[float, float]:
-        """5-day rolling FII and DII net flows in ₹ Crore."""
+    def fii_dii_5d(self) -> tuple[float, float] | None:
+        """5-day rolling FII and DII net flows in ₹ Crore.
+
+        Returns None when no rows exist in the window (missing data),
+        vs (0.0, 0.0) when rows exist but net flow is genuinely zero.
+        """
         rows = self._q(
-            "SELECT sum(fii_net_cr), sum(dii_net_cr) "
+            "SELECT sum(fii_net_cr), sum(dii_net_cr), count(*) "
             "FROM market_data.fii_dii_flows FINAL "
             "WHERE trade_date >= today() - 5"
         )
-        if rows and rows[0][0] is not None:
+        if rows and rows[0][2] and int(rows[0][2]) > 0:
             return float(rows[0][0] or 0), float(rows[0][1] or 0)
-        return 0.0, 0.0
+        return None
 
     # ── News sentiment ────────────────────────────────────────────────────────
 

--- a/src/deepdive/runner.py
+++ b/src/deepdive/runner.py
@@ -58,7 +58,83 @@ def _output_dir(ticker: str, run_date: str) -> Path:
     return Path(settings.output_dir) / "deepdive" / ticker / run_date
 
 
+def _build_llm_for_deepdive():
+    from config.settings import settings
+    provider = settings.llm_provider.lower()
+    
+    # 1. OpenRouter
+    if provider == "openrouter":
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=settings.llm_model,
+            api_key=settings.openrouter_api_key,
+            base_url="https://openrouter.ai/api/v1",
+            temperature=0,
+            max_tokens=settings.llm_token_budget,
+            timeout=settings.cloud_llm_request_timeout,
+        )
+        
+    # 2. Local/Custom OpenAI-compatible Endpoint
+    if settings.llm_base_url:
+        from langchain_openai import ChatOpenAI
+        is_nvidia = "nvidia" in settings.llm_base_url.lower()
+        if is_nvidia:
+            from src.utils.nim_pool import NIMPool
+            return NIMPool.get().acquire(
+                model=settings.llm_model,
+                extra_body={},
+                timeout=settings.llm_request_timeout,
+                max_tokens=settings.llm_token_budget,
+            )
+        extra_body = {"options": {"num_ctx": settings.llm_context_window}}
+        if settings.llm_think:
+            extra_body["think"] = True
+        return ChatOpenAI(
+            model=settings.llm_model,
+            base_url=settings.llm_base_url,
+            api_key=settings.openai_api_key or "local",
+            temperature=0,
+            max_tokens=settings.llm_token_budget,
+            extra_body=extra_body,
+            timeout=settings.llm_request_timeout,
+            streaming=False,
+        )
+        
+    # 3. Google/Gemini
+    if provider == "google":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        return ChatGoogleGenerativeAI(
+            model=settings.llm_model,
+            google_api_key=settings.google_api_key,
+            temperature=0,
+            max_output_tokens=settings.llm_token_budget,
+        )
+        
+    # 4. Anthropic
+    if provider == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(
+            model=settings.llm_model,
+            api_key=settings.anthropic_api_key,
+            temperature=0,
+            max_tokens=settings.llm_token_budget,
+            extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
+            timeout=settings.cloud_llm_request_timeout,
+        )
+        
+    # 5. OpenAI Cloud (Default)
+    from langchain_openai import ChatOpenAI
+    return ChatOpenAI(
+        model=settings.llm_model,
+        api_key=settings.openai_api_key,
+        temperature=0,
+        max_tokens=settings.llm_token_budget,
+        timeout=settings.cloud_llm_request_timeout,
+    )
+
+
 # ── Main entry point ───────────────────────────────────────────────────────────
+
 
 def run_deepdive(
     ticker: str,
@@ -515,19 +591,65 @@ def run_deepdive(
     )
 
     # ── Phase 7: Report assembly ───────────────────────────────────────────────
-    # Sections are written to sections/<key>.md by the caller (Claude CLI) after
-    # reading the Phase 6 prompt blocks from stdout and generating the content.
-    # This phase assembles whatever section files are present into report.md.
-    console.print("[bold]Phase 7:[/bold] Assembling report.md + sources.md…")
+    # If any sections are missing, we automatically generate them using the LLM.
+    console.print("[bold]Phase 7:[/bold] Checking and generating narrative sections…")
 
     from src.deepdive.report import SECTION_ORDER, assemble_report  # noqa: PLC0415
+    from src.deepdive.analyze.gemini_cli import PROMPTS_DIR, assemble_prompt  # noqa: PLC0415
 
     sections_dir = out_dir / "sections"
+    sections_dir.mkdir(parents=True, exist_ok=True)
+    prompts_dir = out_dir / "prompts"
 
     # Report which sections are present / missing before assembly
-    present = [k for k, _ in SECTION_ORDER if (sections_dir / f"{k}.md").exists()
-               and (sections_dir / f"{k}.md").stat().st_size > 100]
+    present = []
+    for k, _ in SECTION_ORDER:
+        section_file = sections_dir / f"{k}.md"
+        if section_file.exists():
+            content = section_file.read_text(encoding="utf-8").strip()
+            if len(content) > 100 and not content.startswith("<!--"):
+                present.append(k)
+
     missing = [k for k, _ in SECTION_ORDER if k not in present]
+    
+    if missing:
+        console.print(f"  [yellow]Missing   : {', '.join(missing)} — generating via LLM…[/yellow]")
+        llm = None
+        for key in missing:
+            prompt_file = prompts_dir / f"{key}_assembled.txt"
+            section_file = sections_dir / f"{key}.md"
+            
+            # Read prompt
+            if not prompt_file.exists():
+                # Re-assemble prompt if missing on disk
+                try:
+                    dataset_json = dataset_path.read_text(encoding="utf-8")
+                    full_prompt = assemble_prompt(key, dataset_json, PROMPTS_DIR)
+                    prompt_file.parent.mkdir(parents=True, exist_ok=True)
+                    prompt_file.write_text(full_prompt, encoding="utf-8")
+                except Exception as e:
+                    log.warning("Could not assemble prompt for %s: %s", key, e)
+                    continue
+            
+            if prompt_file.exists():
+                prompt_content = prompt_file.read_text(encoding="utf-8")
+                try:
+                    if llm is None:
+                        llm = _build_llm_for_deepdive()
+                    
+                    console.print(f"  Generating: [cyan]{key}[/cyan] narrative…")
+                    response = llm.invoke(prompt_content)
+                    narrative = response.content if hasattr(response, 'content') else str(response)
+                    
+                    section_file.write_text(narrative.strip(), encoding="utf-8")
+                    present.append(key)
+                except Exception as exc:
+                    log.error("Failed to generate narrative for %s: %s", key, exc)
+                    console.print(f"  [red]Failed to generate {key}: {exc}[/red]")
+                    
+        # Update missing list after generation attempt
+        missing = [k for k, _ in SECTION_ORDER if k not in present]
+
     if present:
         console.print(f"  Sections  : {len(present)} ready — {', '.join(present)}")
     if missing:

--- a/src/main.py
+++ b/src/main.py
@@ -302,6 +302,7 @@ def config() -> None:
         # [SENSITIVE] settings are masked
         ("OpenAI API Key", masked(settings.openai_api_key), "⚠ YES"),
         ("Anthropic API Key", masked(settings.anthropic_api_key), "⚠ YES"),
+        ("OpenRouter API Key", masked(settings.openrouter_api_key), "⚠ YES"),
         ("NewsAPI Key", masked(settings.newsapi_key), "⚠ YES"),
         ("Kite API Key", masked(settings.kite_api_key), "⚠ YES"),
         ("Kite API Secret", masked(settings.kite_api_secret), "⚠ YES"),

--- a/src/scripts/goldbees_report.py
+++ b/src/scripts/goldbees_report.py
@@ -45,7 +45,16 @@ def get_llm_recommendation(
         llm = None
         if not settings.llm_local_disabled:
             provider = settings.llm_provider.lower()
-            if settings.llm_base_url:
+            if provider == "openrouter":
+                from langchain_openai import ChatOpenAI
+                llm = ChatOpenAI(
+                    model=settings.llm_model,
+                    base_url="https://openrouter.ai/api/v1",
+                    api_key=settings.openrouter_api_key,
+                    temperature=0.2,
+                    max_tokens=256,
+                )
+            elif settings.llm_base_url:
                 from langchain_openai import ChatOpenAI
                 llm = ChatOpenAI(
                     model=settings.llm_model,
@@ -82,6 +91,15 @@ def get_llm_recommendation(
                     temperature=0.2,
                     max_tokens=256,
                     extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
+                )
+            elif provider == "openrouter":
+                from langchain_openai import ChatOpenAI
+                llm = ChatOpenAI(
+                    model=settings.llm_cloud_model,
+                    api_key=settings.openrouter_api_key,
+                    base_url="https://openrouter.ai/api/v1",
+                    temperature=0.2,
+                    max_tokens=256,
                 )
             else:
                 from langchain_openai import ChatOpenAI

--- a/src/scripts/market/analyze_news_trend.py
+++ b/src/scripts/market/analyze_news_trend.py
@@ -23,6 +23,13 @@ console = Console()
 
 def get_llm():
     """Simple LLM factory based on project settings."""
+    if settings.llm_provider.lower() == "openrouter":
+        return ChatOpenAI(
+            model=settings.llm_model,
+            base_url="https://openrouter.ai/api/v1",
+            api_key=settings.openrouter_api_key,
+            temperature=0.2,
+        )
     if settings.llm_base_url:
         return ChatOpenAI(
             model=settings.llm_model,

--- a/src/scripts/portfolio/system_telemetry.py
+++ b/src/scripts/portfolio/system_telemetry.py
@@ -448,7 +448,16 @@ def run_test_prompt(prompt: str):
     
     start_time = time.time()
     try:
-        if settings.llm_base_url:
+        if provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            llm = ChatOpenAI(
+                model=settings.llm_model,
+                base_url="https://openrouter.ai/api/v1",
+                api_key=settings.openrouter_api_key,
+                temperature=0,
+                max_tokens=settings.llm_token_budget,
+            )
+        elif settings.llm_base_url:
             from langchain_openai import ChatOpenAI
             llm = ChatOpenAI(
                 model=settings.llm_model,

--- a/src/tools/company_resolver.py
+++ b/src/tools/company_resolver.py
@@ -112,7 +112,8 @@ def _get_resolver_llm() -> "Any":
     try:
         from config.settings import settings
         kwargs = dict(temperature=0, max_tokens=20)
-        if settings.llm_base_url and not settings.llm_local_disabled:
+        provider = (settings.llm_cloud_provider if settings.llm_local_disabled else settings.llm_provider).strip().lower()
+        if settings.llm_base_url and not settings.llm_local_disabled and provider != "openrouter":
             from langchain_openai import ChatOpenAI
             _resolver_llm = ChatOpenAI(
                 model=settings.llm_model,
@@ -121,7 +122,6 @@ def _get_resolver_llm() -> "Any":
                 **kwargs,
             )
         else:
-            provider = (settings.llm_cloud_provider if settings.llm_local_disabled else settings.llm_provider).strip().lower()
             model = settings.llm_cloud_model if settings.llm_local_disabled else settings.llm_model
             if provider == "anthropic":
                 from langchain_anthropic import ChatAnthropic
@@ -129,6 +129,14 @@ def _get_resolver_llm() -> "Any":
                     model=model,
                     api_key=settings.anthropic_api_key,
                     extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
+                    **kwargs,
+                )
+            elif provider == "openrouter":
+                from langchain_openai import ChatOpenAI
+                _resolver_llm = ChatOpenAI(
+                    model=model,
+                    api_key=settings.openrouter_api_key,
+                    base_url="https://openrouter.ai/api/v1",
                     **kwargs,
                 )
             elif provider == "google":

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -667,6 +667,44 @@ def run_deepdive_analysis(ticker: str, section: str | None = None, skip_fetch: b
     return f"Deep-dive analysis executed.\n\nCommand Log:\n{cmd_output}{preview}"
 
 
+@tool
+def read_deepdive_report(ticker: str) -> str:
+    """
+    Read the latest compiled US equity deep-dive report for a given ticker.
+    Use this to read, summarize, or answer follow-up questions about a company's deep-dive report.
+    Args:
+        ticker: The US ticker symbol (e.g. 'ADSK', 'AAPL').
+    """
+    from datetime import date
+    from pathlib import Path
+    
+    ticker_clean = ticker.strip().upper()
+    base_dir = Path(PROJECT_ROOT) / "output" / "deepdive" / ticker_clean
+    if not base_dir.exists():
+        return f"No deep-dive reports found for ticker: {ticker_clean}"
+    
+    today_str = date.today().isoformat()
+    report_path = base_dir / today_str / "report.md"
+    
+    if not report_path.exists():
+        # Find latest date directory
+        if not os.path.exists(base_dir):
+            return f"No deep-dive reports found for ticker: {ticker_clean}"
+        dates = sorted([d for d in os.listdir(base_dir) if os.path.isdir(base_dir / d)], reverse=True)
+        if not dates:
+            return f"No deep-dive reports found for ticker: {ticker_clean}"
+        report_path = base_dir / dates[0] / "report.md"
+        
+    if not report_path.exists():
+        return f"Report file not found for ticker {ticker_clean} (expected at {report_path})"
+        
+    try:
+        content = report_path.read_text(encoding="utf-8")
+        return content
+    except Exception as exc:
+        return f"Error reading report for {ticker_clean}: {exc}"
+
+
 # ── Canonical tool list ────────────────────────────────────────────────────────
 # Single source of truth — all other lists are subsets of this.
 SKILLS_TOOLS = [
@@ -693,4 +731,5 @@ SKILLS_TOOLS = [
     query_clickhouse_db,
     run_premium_alerts,
     run_deepdive_analysis,
+    read_deepdive_report,
 ]

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -482,6 +482,81 @@ def run_premium_alerts(
     return _run_cmd(args)
 
 
+def _build_llm_for_deepdive():
+    from config.settings import settings
+    provider = settings.llm_provider.lower()
+    
+    # 1. OpenRouter
+    if provider == "openrouter":
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=settings.llm_model,
+            api_key=settings.openrouter_api_key,
+            base_url="https://openrouter.ai/api/v1",
+            temperature=0,
+            max_tokens=settings.llm_token_budget,
+            timeout=settings.cloud_llm_request_timeout,
+        )
+        
+    # 2. Local/Custom OpenAI-compatible Endpoint
+    if settings.llm_base_url:
+        from langchain_openai import ChatOpenAI
+        is_nvidia = "nvidia" in settings.llm_base_url.lower()
+        if is_nvidia:
+            from src.utils.nim_pool import NIMPool
+            return NIMPool.get().acquire(
+                model=settings.llm_model,
+                extra_body={},
+                timeout=settings.llm_request_timeout,
+                max_tokens=settings.llm_token_budget,
+            )
+        extra_body = {"options": {"num_ctx": settings.llm_context_window}}
+        if settings.llm_think:
+            extra_body["think"] = True
+        return ChatOpenAI(
+            model=settings.llm_model,
+            base_url=settings.llm_base_url,
+            api_key=settings.openai_api_key or "local",
+            temperature=0,
+            max_tokens=settings.llm_token_budget,
+            extra_body=extra_body,
+            timeout=settings.llm_request_timeout,
+            streaming=False,
+        )
+        
+    # 3. Google/Gemini
+    if provider == "google":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+        return ChatGoogleGenerativeAI(
+            model=settings.llm_model,
+            google_api_key=settings.google_api_key,
+            temperature=0,
+            max_output_tokens=settings.llm_token_budget,
+        )
+        
+    # 4. Anthropic
+    if provider == "anthropic":
+        from langchain_anthropic import ChatAnthropic
+        return ChatAnthropic(
+            model=settings.llm_model,
+            api_key=settings.anthropic_api_key,
+            temperature=0,
+            max_tokens=settings.llm_token_budget,
+            extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
+            timeout=settings.cloud_llm_request_timeout,
+        )
+        
+    # 5. OpenAI Cloud (Default)
+    from langchain_openai import ChatOpenAI
+    return ChatOpenAI(
+        model=settings.llm_model,
+        api_key=settings.openai_api_key,
+        temperature=0,
+        max_tokens=settings.llm_token_budget,
+        timeout=settings.cloud_llm_request_timeout,
+    )
+
+
 @tool
 def run_deepdive_analysis(ticker: str, section: str | None = None, skip_fetch: bool = False) -> str:
     """
@@ -495,6 +570,10 @@ def run_deepdive_analysis(ticker: str, section: str | None = None, skip_fetch: b
                  core_business, financials, competitors, investments, execution, valuation, talent.
         skip_fetch: If True, uses cached data only and skips live network calls.
     """
+    from datetime import date
+    from pathlib import Path
+    from config.settings import settings
+    
     ticker_clean = ticker.strip().upper()
     args = ["src/main.py", "deepdive", ticker_clean]
     if section:
@@ -504,11 +583,62 @@ def run_deepdive_analysis(ticker: str, section: str | None = None, skip_fetch: b
         
     cmd_output = _run_cmd(args)
     
-    # Try to locate the generated report.md file
-    from datetime import date
+    # Locate output directories
     today_str = date.today().isoformat()
-    report_path = os.path.join(PROJECT_ROOT, "output", "deepdive", ticker_clean, today_str, "report.md")
+    out_dir = Path(PROJECT_ROOT) / "output" / "deepdive" / ticker_clean / today_str
+    prompts_dir = out_dir / "prompts"
+    sections_dir = out_dir / "sections"
     
+    # We must support generating missing narrative sections
+    from src.deepdive.analyze.gemini_cli import SECTION_KEYS
+    targets = [section] if section and section in SECTION_KEYS else SECTION_KEYS
+    
+    sections_dir.mkdir(parents=True, exist_ok=True)
+    
+    llm = None
+    generated_any = False
+    
+    for key in targets:
+        prompt_file = prompts_dir / f"{key}_assembled.txt"
+        section_file = sections_dir / f"{key}.md"
+        
+        # If the prompt exists and the section hasn't been generated yet (or is empty placeholder)
+        if prompt_file.exists():
+            # Check if we need to generate it
+            needs_generation = True
+            if section_file.exists():
+                content = section_file.read_text(encoding="utf-8").strip()
+                # If it's a template error placeholder or empty, regenerate
+                if len(content) > 100 and not content.startswith("<!--"):
+                    needs_generation = False
+            
+            if needs_generation:
+                logger.info(f"Generating narrative for deep-dive section '{key}' using configured LLM...")
+                prompt_content = prompt_file.read_text(encoding="utf-8")
+                
+                try:
+                    if llm is None:
+                        llm = _build_llm_for_deepdive()
+                    
+                    response = llm.invoke(prompt_content)
+                    narrative = response.content if hasattr(response, 'content') else str(response)
+                    
+                    section_file.write_text(narrative.strip(), encoding="utf-8")
+                    generated_any = True
+                except Exception as exc:
+                    logger.error(f"Failed to generate deep-dive section '{key}' narrative: {exc}")
+                    
+    # If we generated any sections, re-run Phase 7 assembly (using --skip-fetch to use cache)
+    if generated_any:
+        logger.info(f"Re-running deep-dive assembly to compile final report.md for {ticker_clean}...")
+        assembly_args = ["src/main.py", "deepdive", ticker_clean, "--skip-fetch"]
+        if section:
+            assembly_args.extend(["--section", section])
+        assembly_output = _run_cmd(assembly_args)
+        cmd_output += f"\n\nAssembly Log:\n{assembly_output}"
+        
+    # Preview output
+    report_path = os.path.join(PROJECT_ROOT, "output", "deepdive", ticker_clean, today_str, "report.md")
     if os.path.exists(report_path):
         try:
             with open(report_path, "r", encoding="utf-8") as f:

--- a/src/tools/summarization.py
+++ b/src/tools/summarization.py
@@ -45,6 +45,16 @@ def _get_llm() -> Any:
     """
     from langchain_openai import ChatOpenAI
 
+    # ── OpenRouter cloud ──────────────────────────────────────────────────────
+    if settings.llm_provider.lower() == "openrouter":
+        return ChatOpenAI(
+            model=settings.llm_model,
+            base_url="https://openrouter.ai/api/v1",
+            api_key=settings.openrouter_api_key,
+            temperature=0.2,
+            max_tokens=settings.llm_token_budget,
+        )
+
     # ── Local / custom OpenAI-compatible endpoint ─────────────────────────────
     if settings.llm_base_url:
         return ChatOpenAI(

--- a/tests/test_chat_followup.py
+++ b/tests/test_chat_followup.py
@@ -6,7 +6,7 @@ Unit tests for the follow-up routing logic in chat_cmd.py.
 import unittest
 import re
 
-from src.commands.chat_cmd import _FOLLOWUP_RE, _CONFIRMATION_RE, _is_numeric_choice_prompt
+from src.commands.chat_cmd import _FOLLOWUP_RE, _CONFIRMATION_RE, _is_numeric_choice_prompt, _REPORT_FOLLOWUP_RE
 
 class TestChatFollowupRouting(unittest.TestCase):
     def test_followup_regex(self):
@@ -21,6 +21,19 @@ class TestChatFollowupRouting(unittest.TestCase):
         self.assertFalse(_FOLLOWUP_RE.match("yes"))
         self.assertFalse(_FOLLOWUP_RE.match("no"))
         self.assertFalse(_FOLLOWUP_RE.match("show composite signals"))
+
+    def test_report_followup_regex(self):
+        """Test that _REPORT_FOLLOWUP_RE correctly matches report-specific queries."""
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("summarise the report"))
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("summarize it"))
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("explain the risks"))
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("any red flags?"))
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("what is the valuation?"))
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("tell me about the competitors"))
+        self.assertTrue(_REPORT_FOLLOWUP_RE.search("details on the company"))
+        
+        self.assertFalse(_REPORT_FOLLOWUP_RE.search("compare goldbees and nifty"))
+        self.assertFalse(_REPORT_FOLLOWUP_RE.search("get stock news for tata"))
 
     def test_confirmation_regex(self):
         """Test that _CONFIRMATION_RE correctly matches confirmation/negation words."""

--- a/tests/test_chat_persistence.py
+++ b/tests/test_chat_persistence.py
@@ -57,5 +57,40 @@ class TestChatPersistence(unittest.TestCase):
             self.assertEqual(result.exit_code, 0)
             mock_run_chat_loop.assert_called_with(None, thread_id="resume-id-short")
 
+    def test_dispatch_list_threads(self):
+        from src.commands.chat_cmd import _dispatch_slash
+        
+        # Mock agent and checkpointer
+        mock_agent = MagicMock()
+        mock_checkpointer = MagicMock()
+        mock_agent._checkpointer = mock_checkpointer
+        
+        # Mock checkpoints returned by checkpointer.list(None)
+        from langchain_core.messages import HumanMessage
+        mock_tuple = MagicMock()
+        mock_tuple.config = {"configurable": {"thread_id": "thread-1"}}
+        mock_tuple.checkpoint = {
+            "ts": "2026-06-17T11:42:55",
+            "channel_values": {
+                "messages": [HumanMessage(content="test query")]
+            }
+        }
+        mock_checkpointer.list.return_value = [mock_tuple]
+        
+        mock_console = MagicMock()
+        
+        # Dispatch the slash command /list thread
+        ans, tid = _dispatch_slash("/list thread", mock_console, mock_agent, "thread-1")
+        
+        # Verify response
+        self.assertEqual(ans, "")
+        self.assertEqual(tid, "thread-1")
+        
+        # Verify checkpointer.list was called
+        mock_checkpointer.list.assert_called_once_with(None)
+        
+        # Verify console.print was called to render the table
+        mock_console.print.assert_called()
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Changes

### Anomaly Regime → Numeric Score
Regime labels from GARCH+IF+PELT pipeline now map to 0-100 scores and participate in the weighted composite:
| Regime | Score |
|--------|-------|
| Strong Trend (HODL) | 70 |
| Normal | 50 |
| Volatile Breakout | 40 |
| Regime Shift | 35 |
| Blow-off Top | 30 |
| Flash Crash | 25 |
| Panic | 20 |

### Weight Rebalancing
| Factor | Old | New | Rationale |
|--------|-----|-----|-----------|
| Macro | 25% | 20% | Slight reduction |
| Sentiment | 15% | 15% | Unchanged |
| Valuation | 15% | **25%** | Biggest cross-ETF differentiator |
| Flow | 25% | **10%** | Single scalar, zero ranking power when flat |
| ML | 15% | **20%** | Reward forecasted returns |
| Anomaly | 5% | **10%** | Regime awareness for sizing |

Removes the `flow_extra=0.10` hack — weights sum cleanly to 1.00.

### Auditable Score Breakdown
New `Score Breakdown (Top 5)` panel shows per-pillar weighted contributions:
```
GOLDBEES = 72
  Macro=100 ×0.20=+20.0 | Sent.=42 ×0.15=+6.4 | Val.=95 ×0.25=+23.6
  Flow=50 ×0.10=+5.0 | ML=52 ×0.20=+10.3 | Anom.=70 ×0.10=+7.0
```

### Flow Fixes
- **GOLDBEES/SILVERBEES** moved to commodity bucket (neutral Flow=50) — FII/DII equity flows don't drive commodity-backed ETFs
- **fii_dii_5d()** returns `None` when no data exists vs `(0,0)` for genuinely flat flows
- Explicit ⚠ warning logged when FII/DII data is missing