### PR TITLE
fix(llm): prioritise local Ollama over OpenRouter when base_url is localhost

### DIFF
--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -166,13 +166,29 @@ def _get_router_llm() -> Any | None:
         except Exception as exc:
             logger.debug("Router LLM (NVIDIA NIM) build failed: %s", exc)
 
-    # 3. Otherwise fall back to local/default API key providers
-    # Prefer a small fast model for routing — gpt-4o-mini costs ~$0.0001 per call
-    if settings.llm_provider.lower() == "openrouter" and _real_key(settings.openrouter_api_key):
+    # 3. Local Ollama / LM Studio — use when base_url points to localhost
+    if settings.llm_base_url and any(h in settings.llm_base_url for h in ("localhost", "127.0.0.1")):
         try:
             from langchain_openai import ChatOpenAI
             return ChatOpenAI(
                 model=settings.llm_model,
+                base_url=settings.llm_base_url,
+                api_key=settings.openai_api_key or "ollama",
+                temperature=0,
+                max_tokens=50,
+                request_timeout=120,
+                timeout=120,
+            )
+        except Exception as exc:
+            logger.debug("Router LLM (Local/Ollama) build failed: %s", exc)
+
+    # 4. OpenRouter cloud — use a cheap routing model, NOT settings.llm_model
+    #    (which may be a local Ollama name like 'mosaic-gemma4')
+    if settings.llm_provider.lower() == "openrouter" and _real_key(settings.openrouter_api_key):
+        try:
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model="google/gemma-3-12b-it:free",
                 api_key=settings.openrouter_api_key,
                 base_url="https://openrouter.ai/api/v1",
                 temperature=0,

--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -350,19 +350,9 @@ class MosaicFundAgent:
 
         provider = settings.llm_provider.lower()
 
-        # ── OpenRouter cloud ───────────────────────────────────────────────────
-        if provider == "openrouter":
-            from langchain_openai import ChatOpenAI
-            return ChatOpenAI(
-                model=settings.llm_model,
-                api_key=settings.openrouter_api_key,
-                base_url="https://openrouter.ai/api/v1",
-                temperature=0,
-                max_tokens=settings.llm_token_budget,
-                timeout=settings.cloud_llm_request_timeout,
-            )
-
         # ── Local / custom OpenAI-compatible endpoint (Ollama, LM Studio, etc.) ──
+        # Checked BEFORE cloud providers so that a localhost base_url takes
+        # priority even when llm_provider is set to "openrouter" or "openai".
         if settings.llm_base_url:
             from langchain_openai import ChatOpenAI
             logger.info(
@@ -404,6 +394,18 @@ class MosaicFundAgent:
                 extra_body=extra_body,
                 timeout=settings.llm_request_timeout,
                 streaming=False,
+            )
+
+        # ── OpenRouter cloud ───────────────────────────────────────────────────
+        if provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=settings.llm_model,
+                api_key=settings.openrouter_api_key,
+                base_url="https://openrouter.ai/api/v1",
+                temperature=0,
+                max_tokens=settings.llm_token_budget,
+                timeout=settings.cloud_llm_request_timeout,
             )
 
         # ── Anthropic cloud ────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes `mosaic-gemma4 is not a valid model ID` error on OpenRouter.

**Root cause:** When `LLM_PROVIDER=openrouter` + `LLM_BASE_URL=http://127.0.0.1:11434/v1` (Ollama) + `LLM_MODEL=mosaic-gemma4`, both the main agent and intent router hit the OpenRouter cloud path first, sending a local Ollama model name to the OpenRouter API.

**Fix:** Check for a localhost `llm_base_url` BEFORE the OpenRouter cloud path in both:
- `_build_llm()` in mosaic_fund_agent.py
- `_get_router_llm()` in intent_router.py

Additionally, the intent router's OpenRouter fallback now uses a hardcoded free model (`google/gemma-3-12b-it:free`) instead of `settings.llm_model` to prevent sending local model names to cloud APIs if Ollama is down.