### PR TITLE
feat: add news-RAG correlation engine, pre-LLM news filter, and shared utilities

### DIFF
--- a/config/clickhouse/migrations/001_add_news_embedding.py
+++ b/config/clickhouse/migrations/001_add_news_embedding.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+config/clickhouse/migrations/001_add_news_embedding.py
+──────────────────────────────────────────────────────
+Adds an `embedding` column (Array(Float32)) to market_data.news_articles
+for semantic RAG retrieval in the correlation engine.
+
+Run once:
+    python config/clickhouse/migrations/001_add_news_embedding.py
+"""
+from src.db.pool import execute, query_df
+
+def migrate():
+    # Check if column already exists
+    df = query_df(
+        "SELECT name FROM system.columns "
+        "WHERE database = 'market_data' AND table = 'news_articles' AND name = 'embedding'"
+    )
+    if not df.empty:
+        print("✅ Column 'embedding' already exists in market_data.news_articles")
+        return
+
+    execute(
+        "ALTER TABLE market_data.news_articles "
+        "ADD COLUMN IF NOT EXISTS embedding Array(Float32) DEFAULT []"
+    )
+    print("✅ Added 'embedding' column to market_data.news_articles")
+
+
+if __name__ == "__main__":
+    migrate()

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -1,0 +1,186 @@
+"""
+src/db/queries.py
+──────────────────
+Typed, parameterized ClickHouse query accessors (Repository Pattern).
+
+All functions use ``src.db.pool.query_df`` internally with ``FINAL`` (to
+deduplicate ReplacingMergeTree rows) and parameterized arguments (to prevent
+SQL injection).
+
+Previously, equivalent inline SQL blocks were duplicated across:
+  • src/tools/market/correlation_tools.py  (3 inline queries)
+  • src/tools/indian_equity_tools.py
+  • src/tools/premium_alerts.py
+  • src/tools/garch_position_sizer.py
+  • src/tools/quant_scorecard.py
+
+Usage
+-----
+    from src.db.queries import fetch_ohlcv, fetch_benchmark, fetch_fx_rates
+
+    df = fetch_ohlcv("GOLDBEES", days=365)
+    bench = fetch_benchmark("NIFTYBEES", days=365)
+    fx = fetch_fx_rates("USDINR", days=365)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Optional
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+
+def _cutoff_date(days: int) -> str:
+    """Return the ISO-8601 date string for *days* before today."""
+    return (date.today() - timedelta(days=days)).isoformat()
+
+
+def fetch_ohlcv(
+    symbol: str,
+    days: int = 365,
+) -> pd.DataFrame:
+    """
+    Fetch full OHLCV history for *symbol* from ``market_data.daily_prices``.
+
+    Args:
+        symbol: NSE/BSE ticker (e.g. ``"GOLDBEES"``, ``"RELIANCE"``).
+        days:   Lookback window in calendar days (default 365).
+
+    Returns:
+        DataFrame with columns ``[trade_date, open, high, low, close, volume]``,
+        sorted ascending by ``trade_date``.  Empty DataFrame on error.
+    """
+    from src.db.pool import query_df
+
+    try:
+        df = query_df(
+            """
+            SELECT trade_date,
+                   toFloat64(argMax(open,   imported_at)) AS open,
+                   toFloat64(argMax(high,   imported_at)) AS high,
+                   toFloat64(argMax(low,    imported_at)) AS low,
+                   toFloat64(argMax(close,  imported_at)) AS close,
+                   toFloat64(argMax(volume, imported_at)) AS volume
+            FROM market_data.daily_prices FINAL
+            WHERE symbol = {sym:String}
+              AND trade_date >= {cutoff:String}
+            GROUP BY trade_date
+            ORDER BY trade_date ASC
+            """,
+            parameters={"sym": symbol.strip().upper(), "cutoff": _cutoff_date(days)},
+        )
+        if not df.empty:
+            df["trade_date"] = pd.to_datetime(df["trade_date"])
+        return df
+    except Exception as exc:
+        logger.warning("fetch_ohlcv(%s, days=%d): %s", symbol, days, exc)
+        return pd.DataFrame()
+
+
+def fetch_close(
+    symbol: str,
+    days: int = 365,
+    table: str = "daily_prices",
+) -> pd.DataFrame:
+    """
+    Fetch close-price history for *symbol*.
+
+    Supports both ``daily_prices`` (equities/ETFs) and ``fx_rates`` (FX pairs).
+
+    Args:
+        symbol: Ticker or currency pair (e.g. ``"NIFTYBEES"``, ``"USDINR"``).
+        days:   Lookback window in calendar days.
+        table:  ClickHouse table name (``"daily_prices"`` or ``"fx_rates"``).
+
+    Returns:
+        DataFrame with columns ``[trade_date, close]``, ascending.
+    """
+    from src.db.pool import query_df
+
+    valid_tables = {"daily_prices", "fx_rates", "mf_nav"}
+    if table not in valid_tables:
+        logger.error("fetch_close: unknown table %r (allowed: %s)", table, valid_tables)
+        return pd.DataFrame()
+
+    try:
+        df = query_df(
+            f"""
+            SELECT trade_date,
+                   toFloat64(argMax(close, imported_at)) AS close
+            FROM market_data.{table} FINAL
+            WHERE symbol = {{sym:String}}
+              AND trade_date >= {{cutoff:String}}
+            GROUP BY trade_date
+            ORDER BY trade_date ASC
+            """,
+            parameters={"sym": symbol.strip().upper(), "cutoff": _cutoff_date(days)},
+        )
+        if not df.empty:
+            df["trade_date"] = pd.to_datetime(df["trade_date"])
+        return df
+    except Exception as exc:
+        logger.warning("fetch_close(%s, table=%s, days=%d): %s", symbol, table, days, exc)
+        return pd.DataFrame()
+
+
+def fetch_benchmark(symbol: str = "NIFTYBEES", days: int = 365) -> pd.DataFrame:
+    """
+    Convenience wrapper: fetch close-price history for a benchmark ETF.
+
+    Args:
+        symbol: Benchmark ticker (default ``"NIFTYBEES"``).
+        days:   Lookback window.
+
+    Returns:
+        DataFrame with columns ``[trade_date, close]``.
+    """
+    return fetch_close(symbol, days=days, table="daily_prices")
+
+
+def fetch_fx_rates(pair: str = "USDINR", days: int = 365) -> pd.DataFrame:
+    """
+    Convenience wrapper: fetch close-rate history for an FX pair.
+
+    Args:
+        pair: Currency pair (e.g. ``"USDINR"``, ``"EURUSD"``).
+        days: Lookback window.
+
+    Returns:
+        DataFrame with columns ``[trade_date, close]``.
+    """
+    return fetch_close(pair, days=days, table="fx_rates")
+
+
+def fetch_latest_signal(symbol: str) -> Optional[dict]:
+    """
+    Fetch the most recent composite signal row for *symbol*.
+
+    Args:
+        symbol: NSE/BSE ticker.
+
+    Returns:
+        Dict of the latest ``signal_composite`` row, or ``None`` if not found.
+    """
+    from src.db.pool import query_df
+
+    try:
+        df = query_df(
+            """
+            SELECT *
+            FROM market_data.signal_composite FINAL
+            WHERE symbol = {sym:String}
+            ORDER BY trade_date DESC
+            LIMIT 1
+            """,
+            parameters={"sym": symbol.strip().upper()},
+        )
+        if df.empty:
+            return None
+        return df.iloc[0].to_dict()
+    except Exception as exc:
+        logger.warning("fetch_latest_signal(%s): %s", symbol, exc)
+        return None

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -1,0 +1,146 @@
+"""
+src/llm/client.py
+──────────────────
+Singleton LLM factory for the Mosaic platform.
+
+Provides ``get_llm(context)`` which returns a LangChain LLM instance wired
+to the provider/endpoint configured in ``config/settings.py``.
+
+Provider resolution order
+─────────────────────────
+1. ``LLM_BASE_URL`` set → local OpenAI-compatible server (Ollama, LM Studio, …)
+2. ``LLM_PROVIDER=openrouter`` → OpenRouter cloud
+3. ``LLM_PROVIDER=anthropic``  → Anthropic cloud
+4. ``LLM_PROVIDER=google``     → Google Generative AI
+5. Default                     → OpenAI cloud
+
+Context modes
+─────────────
+* ``"default"``   — full ``LLM_TOKEN_BUDGET`` + temperature 0.2  (general use)
+* ``"resolver"``  — minimal ``max_tokens=20`` + temperature 0  (symbol lookup)
+
+Both modes follow the same provider chain; the *context* only affects
+``max_tokens`` and ``temperature``.
+
+Previously duplicated as:
+  • ``_get_llm()``          in ``src/tools/summarization.py``
+  • ``_get_resolver_llm()`` in ``src/tools/company_resolver.py``
+
+[SENSITIVE] All API keys are loaded via ``config/settings.py`` from ``.env``.
+            Never hard-code keys here.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+logger = logging.getLogger(__name__)
+
+# Module-level singleton cache: context → LLM instance.
+# Populated lazily on first call per context; never evicted.
+_INSTANCES: dict[str, Any] = {}
+
+Context = Literal["default", "resolver"]
+
+
+def get_llm(context: Context = "default") -> Any:
+    """
+    Return a cached LangChain LLM instance for *context*.
+
+    Args:
+        context: ``"default"`` for general-purpose chat (temperature 0.2,
+                 full token budget) or ``"resolver"`` for single-token symbol
+                 lookups (temperature 0, ``max_tokens=20``).
+
+    Returns:
+        A LangChain ``BaseChatModel`` instance, or ``None`` if no provider
+        could be initialised (errors are logged as warnings).
+
+    [SENSITIVE] API keys loaded from config/settings.py → .env
+    """
+    if context in _INSTANCES:
+        return _INSTANCES[context]
+
+    result = _build_llm(context)
+    _INSTANCES[context] = result
+    return result
+
+
+def _build_llm(context: Context) -> Any:
+    """Build a fresh LLM instance for *context* (no caching)."""
+    try:
+        from config.settings import settings
+
+        is_resolver = context == "resolver"
+        temperature = 0 if is_resolver else 0.2
+        max_tokens = 20 if is_resolver else settings.llm_token_budget
+
+        # Determine active provider, respecting llm_local_disabled for resolver
+        if is_resolver:
+            provider = (
+                settings.llm_cloud_provider
+                if settings.llm_local_disabled
+                else settings.llm_provider
+            ).strip().lower()
+            use_local = settings.llm_base_url and not settings.llm_local_disabled and provider != "openrouter"
+            model = settings.llm_cloud_model if settings.llm_local_disabled else settings.llm_model
+        else:
+            provider = settings.llm_provider.strip().lower()
+            use_local = bool(settings.llm_base_url)
+            model = settings.llm_model
+
+        kwargs: dict[str, Any] = {"temperature": temperature, "max_tokens": max_tokens}
+
+        # ── Local / custom OpenAI-compatible endpoint ─────────────────────────
+        if use_local:
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=model,
+                base_url=settings.llm_base_url,
+                api_key=settings.openai_api_key or "local",
+                **kwargs,
+            )
+
+        # ── OpenRouter cloud ──────────────────────────────────────────────────
+        if provider == "openrouter":
+            from langchain_openai import ChatOpenAI
+            return ChatOpenAI(
+                model=model,
+                base_url="https://openrouter.ai/api/v1",
+                api_key=settings.openrouter_api_key,
+                **kwargs,
+            )
+
+        # ── Anthropic cloud ───────────────────────────────────────────────────
+        if provider == "anthropic":
+            from langchain_anthropic import ChatAnthropic
+            return ChatAnthropic(
+                model=model,
+                api_key=settings.anthropic_api_key,
+                extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
+                **kwargs,
+            )
+
+        # ── Google Generative AI ──────────────────────────────────────────────
+        if provider == "google":
+            from langchain_google_genai import ChatGoogleGenerativeAI
+            # Google uses max_output_tokens, not max_tokens
+            google_kwargs = {"temperature": temperature, "max_output_tokens": max_tokens}
+            return ChatGoogleGenerativeAI(
+                model=model,
+                google_api_key=settings.google_api_key,
+                **google_kwargs,
+            )
+
+        # ── OpenAI cloud (default) ────────────────────────────────────────────
+        from langchain_openai import ChatOpenAI
+        return ChatOpenAI(
+            model=model,
+            api_key=settings.openai_api_key,
+            **kwargs,
+        )
+
+    except Exception as exc:
+        logger.warning("get_llm(context=%r): could not build LLM — %s", context, exc)
+        return None

--- a/src/ml/correlation/__init__.py
+++ b/src/ml/correlation/__init__.py
@@ -1,0 +1,36 @@
+"""
+src/ml/correlation/__init__.py
+───────────────────────────────
+Correlation engine package — maps price/volume anomalies to corporate actions,
+macro events, and news using pluggable strategies.
+
+All public symbols are re-exported here for backward compatibility:
+    from src.ml.correlation import CorrelationService, EventType, ...
+"""
+
+from .models import CandidateEvent, CorrelationFinding, EventType
+from .strategies import (
+    CorrelationStrategy,
+    CrossAssetCoMovementStrategy,
+    PostMacroShockStrategy,
+    PreEventLeakStrategy,  # deprecated — kept for backward compat imports only
+)
+from .service import CorrelationService
+from .event_registry import EventRegistry
+from .filters import FindingsPipeline, apply_quality_weights, deduplicate_by_date, cluster_episodes
+
+__all__ = [
+    "CandidateEvent",
+    "CorrelationFinding",
+    "CorrelationService",
+    "CorrelationStrategy",
+    "CrossAssetCoMovementStrategy",
+    "EventRegistry",
+    "EventType",
+    "FindingsPipeline",
+    "PostMacroShockStrategy",
+    "PreEventLeakStrategy",  # deprecated
+    "apply_quality_weights",
+    "cluster_episodes",
+    "deduplicate_by_date",
+]

--- a/src/ml/correlation/event_registry.py
+++ b/src/ml/correlation/event_registry.py
@@ -1,0 +1,293 @@
+"""
+src/ml/correlation/event_registry.py
+─────────────────────────────────────
+Loads candidate events from all sources: corporate actions, hardcoded macro
+milestones, dynamic FX shocks, and news (RAG + live GNews fallback).
+
+Each event source is a method — add new sources by subclassing or by adding
+methods and calling them from `load_all()`.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime
+from typing import List, Optional
+
+import pandas as pd
+
+from .models import CandidateEvent, EventType
+
+log = logging.getLogger(__name__)
+
+
+class EventRegistry:
+    """Aggregates candidate events from multiple data sources."""
+
+    def load_all(
+        self,
+        symbol: str,
+        df_corp: Optional[pd.DataFrame],
+        lookback_days: int = 365,
+    ) -> List[CandidateEvent]:
+        """Load events from all registered sources."""
+        events: List[CandidateEvent] = []
+        events.extend(self._from_corporate_actions(df_corp))
+        events.extend(self._from_macro_milestones())
+        events.extend(self._from_fx_shocks())
+        events.extend(self._from_news(symbol, lookback_days))
+        return events
+
+    # ── Corporate Actions ─────────────────────────────────────────────────────
+
+    @staticmethod
+    def load_corp_actions(symbol: str) -> Optional[pd.DataFrame]:
+        """Fetch corporate actions DataFrame from ClickHouse."""
+        try:
+            from src.db.pool import query_df
+            _ca = query_df(
+                "SELECT ex_date, action_type, ratio, purpose "
+                "FROM market_data.corporate_actions FINAL "
+                "WHERE symbol = {sym:String}",
+                parameters={"sym": symbol.upper()},
+            )
+            if not _ca.empty:
+                _ca["ex_date"] = pd.to_datetime(_ca["ex_date"])
+                return _ca
+        except Exception as e:
+            log.warning("Failed to load corporate actions for %s: %s", symbol, e)
+        return None
+
+    @staticmethod
+    def _from_corporate_actions(df_corp: Optional[pd.DataFrame]) -> List[CandidateEvent]:
+        """Convert corporate actions DataFrame to CandidateEvents."""
+        events: List[CandidateEvent] = []
+        if df_corp is None or df_corp.empty:
+            return events
+
+        for _, row in df_corp.iterrows():
+            ex_date = pd.to_datetime(row["ex_date"]).date()
+            action_type = str(row["action_type"])
+            ratio = str(row["ratio"])
+            purpose = str(row["purpose"])
+
+            events.append(
+                CandidateEvent(
+                    trade_date=ex_date,
+                    event_type=EventType.COMPANY_FILING,
+                    label=f"{action_type.upper()} ({ratio})" if ratio else action_type.upper(),
+                    description=purpose,
+                    metadata={"action_type": action_type, "ratio": ratio},
+                )
+            )
+        return events
+
+    # ── Hardcoded Macro Milestones ────────────────────────────────────────────
+
+    @staticmethod
+    def _from_macro_milestones() -> List[CandidateEvent]:
+        """Major rate decisions, geopolitical events, and commodity policy shocks."""
+        milestones = [
+            # Fed decisions
+            (date(2025, 9, 18), EventType.MACRO_RATE_DECISION, "US Fed Rate Cut (-50 bps)", "Fed pivot kicks off policy easing cycle"),
+            (date(2025, 11, 7), EventType.MACRO_RATE_DECISION, "US Fed Rate Cut (-25 bps)", "Fed rate cut following election results"),
+            (date(2025, 12, 18), EventType.MACRO_RATE_DECISION, "US Fed Rate Cut (-25 bps)", "Final Fed easing of 2025"),
+            (date(2026, 3, 19), EventType.MACRO_RATE_DECISION, "US Fed Meeting Pause", "Fed holds rates steady amid sticky inflation"),
+            # RBI decisions
+            (date(2025, 10, 9), EventType.MACRO_RATE_DECISION, "RBI Policy Pause", "RBI holds repo rate at 6.50%"),
+            (date(2025, 12, 5), EventType.MACRO_RATE_DECISION, "RBI Repo Rate Cut (-25 bps)", "RBI starts monetary easing cycle"),
+            (date(2026, 2, 6), EventType.MACRO_RATE_DECISION, "RBI Policy Pause", "RBI pauses rate cuts to monitor food inflation"),
+            # Geopolitical
+            (date(2025, 10, 1), EventType.MACRO_GEOPOLITICAL, "Middle East Geopolitical Escalation", "Spike in energy and global risk off sentiment"),
+            (date(2026, 1, 12), EventType.MACRO_GEOPOLITICAL, "Global Trade War Tariff Tariffs", "Geopolitical tensions trigger worldwide supply shock"),
+            # India commodity policy
+            (date(2026, 5, 13), EventType.MACRO_RATE_DECISION, "India Gold Import Duty Hike to 15%", "Government raises gold import duty from 6% to 15%; caps duty-free imports at 100kg per licence. Bearish for gold demand, bullish for domestic gold prices short-term on supply squeeze."),
+        ]
+        return [
+            CandidateEvent(trade_date=dt, event_type=ev_type, label=label, description=desc)
+            for dt, ev_type, label, desc in milestones
+        ]
+
+    # ── Dynamic FX Shocks ─────────────────────────────────────────────────────
+
+    # Minimum daily USDINR move to qualify as a macro shock candidate.
+    # The earlier 0.0075 (0.75%) threshold produced ~30+ events per year, which
+    # caused the PostMacroShockStrategy to attach an FX event to nearly every
+    # stock anomaly within its ±3-day window. Raised to 1.00% to surface only
+    # genuinely market-moving USDINR days.
+    _FX_SHOCK_MIN_PCT = 0.01
+
+    @staticmethod
+    def _from_fx_shocks() -> List[CandidateEvent]:
+        """USDINR daily moves ≥ ``_FX_SHOCK_MIN_PCT`` from ClickHouse fx_rates."""
+        events: List[CandidateEvent] = []
+        try:
+            from src.db.pool import query_df
+            df_fx = query_df(
+                "SELECT trade_date, toFloat64(close) AS close "
+                "FROM market_data.fx_rates FINAL WHERE symbol = 'USDINR' "
+                "ORDER BY trade_date ASC"
+            )
+            if not df_fx.empty:
+                df_fx["trade_date"] = pd.to_datetime(df_fx["trade_date"])
+                df_fx["pct_change"] = df_fx["close"].pct_change()
+                extreme_fx = df_fx[df_fx["pct_change"].abs() >= EventRegistry._FX_SHOCK_MIN_PCT]
+                for _, row in extreme_fx.iterrows():
+                    fx_date = pd.to_datetime(row["trade_date"]).date()
+                    pct = float(row["pct_change"])
+                    direction = "Depreciation" if pct > 0 else "Appreciation"
+                    events.append(
+                        CandidateEvent(
+                            trade_date=fx_date,
+                            event_type=EventType.MACRO_COMMODITY_SHOCK,
+                            label=f"USDINR {direction} ({pct*100:+.2f}%)",
+                            description="Significant daily currency volatility shock in INR exchange rates.",
+                            metadata={"fx_pct_change": float(pct)},
+                        )
+                    )
+        except Exception as e:
+            log.warning("Could not dynamically build USDINR macro events: %s", e)
+        return events
+
+    # ── News (RAG + Live Fallback) ────────────────────────────────────────────
+
+    def _from_news(self, symbol: str, lookback_days: int) -> List[CandidateEvent]:
+        """
+        Semantic RAG retrieval (primary) with live GNews fallback for cold-start.
+        Persists live-fetched articles back to ClickHouse for future retrieval.
+        """
+        from src.utils.symbol_mapper import get_company_name
+
+        company_name = get_company_name(symbol) or symbol
+        query_text = f"{symbol} {company_name} price"
+        today = date.today()
+
+        events: List[CandidateEvent] = []
+
+        # Primary: semantic retrieval from embedded news_articles
+        try:
+            from .news_rag import retrieve_articles
+            articles = retrieve_articles(
+                query=query_text,
+                around_date=today,
+                days=lookback_days,
+                k=20,
+            )
+            for a in articles:
+                pub_str = a.get("published_at", "")
+                try:
+                    from dateutil import parser as date_parser
+                    pub_date = date_parser.parse(pub_str).date() if pub_str else today
+                except Exception:
+                    pub_date = today
+
+                events.append(
+                    CandidateEvent(
+                        trade_date=pub_date,
+                        event_type=EventType.NEWS_ANNOUNCEMENT,
+                        label=a.get("title", ""),
+                        description="",
+                        metadata={
+                            "source": a.get("source", ""),
+                            "url": a.get("url", ""),
+                            "similarity": a.get("similarity", 0.0),
+                        },
+                    )
+                )
+        except Exception as e:
+            log.warning("RAG retrieval failed for %s: %s — falling back to live GNews", symbol, e)
+
+        # Fallback: live GNews if retrieval returned <5 results
+        if len(events) < 5:
+            live_events = self._fetch_live_gnews(symbol, lookback_days)
+            self._persist_live_news(live_events, symbol)
+            events.extend(live_events)
+
+        return events
+
+    @staticmethod
+    def _fetch_live_gnews(symbol: str, lookback_days: int) -> List[CandidateEvent]:
+        """Live GNews fallback fetcher."""
+        try:
+            from gnews import GNews
+            from config.settings import settings
+            from dateutil import parser as date_parser
+            import pytz
+            from src.utils.symbol_mapper import get_company_name
+
+            client = GNews(
+                language="en",
+                country="IN",
+                max_results=20,
+                period=f"{lookback_days}d",
+            )
+            company_name = get_company_name(symbol)
+            query = f"{symbol} {company_name}" if company_name else f"{symbol} NSE"
+            articles = client.get_news(query)
+            if not articles:
+                articles = client.get_news(symbol)
+
+            events: List[CandidateEvent] = []
+            tz = pytz.timezone(settings.market_timezone or "Asia/Kolkata")
+            for a in articles:
+                pub_date_str = a.get("published date", "")
+                if not pub_date_str:
+                    continue
+                try:
+                    pub_date = date_parser.parse(pub_date_str)
+                    if pub_date.tzinfo is not None:
+                        pub_date = pub_date.astimezone(tz)
+                    pub_dt = pub_date.date()
+                except Exception:
+                    continue
+
+                title = a.get("title") or ""
+                desc = a.get("description") or ""
+                publisher = a.get("publisher", {})
+                source = publisher.get("title", "") if isinstance(publisher, dict) else str(publisher)
+
+                events.append(
+                    CandidateEvent(
+                        trade_date=pub_dt,
+                        event_type=EventType.NEWS_ANNOUNCEMENT,
+                        label=title,
+                        description=desc,
+                        metadata={"source": source, "url": a.get("url") or ""},
+                    )
+                )
+            return events
+        except Exception as e:
+            log.warning("Live GNews fetch failed for %s: %s", symbol, e)
+            return []
+
+    @staticmethod
+    def _persist_live_news(events: List[CandidateEvent], symbol: str) -> None:
+        """Persist live-fetched news back to ClickHouse for cache warming."""
+        if not events:
+            return
+        try:
+            from src.importer.clickhouse import ClickHouseImporter
+            importer = ClickHouseImporter()
+            rows = []
+            for ev in events:
+                if ev.event_type != EventType.NEWS_ANNOUNCEMENT:
+                    continue
+                rows.append({
+                    "fetched_at": datetime.now(),
+                    "published_at": str(ev.trade_date),
+                    "source_type": "correlation_live",
+                    "fetch_source": "gnews",
+                    "category": symbol,
+                    "etfs_impacted": symbol,
+                    "sentiment": "NEUTRAL",
+                    "impact_tier": "",
+                    "title": ev.label,
+                    "description": ev.description,
+                    "source": ev.metadata.get("source", ""),
+                    "url": ev.metadata.get("url", ""),
+                })
+            if rows:
+                importer.insert_news_articles(rows)
+                log.info("Persisted %d live news articles for %s", len(rows), symbol)
+        except Exception as e:
+            log.debug("Could not persist live news for %s: %s", symbol, e)

--- a/src/ml/correlation/filters.py
+++ b/src/ml/correlation/filters.py
@@ -1,0 +1,246 @@
+"""
+src/ml/correlation/filters.py
+──────────────────────────────
+Post-processing pipeline for CorrelationFindings:
+  1. Quality & source hierarchy weighting
+  2. Date-based deduplication with secondary trigger merging
+  3. Episode clustering (consecutive anomalies → single representative)
+
+Each stage is a standalone function composable into a pipeline via
+`FindingsPipeline.run()`.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, List
+
+from .models import CorrelationFinding, EventType
+
+log = logging.getLogger(__name__)
+
+# Macro events whose semantic relevance to the symbol falls below this
+# threshold are dropped entirely rather than down-weighted. The previous
+# floor of 0.30 let irrelevant macro themes (e.g. "India Gold Import Duty"
+# → a specialty-films stock) leak into findings with MODERATE confidence.
+_MIN_MACRO_RELEVANCE = 0.42
+
+# Sentinel value: when h_weight equals this, the relevance is a *fallback*
+# (e.g. Ollama unreachable) rather than a measured similarity. Fallbacks
+# bypass the cutoff so non-embedding environments keep working.
+_RELEVANCE_FALLBACK = 0.5
+
+
+# ── Individual Filter Stages ──────────────────────────────────────────────────
+
+
+def apply_quality_weights(
+    findings: List[CorrelationFinding],
+    min_score: float = 15.0,
+    symbol: str = "",
+) -> List[CorrelationFinding]:
+    """Apply source hierarchy and news quality weights to adjust scores.
+
+    - Company filings/news with sector keywords get h_weight=0.8
+    - Macro events get semantic relevance weight (cosine similarity between
+      event description and symbol context), ranging [0.3, 1.0]
+    - NEWS_ANNOUNCEMENT gets semantic quality weight via RAG exemplar scoring
+    - Hard blocklist zeroes out known-bad publishers
+    """
+    adjusted: List[CorrelationFinding] = []
+
+    for f in findings:
+        # 1. Source Hierarchy Weight
+        h_weight = 1.0
+        et = f.event.event_type
+        if et in (EventType.COMPANY_FILING, EventType.NEWS_ANNOUNCEMENT):
+            text = (f.event.label + " " + f.event.description).lower()
+            clean_text = "".join(c if c.isalnum() or c.isspace() else " " for c in text)
+            words = set(clean_text.split())
+            sector_keywords = {"sector", "industry", "auto", "it", "banking", "pharma", "metal", "oil", "commodity"}
+            if words & sector_keywords:
+                h_weight = 0.8
+        elif et in (EventType.MACRO_RATE_DECISION, EventType.MACRO_GEOPOLITICAL, EventType.MACRO_COMMODITY_SHOCK):
+            # Semantic relevance: how directly does this event relate to the symbol?
+            # "Gold import duty" → GOLDBEES → high similarity → h_weight ~0.85
+            # "Fed rate cut"     → GOLDBEES → low similarity  → h_weight ~0.40
+            if symbol:
+                try:
+                    from .news_rag import score_event_relevance
+                    event_text = f"{f.event.label} {f.event.description}"
+                    h_weight = score_event_relevance(event_text, symbol)
+                except Exception:
+                    h_weight = _RELEVANCE_FALLBACK
+            else:
+                h_weight = _RELEVANCE_FALLBACK
+
+            # Drop events whose measured relevance is below the cutoff.
+            # The fallback value (Ollama unreachable) is exempt so non-
+            # embedding environments don't silently filter everything.
+            if (
+                h_weight < _MIN_MACRO_RELEVANCE
+                and abs(h_weight - _RELEVANCE_FALLBACK) > 1e-6
+            ):
+                log.debug(
+                    "Dropping low-relevance macro event '%s' for %s (h=%.3f < %.2f)",
+                    f.event.label, symbol, h_weight, _MIN_MACRO_RELEVANCE,
+                )
+                continue
+
+        # 2. News Quality Weight (NEWS_ANNOUNCEMENT only)
+        nq_weight = 1.0
+        if et == EventType.NEWS_ANNOUNCEMENT:
+            text = (f.event.label + " " + f.event.description).lower()
+            source = str(f.event.metadata.get("source", "")).lower()
+            url = str(f.event.metadata.get("url", "")).lower()
+
+            # Hard blocklist
+            if any(k in text or k in source or k in url for k in ["simplywall.st", "simplywall", "blog", "opinion article"]):
+                nq_weight = 0.0
+            elif any(k in text for k in ["could get bumped", "should weakness", "opinion", "why simply", "foolish", "target by 20", "target by 2"]):
+                nq_weight = 0.10
+            else:
+                # Semantic scoring via exemplar embeddings
+                try:
+                    from .news_rag import score_news_quality
+                    nq_weight = score_news_quality(f.event.label)
+                except Exception:
+                    nq_weight = 0.20
+
+        # Compute final adjusted score
+        f.correlation_score = f.correlation_score * nq_weight * h_weight
+
+        if f.correlation_score < min_score:
+            continue
+
+        # Update confidence band
+        if f.correlation_score >= 70.0:
+            f.confidence = "HIGH"
+        elif f.correlation_score >= 40.0:
+            f.confidence = "MODERATE"
+        else:
+            f.confidence = "LOW"
+
+        adjusted.append(f)
+
+    return adjusted
+
+
+def deduplicate_by_date(findings: List[CorrelationFinding]) -> List[CorrelationFinding]:
+    """Group findings by anomaly date, keeping best score + merging secondaries into explanation."""
+    by_date: dict[Any, List[CorrelationFinding]] = {}
+    for f in findings:
+        by_date.setdefault(f.anomaly_date, []).append(f)
+
+    deduped: List[CorrelationFinding] = []
+    for anom_date, date_findings in by_date.items():
+        if len(date_findings) == 1:
+            deduped.append(date_findings[0])
+        else:
+            date_findings = sorted(date_findings, key=lambda x: (-x.correlation_score, x.strategy_name))
+            primary = date_findings[0]
+            secondary_trigs = date_findings[1:]
+
+            extra_explanations = []
+            for sec in secondary_trigs:
+                offset_str = f"{sec.lead_lag_days:+}d"
+                extra_explanations.append(
+                    f"{sec.event.label} ({offset_str} offset, score: {sec.correlation_score:.1f} via {sec.strategy_name})"
+                )
+
+            new_explanation = primary.explanation + "\n   *Secondary Triggers:* " + "; ".join(extra_explanations)
+
+            merged_finding = CorrelationFinding(
+                anomaly_date=primary.anomaly_date,
+                event=primary.event,
+                strategy_name=primary.strategy_name,
+                correlation_score=primary.correlation_score,
+                lead_lag_days=primary.lead_lag_days,
+                confidence=primary.confidence,
+                explanation=new_explanation,
+            )
+            deduped.append(merged_finding)
+
+    return sorted(deduped, key=lambda f: (f.anomaly_date, -f.correlation_score))
+
+
+def cluster_episodes(
+    findings: List[CorrelationFinding],
+    max_gap_days: int = 5,
+) -> List[CorrelationFinding]:
+    """Group consecutive anomaly dates within `max_gap_days` into single episodes."""
+    if not findings:
+        return findings
+
+    episodes: List[List[CorrelationFinding]] = []
+    current_episode: List[CorrelationFinding] = [findings[0]]
+    for f in findings[1:]:
+        prev_date = current_episode[-1].anomaly_date
+        if (f.anomaly_date - prev_date).days <= max_gap_days:
+            current_episode.append(f)
+        else:
+            episodes.append(current_episode)
+            current_episode = [f]
+    episodes.append(current_episode)
+
+    clustered: List[CorrelationFinding] = []
+    for ep in episodes:
+        if len(ep) == 1:
+            clustered.append(ep[0])
+        else:
+            ep_sorted = sorted(ep, key=lambda x: -x.correlation_score)
+            primary = ep_sorted[0]
+            other_dates = [
+                f"{f.anomaly_date} ({f.event.label}, score: {f.correlation_score:.1f})"
+                for f in ep_sorted[1:]
+            ]
+            episode_note = (
+                f"\n   *Episode cluster ({len(ep)} days):* "
+                + "; ".join(other_dates)
+            )
+            merged = CorrelationFinding(
+                anomaly_date=primary.anomaly_date,
+                event=primary.event,
+                strategy_name=primary.strategy_name,
+                correlation_score=primary.correlation_score,
+                lead_lag_days=primary.lead_lag_days,
+                confidence=primary.confidence,
+                explanation=primary.explanation + episode_note,
+                abnormal_return=primary.abnormal_return,
+            )
+            clustered.append(merged)
+
+    return clustered
+
+
+# ── Pipeline Orchestrator ─────────────────────────────────────────────────────
+
+
+class FindingsPipeline:
+    """Chains filter stages into an ordered pipeline.
+
+    Default pipeline: quality_weights → deduplicate → cluster_episodes.
+    Stages can be customized by passing a list of callables to __init__.
+    Keyword arguments passed to run() are forwarded to each stage (stages
+    that don't accept them will simply ignore them via **kwargs).
+    """
+
+    def __init__(self, stages=None):
+        if stages is None:
+            stages = [
+                apply_quality_weights,
+                deduplicate_by_date,
+                cluster_episodes,
+            ]
+        self._stages = stages
+
+    def run(self, findings: List[CorrelationFinding], **kwargs) -> List[CorrelationFinding]:
+        """Execute all pipeline stages in order, forwarding kwargs."""
+        import inspect
+
+        for stage in self._stages:
+            sig = inspect.signature(stage)
+            # Only pass kwargs that the stage accepts
+            accepted = {k: v for k, v in kwargs.items() if k in sig.parameters}
+            findings = stage(findings, **accepted)
+        return findings

--- a/src/ml/correlation/models.py
+++ b/src/ml/correlation/models.py
@@ -1,0 +1,44 @@
+"""
+src/ml/correlation/models.py
+─────────────────────────────
+Core data models for the correlation engine: event types, candidate events,
+and correlation findings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from enum import Enum
+from typing import Optional
+
+
+class EventType(str, Enum):
+    COMPANY_FILING = "company_filing"
+    NEWS_ANNOUNCEMENT = "news_announcement"
+    MACRO_RATE_DECISION = "macro_rate_decision"
+    MACRO_COMMODITY_SHOCK = "macro_commodity_shock"
+    MACRO_GEOPOLITICAL = "macro_geopolitical"
+
+
+@dataclass
+class CandidateEvent:
+    """A qualitative corporate filing or external macro event."""
+    trade_date: date
+    event_type: EventType
+    label: str
+    description: str
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass
+class CorrelationFinding:
+    """The mapping of an anomaly day to a candidate event trigger."""
+    anomaly_date: date
+    event: CandidateEvent
+    strategy_name: str
+    correlation_score: float  # 0 to 100
+    lead_lag_days: int        # Negative = anomaly is BEFORE event (leak), Positive = AFTER (reaction)
+    confidence: str           # "HIGH" | "MODERATE" | "LOW"
+    explanation: str
+    abnormal_return: Optional[float] = None

--- a/src/ml/correlation/news_rag.py
+++ b/src/ml/correlation/news_rag.py
@@ -1,0 +1,355 @@
+"""
+src/ml/correlation/news_rag.py
+──────────────────────────────
+Embedding-based news retrieval and quality scoring for the correlation engine.
+
+Uses Ollama `nomic-embed-text` (768-dim) for embeddings, stored in ClickHouse
+`news_articles.embedding` column. Provides:
+  - embed_text()           — embed a single text string via Ollama HTTP API
+  - retrieve_articles()    — semantic search within a date window
+  - score_news_quality()   — exemplar-based quality weight (replaces keyword tiers)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+from datetime import date, timedelta
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+import requests
+
+log = logging.getLogger(__name__)
+
+# ── Configuration ─────────────────────────────────────────────────────────────
+
+_OLLAMA_BASE = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+_EMBED_MODEL = "nomic-embed-text"
+_EMBED_DIM = 768
+_CACHE_DIR = Path("data/.cache/embeddings")
+
+# ── Embedding primitives ──────────────────────────────────────────────────────
+
+
+def embed_text(text: str) -> list[float]:
+    """Embed a single text string via Ollama HTTP API.
+
+    Returns a 768-dim float vector. Raises on Ollama failure after 1 retry.
+    Results are cached to disk by sha256(text) for 24h.
+    """
+    if not text or not text.strip():
+        return [0.0] * _EMBED_DIM
+
+    text = text.strip()[:512]  # nomic-embed-text has 512 token window
+
+    # Check disk cache
+    cache_key = hashlib.sha256(text.encode()).hexdigest()
+    cache_path = _CACHE_DIR / f"{cache_key}.json"
+    if cache_path.exists():
+        try:
+            age_hours = (os.path.getmtime(str(cache_path)) - os.time()) / 3600
+        except Exception:
+            age_hours = 0
+        # Use cache if < 24h old
+        import time
+        age_hours = (time.time() - os.path.getmtime(str(cache_path))) / 3600
+        if age_hours < 24:
+            try:
+                return json.loads(cache_path.read_text())
+            except Exception:
+                pass
+
+    # Call Ollama
+    url = f"{_OLLAMA_BASE}/api/embed"
+    payload = {"model": _EMBED_MODEL, "input": text}
+    try:
+        resp = requests.post(url, json=payload, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        # Ollama returns {"embeddings": [[...]]} for /api/embed
+        vec = data["embeddings"][0]
+    except Exception as e:
+        log.warning("Ollama embed failed: %s", e)
+        return [0.0] * _EMBED_DIM
+
+    # Cache to disk
+    try:
+        _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(vec))
+    except Exception:
+        pass
+
+    return vec
+
+
+def embed_batch(texts: list[str]) -> list[list[float]]:
+    """Embed multiple texts in a single Ollama call (batched)."""
+    if not texts:
+        return []
+
+    cleaned = [t.strip()[:512] if t else "" for t in texts]
+    url = f"{_OLLAMA_BASE}/api/embed"
+    payload = {"model": _EMBED_MODEL, "input": cleaned}
+    try:
+        resp = requests.post(url, json=payload, timeout=120)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["embeddings"]
+    except Exception as e:
+        log.warning("Ollama batch embed failed: %s — falling back to individual", e)
+        return [embed_text(t) for t in texts]
+
+
+# ── Exemplar-based quality scoring ────────────────────────────────────────────
+
+# ── Event-to-symbol relevance scoring ─────────────────────────────────────────
+
+# Cache for symbol context embeddings (symbol → vector)
+_symbol_context_cache: dict[str, np.ndarray] = {}
+
+
+def score_event_relevance(event_text: str, symbol: str) -> float:
+    """Score how relevant an event is to a specific symbol using cosine similarity.
+
+    Compares the embedding of the event label/description against a symbol's
+    domain context string (e.g. "GOLDBEES Nippon India ETF Gold BeES gold ETF
+    India"). Returns a float in [0.3, 1.0] — floor at 0.3 ensures even weakly
+    related macro events retain some influence.
+
+    Falls back to 0.5 (the old hardcoded value) if embeddings are unavailable.
+    """
+    if not event_text or not event_text.strip():
+        return 0.5
+
+    # Build or retrieve symbol context embedding
+    sym_upper = symbol.upper()
+    if sym_upper not in _symbol_context_cache:
+        try:
+            from src.utils.symbol_mapper import get_company_name
+            company = get_company_name(sym_upper)
+            context = f"{sym_upper} {company}"
+            cl = company.lower()
+            # Enrich with asset-class keywords for ETFs
+            if any(k in cl for k in ["etf", "bees", "index"]):
+                if "gold" in cl:
+                    context += " gold precious metals commodity India"
+                elif "bank" in cl:
+                    context += " banking financial services India"
+                elif "nifty" in cl or "fang" in cl or "nyse" in cl:
+                    context += " equity index India market"
+                elif "silver" in cl:
+                    context += " silver precious metals commodity India"
+                elif "it" in cl:
+                    context += " technology IT sector India"
+                elif "liquid" in cl:
+                    context += " debt liquid money market India"
+            else:
+                # Sector enrichment for individual stocks (heuristic from company name)
+                if any(k in cl for k in ["bank", "finance", "life insurance", "prudential"]):
+                    context += " banking financial services NBFC India RBI repo rate"
+                elif any(k in cl for k in ["pharma", "laboratories", "biocon", "lupin", "cipla", "apollo", "hospital"]):
+                    context += " pharmaceutical healthcare drugs FDA India"
+                elif any(k in cl for k in ["motors", "auto", "leyland", "mrf", "tvs", "maruti", "hero", "eicher", "bajaj auto"]):
+                    context += " automobile auto sector EV electric vehicle India"
+                elif any(k in cl for k in ["reliance industries", "ongc", "oil", "petroleum", "petronet", "bpcl", "gail"]):
+                    context += " oil gas petrochemicals crude WTI OPEC refining India"
+                elif any(k in cl for k in ["tcs", "infosys", "wipro", "tech mahindra", "hcl tech", "mphasis", "persistent", "ltimindtree", "coforge", "kpit", "tata elxsi"]):
+                    context += " technology IT software services USD India exports"
+                elif any(k in cl for k in ["steel", "hindalco", "coal", "jsw", "ntpc", "power grid", "tata steel"]):
+                    context += " metals mining commodities steel coal power utilities India"
+                elif any(k in cl for k in ["hindustan unilever", "itc", "nestle", "britannia", "marico", "dabur", "godrej", "colgate", "varun", "tata consumer", "emami"]):
+                    context += " FMCG consumer staples India rural demand"
+                elif any(k in cl for k in ["airtel", "telecom"]):
+                    context += " telecom data subscribers India spectrum"
+                elif any(k in cl for k in ["paints", "cement", "ultratech", "asian paints", "berger", "pidilite", "havells", "siemens", "abb", "cummins", "larsen"]):
+                    context += " capital goods infrastructure construction India capex"
+                elif any(k in cl for k in ["adani"]):
+                    context += " Adani group infrastructure ports green energy India"
+            vec = np.array(embed_text(context), dtype=np.float32)
+            _symbol_context_cache[sym_upper] = vec
+        except Exception:
+            return 0.5
+
+    sym_vec = _symbol_context_cache[sym_upper]
+    sym_norm = np.linalg.norm(sym_vec)
+    if sym_norm == 0:
+        return 0.5
+
+    # Embed the event text
+    event_vec = np.array(embed_text(event_text), dtype=np.float32)
+    event_norm = np.linalg.norm(event_vec)
+    if event_norm == 0:
+        return 0.5
+
+    sim = float(np.dot(sym_vec, event_vec) / (sym_norm * event_norm))
+
+    # Map similarity [0, 1] → h_weight [0.3, 1.0]
+    # Floor of 0.3 ensures even distantly-related macro events keep some weight
+    return max(0.3, min(1.0, sim))
+
+
+_EXEMPLARS_PATH = Path(__file__).parent.parent.parent.parent / "data" / "news_quality_exemplars.json"
+_exemplar_cache: Optional[dict] = None
+
+
+def _load_exemplars() -> dict:
+    """Load and embed exemplar headlines. Cached in module memory."""
+    global _exemplar_cache
+    if _exemplar_cache is not None:
+        return _exemplar_cache
+
+    try:
+        exemplars = json.loads(_EXEMPLARS_PATH.read_text())
+    except Exception as e:
+        log.warning("Could not load news quality exemplars: %s", e)
+        _exemplar_cache = {"texts": [], "weights": [], "vectors": []}
+        return _exemplar_cache
+
+    texts = [e["text"] for e in exemplars]
+    weights = [e["weight"] for e in exemplars]
+
+    # Embed all exemplars
+    vectors = embed_batch(texts)
+
+    _exemplar_cache = {
+        "texts": texts,
+        "weights": np.array(weights, dtype=np.float32),
+        "vectors": np.array(vectors, dtype=np.float32),
+    }
+    return _exemplar_cache
+
+
+def score_news_quality(headline: str) -> float:
+    """Score a news headline by semantic similarity to labelled exemplars.
+
+    Returns a weight ∈ [0.0, 1.0]. Higher = more material/actionable.
+    Falls back to 0.20 (neutral) if exemplars unavailable.
+    """
+    if not headline or not headline.strip():
+        return 0.0
+
+    exemplars = _load_exemplars()
+    if len(exemplars["vectors"]) == 0:
+        return 0.20  # fallback to keyword-era neutral weight
+
+    query_vec = np.array(embed_text(headline), dtype=np.float32)
+    if np.linalg.norm(query_vec) == 0:
+        return 0.20
+
+    # Cosine similarity against all exemplars
+    exemplar_vecs = exemplars["vectors"]
+    norms = np.linalg.norm(exemplar_vecs, axis=1)
+    # Avoid division by zero
+    valid = norms > 0
+    if not valid.any():
+        return 0.20
+
+    sims = exemplar_vecs[valid] @ query_vec / (norms[valid] * np.linalg.norm(query_vec))
+
+    # Weighted average of top-5 by similarity
+    k = min(5, len(sims))
+    top_k_idx = np.argpartition(sims, -k)[-k:]
+    top_sims = sims[top_k_idx]
+
+    # Convert similarities to positive weights (clip negatives)
+    sim_weights = np.clip(top_sims, 0.0, 1.0)
+    if sim_weights.sum() == 0:
+        return 0.20
+
+    top_quality_weights = exemplars["weights"][valid][top_k_idx]
+    score = float(np.average(top_quality_weights, weights=sim_weights))
+
+    return max(0.0, min(1.0, score))
+
+
+# ── Semantic retrieval from ClickHouse ────────────────────────────────────────
+
+
+def retrieve_articles(
+    query: str,
+    around_date: date,
+    days: int = 7,
+    k: int = 20,
+    category_filter: Optional[str] = None,
+) -> list[dict]:
+    """Retrieve top-k semantically relevant news articles within a date window.
+
+    Queries news_articles table for rows with non-empty embeddings within
+    [around_date - days, around_date + days], ranks by cosine similarity.
+
+    Returns list of dicts with keys: title, source, url, published_at,
+    category, sentiment, similarity.
+    """
+    from src.db.pool import query_df
+
+    query_vec = embed_text(query)
+    if all(v == 0.0 for v in query_vec):
+        return []
+
+    start_date = around_date - timedelta(days=days)
+    end_date = around_date + timedelta(days=days)
+
+    # Build SQL — fetch articles with embeddings in the date window.
+    # Use BOTH fetched_at and published_at for matching: an article about a duty
+    # hike published May 18 but fetched June 19 should still match a May lookback.
+    sql = """
+        SELECT title, source, url, published_at, category, sentiment,
+               embedding
+        FROM market_data.news_articles FINAL
+        WHERE length(embedding) > 0
+          AND (
+            toDate(fetched_at) BETWEEN {start:Date} AND {end:Date}
+            OR toDate(parseDateTimeBestEffortOrNull(published_at)) BETWEEN {start:Date} AND {end:Date}
+          )
+    """
+    params: dict = {"start": str(start_date), "end": str(end_date)}
+
+    if category_filter:
+        sql += " AND category = {cat:String}"
+        params["cat"] = category_filter
+
+    sql += " LIMIT 500"  # cap for brute-force cosine
+
+    try:
+        df = query_df(sql, parameters=params)
+    except Exception as e:
+        log.warning("retrieve_articles query failed: %s", e)
+        return []
+
+    if df.empty:
+        return []
+
+    # Compute cosine similarities
+    query_arr = np.array(query_vec, dtype=np.float32)
+    q_norm = np.linalg.norm(query_arr)
+    if q_norm == 0:
+        return []
+
+    results = []
+    for _, row in df.iterrows():
+        emb = row["embedding"]
+        if not emb or len(emb) == 0:
+            continue
+        emb_arr = np.array(emb, dtype=np.float32)
+        e_norm = np.linalg.norm(emb_arr)
+        if e_norm == 0:
+            continue
+        sim = float(np.dot(query_arr, emb_arr) / (q_norm * e_norm))
+        results.append({
+            "title": row["title"],
+            "source": row["source"],
+            "url": row["url"],
+            "published_at": row["published_at"],
+            "category": row["category"],
+            "sentiment": row["sentiment"],
+            "similarity": sim,
+        })
+
+    # Sort by similarity descending, take top-k
+    results.sort(key=lambda x: -x["similarity"])
+    return results[:k]

--- a/src/ml/correlation/service.py
+++ b/src/ml/correlation/service.py
@@ -1,0 +1,82 @@
+"""
+src/ml/correlation/service.py
+──────────────────────────────
+Thin orchestrator: wires EventRegistry → Strategies → FindingsPipeline.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import pandas as pd
+
+from .event_registry import EventRegistry
+from .filters import FindingsPipeline
+from .models import CorrelationFinding
+from .strategies import (
+    CorrelationStrategy,
+    CrossAssetCoMovementStrategy,
+    PostMacroShockStrategy,
+)
+
+log = logging.getLogger(__name__)
+
+
+class CorrelationService:
+    """Orchestrates candidate event loading and pluggable correlation strategies.
+
+    Default strategies:
+      - PostMacroShockStrategy   — anomaly → macro event attribution
+      - CrossAssetCoMovementStrategy — anomaly → FX/commodity shock attribution
+    """
+
+    def __init__(self) -> None:
+        self._strategies: List[CorrelationStrategy] = []
+        self._registry = EventRegistry()
+        self._pipeline = FindingsPipeline()
+
+        # Register default strategies (anomaly-first: detect anomalies, then
+        # attribute them to external signals that impacted the price).
+        self.register_strategy(PostMacroShockStrategy())
+        self.register_strategy(CrossAssetCoMovementStrategy())
+
+    def register_strategy(self, strategy: CorrelationStrategy) -> None:
+        self._strategies.append(strategy)
+
+    def find_correlations(
+        self,
+        symbol: str,
+        df_ohlcv: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame] = None,
+        lookback_days: int = 365,
+    ) -> List[CorrelationFinding]:
+        """Executes all registered strategies against price data and candidate events."""
+        if df_ohlcv.empty or len(df_ohlcv) < 5:
+            return []
+
+        from src.ml.anomaly import run_composite_anomaly
+
+        df_ohlcv = df_ohlcv.copy()
+        df_ohlcv["trade_date"] = pd.to_datetime(df_ohlcv["trade_date"])
+
+        # 1. Load corporate actions + run anomaly detection
+        df_corp = self._registry.load_corp_actions(symbol)
+        df_anomaly_res, _, _ = run_composite_anomaly(df_ohlcv, df_corp_actions=df_corp)
+
+        # 2. Build candidate events from all sources
+        events = self._registry.load_all(symbol, df_corp, lookback_days)
+
+        # 3. Execute strategies
+        findings: List[CorrelationFinding] = []
+        for strat in self._strategies:
+            try:
+                strat_findings = strat.analyze(df_ohlcv, df_anomaly_res, df_benchmark, events)
+                findings.extend(strat_findings)
+            except Exception as exc:
+                log.error("Correlation Strategy %s failed: %s", strat.name, exc, exc_info=True)
+
+        # 4. Post-processing pipeline (quality → dedup → cluster)
+        findings = self._pipeline.run(findings, symbol=symbol)
+
+        return findings

--- a/src/ml/correlation/strategies.py
+++ b/src/ml/correlation/strategies.py
@@ -1,0 +1,681 @@
+"""
+src/ml/correlation/strategies.py
+─────────────────────────────────
+Pluggable correlation strategies: maps detected price anomalies to external
+signals (macro events, FX shocks, news) that impacted the price.
+
+Architecture
+────────────
+The pipeline is anomaly-first:
+  1. Anomaly detection (GARCH + Isolation Forest + PELT) runs independently.
+  2. Strategies attribute each flagged anomaly to external events.
+
+Each strategy splits its work into two distinct phases:
+
+  1. ``_detect_signals()``  — **SIGNAL** phase.
+     Pure detection. Iterates events/anomalies and produces raw ``_Signal``
+     records carrying the features needed to score the match. No scoring,
+     no thresholds, no penalties, no explanation strings.
+
+  2. ``_score_signal()``    — **EXECUTION** phase.
+     Takes one ``_Signal`` and produces a fully-scored ``CorrelationFinding``
+     (or returns ``None`` when the signal fails a quality gate such as
+     minimum return / lag decay / direction penalty).
+
+The base class ``CorrelationStrategy.analyze()`` is a concrete orchestrator
+that calls both phases in order, emits timestamped INFO logs at each
+boundary (with elapsed milliseconds), and returns the surviving findings.
+
+Strategies:
+  - PreEventLeakStrategy         — detects insider leaks before corporate actions
+  - PostMacroShockStrategy       — detects reactions after macro events
+  - CrossAssetCoMovementStrategy — correlates with extreme FX/commodity shocks
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, List, Optional
+
+import numpy as np
+import pandas as pd
+
+from .models import CandidateEvent, CorrelationFinding, EventType
+
+log = logging.getLogger(__name__)
+
+
+# ── Timestamped logging setup ─────────────────────────────────────────────────
+#
+# The CLI configures root logging via _setup_logging() in src/main.py with an
+# asctime formatter. When the correlation engine runs from contexts where root
+# logging is NOT configured (Streamlit, MCP server, pytest, ad-hoc scripts),
+# we attach our own handler so every strategy log line still carries a
+# timestamp. The helper is idempotent — safe to call repeatedly.
+
+_TS_FORMAT = "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+_TS_DATEFMT = "%Y-%m-%d %H:%M:%S"
+
+
+def _ensure_timestamp_handler() -> None:
+    """Attach a stream handler with asctime if neither root nor this module
+    already has one. Prevents duplicate handlers on repeat calls."""
+    if log.handlers:
+        return
+    root = logging.getLogger()
+    root_has_ts = any(
+        getattr(h.formatter, "_fmt", None) and "%(asctime)" in (h.formatter._fmt or "")
+        for h in root.handlers
+    )
+    if root.handlers and root_has_ts:
+        return  # root will format with timestamps — propagation does the work
+    h = logging.StreamHandler()
+    h.setFormatter(logging.Formatter(_TS_FORMAT, datefmt=_TS_DATEFMT))
+    log.addHandler(h)
+    if log.level == logging.NOTSET:
+        log.setLevel(logging.INFO)
+    log.propagate = False
+
+
+_ensure_timestamp_handler()
+
+
+# ── Internal: signal phase output ─────────────────────────────────────────────
+
+
+@dataclass
+class _Signal:
+    """Raw detection record produced by ``_detect_signals()``.
+
+    Carries the features needed for ``_score_signal()`` to compute a final
+    ``CorrelationFinding``. Strategy-specific fields live inside ``metrics``
+    so the dataclass stays stable across strategies.
+    """
+    anomaly_date: date
+    event: CandidateEvent
+    metrics: dict = field(default_factory=dict)
+
+
+# ── Base class ────────────────────────────────────────────────────────────────
+
+
+class CorrelationStrategy(ABC):
+    """Abstract interface for correlation mapping strategies.
+
+    Subclasses implement ``_detect_signals`` (signal phase) and
+    ``_score_signal`` (execution phase). The orchestrator ``analyze()`` is
+    concrete and handles ordering, timing, and per-signal error containment.
+    """
+
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        ...
+
+    # ── Phase 1: SIGNAL ──
+    @abstractmethod
+    def _detect_signals(
+        self,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+        events: List[CandidateEvent],
+    ) -> List[_Signal]:
+        """Produce raw signal candidates — no scoring or thresholding."""
+
+    # ── Phase 2: EXECUTION ──
+    @abstractmethod
+    def _score_signal(
+        self,
+        signal: _Signal,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+    ) -> Optional[CorrelationFinding]:
+        """Score one signal. Return ``None`` to drop it from the findings."""
+
+    # ── Concrete orchestrator ──
+    def analyze(
+        self,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+        events: List[CandidateEvent],
+    ) -> List[CorrelationFinding]:
+        """SIGNAL → EXECUTION pipeline with timed, timestamped logging."""
+        t0 = time.perf_counter()
+        try:
+            signals = self._detect_signals(df_ohlcv, df_anomaly, df_benchmark, events)
+        except Exception as exc:  # noqa: BLE001 — strategy is plug-in
+            log.error("[%s] SIGNAL phase failed: %s", self.name, exc, exc_info=True)
+            return []
+        t1 = time.perf_counter()
+        log.info(
+            "[%s] SIGNAL    events=%d → signals=%d (%.1f ms)",
+            self.name, len(events), len(signals), (t1 - t0) * 1000.0,
+        )
+
+        findings: List[CorrelationFinding] = []
+        for sig in signals:
+            try:
+                f = self._score_signal(sig, df_ohlcv, df_anomaly, df_benchmark)
+            except Exception as exc:  # noqa: BLE001 — keep other signals
+                log.warning(
+                    "[%s] EXECUTION failed for signal on %s: %s",
+                    self.name, sig.anomaly_date, exc,
+                )
+                continue
+            if f is not None:
+                findings.append(f)
+        t2 = time.perf_counter()
+        log.info(
+            "[%s] EXECUTION signals=%d → findings=%d (%.1f ms, total %.1f ms)",
+            self.name, len(signals), len(findings),
+            (t2 - t1) * 1000.0, (t2 - t0) * 1000.0,
+        )
+        return findings
+
+
+# ── Confidence band helper ────────────────────────────────────────────────────
+
+
+def _confidence_for(score: float) -> str:
+    if score >= 70.0:
+        return "HIGH"
+    if score >= 40.0:
+        return "MODERATE"
+    return "LOW"
+
+
+# ── Pre-Event Leak Strategy (DEPRECATED) ─────────────────────────────────────
+# Not registered by default. Kept for backward-compatibility imports.
+# Rationale: the pipeline now focuses on anomaly detection + attribution to
+# external signals impacting price (macro/FX). Speculative insider-leak scoring
+# produced noise without actionable alpha.
+
+
+class PreEventLeakStrategy(CorrelationStrategy):
+    """**DEPRECATED** — no longer registered by default.
+
+    Detects potential insider leaks or front-running prior to corporate
+    actions. Scans the window [T - W, T - 1] before an ex-date.
+
+    .. deprecated:: 2026-06-20
+        Use PostMacroShockStrategy and CrossAssetCoMovementStrategy instead.
+        This class remains importable for existing callers that register it
+        explicitly.
+    """
+
+    def __init__(self, window_days: int = 5, min_score: float = 20.0) -> None:
+        self.window_days = window_days
+        self.min_score = min_score
+
+    @property
+    def name(self) -> str:
+        return "Pre-Event Leak Detector"
+
+    # ── Phase 1: SIGNAL ──────────────────────────────────────────────────────
+    def _detect_signals(
+        self,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+        events: List[CandidateEvent],
+    ) -> List[_Signal]:
+        signals: List[_Signal] = []
+
+        company_events = [
+            e for e in events
+            if e.event_type in (EventType.COMPANY_FILING, EventType.NEWS_ANNOUNCEMENT)
+        ]
+        if not company_events or df_ohlcv.empty:
+            return signals
+
+        df_ohlcv = df_ohlcv.sort_values("trade_date").reset_index(drop=True)
+        trade_dates = pd.to_datetime(df_ohlcv["trade_date"]).dt.date.tolist()
+
+        for ev in company_events:
+            ev_date = ev.trade_date
+            if ev_date not in trade_dates:
+                continue
+
+            ev_idx = trade_dates.index(ev_date)
+            start_idx = max(0, ev_idx - self.window_days)
+            end_idx = max(0, ev_idx - 1)
+            if start_idx >= end_idx:
+                continue
+
+            sub_ohlcv = df_ohlcv.iloc[start_idx:end_idx + 1]
+            sub_anomaly = df_anomaly.iloc[start_idx:end_idx + 1]
+
+            # Raw price return in pre-event window
+            price_start = float(df_ohlcv.iloc[max(0, start_idx - 1)]["close"])
+            price_end = float(df_ohlcv.iloc[end_idx]["close"])
+            raw_return = (price_end / price_start) - 1.0
+
+            # Cumulative Abnormal Return (CAR)
+            bench_return = 0.0
+            if df_benchmark is not None and not df_benchmark.empty:
+                df_bench_sorted = df_benchmark.sort_values("trade_date").reset_index(drop=True)
+                b_dates = pd.to_datetime(df_bench_sorted["trade_date"]).dt.date.tolist()
+                try:
+                    bench_start_date = df_ohlcv.iloc[max(0, start_idx - 1)]["trade_date"]
+                    bench_end_date = df_ohlcv.iloc[end_idx]["trade_date"]
+                    b_start_idx = b_dates.index(pd.to_datetime(bench_start_date).date())
+                    b_end_idx = b_dates.index(pd.to_datetime(bench_end_date).date())
+                    b_price_start = float(df_bench_sorted.iloc[b_start_idx]["close"])
+                    b_price_end = float(df_bench_sorted.iloc[b_end_idx]["close"])
+                    bench_return = (b_price_end / b_price_start) - 1.0 if b_price_start > 0 else 0.0
+                except (ValueError, IndexError):
+                    pass
+            car = raw_return - bench_return
+
+            # Abnormal Volume Ratio (AVR)
+            pre_start_idx = max(0, start_idx - 20)
+            hist_vol_df = df_ohlcv.iloc[pre_start_idx:start_idx]
+            hist_vol_median = hist_vol_df["volume"].median() if not hist_vol_df.empty else 1.0
+            if hist_vol_median <= 0:
+                hist_vol_median = 1.0
+            pre_vol_median = sub_ohlcv["volume"].median()
+            avr = pre_vol_median / hist_vol_median
+
+            # Volatility expansion (GARCH)
+            hist_vol_garch = df_anomaly.iloc[pre_start_idx:start_idx]["garch_vol"].median() \
+                if "garch_vol" in df_anomaly.columns else 1.0
+            pre_vol_garch = sub_anomaly["garch_vol"].median() \
+                if "garch_vol" in sub_anomaly.columns else 1.0
+            vol_ratio = pre_vol_garch / hist_vol_garch \
+                if (hist_vol_garch and not pd.isna(hist_vol_garch)) else 1.0
+
+            # Count of flagged anomalies in pre-event window
+            anomaly_count = 0
+            if "is_anomaly" in sub_anomaly.columns:
+                anomaly_count = int(sub_anomaly["is_anomaly"].sum())
+
+            # Pick representative anomaly date for the finding
+            best_anom_idx = start_idx
+            if anomaly_count > 0:
+                anomaly_indices = sub_anomaly[sub_anomaly["is_anomaly"] == True].index.tolist()  # noqa: E712
+                if anomaly_indices:
+                    best_anom_idx = anomaly_indices[-1]
+            else:
+                returns = sub_ohlcv["close"].pct_change().abs().values
+                max_dev = np.argmax(returns) if len(returns) > 0 else 0
+                best_anom_idx = start_idx + max_dev
+
+            anomaly_date = pd.to_datetime(df_ohlcv.iloc[best_anom_idx]["trade_date"]).date()
+            lead_days = int((anomaly_date - pd.to_datetime(ev_date).date()).days)
+
+            action_type = str(ev.metadata.get("action_type", "")).lower() if ev.metadata else ""
+            is_public_value_neutral = action_type in {"bonus", "split", "face_value_split"}
+
+            signals.append(_Signal(
+                anomaly_date=anomaly_date,
+                event=ev,
+                metrics={
+                    "avr": avr,
+                    "car": car,
+                    "vol_ratio": vol_ratio,
+                    "anomaly_count": anomaly_count,
+                    "lead_days": lead_days,
+                    "is_public_value_neutral": is_public_value_neutral,
+                },
+            ))
+
+        return signals
+
+    # ── Phase 2: EXECUTION ───────────────────────────────────────────────────
+    def _score_signal(
+        self,
+        signal: _Signal,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+    ) -> Optional[CorrelationFinding]:
+        m = signal.metrics
+        avr = m["avr"]
+        car = m["car"]
+        vol_ratio = m["vol_ratio"]
+        anomaly_count = m["anomaly_count"]
+        lead_days = m["lead_days"]
+        is_public_value_neutral = m["is_public_value_neutral"]
+
+        volume_pts = min(30.0, max(0.0, (avr - 1.0) * 20.0))
+        car_pts    = min(30.0, max(0.0, abs(car) * 600.0))
+        vol_pts    = min(20.0, max(0.0, (vol_ratio - 1.0) * 40.0))
+        anom_pts   = 20.0 if anomaly_count > 0 else 0.0
+        score = volume_pts + car_pts + vol_pts + anom_pts
+
+        if score < self.min_score:
+            return None
+
+        # Bonus/split/face-value-split are publicly announced weeks before ex-date;
+        # pre-event positioning is routine arbitrage, not information leakage.
+        if is_public_value_neutral:
+            score *= 0.5
+            explanation = (
+                f"Pre-corporate-action positioning on {signal.anomaly_date} ahead of "
+                f"'{signal.event.label}' ({abs(lead_days)} days before ex-date). "
+                f"Detected abnormal volume ratio of {avr:.2f}x, cumulative abnormal "
+                f"return of {car*100:+.2f}%, and {anomaly_count} flagged anomaly day(s) "
+                f"in the pre-event window. "
+                f"Note: bonus/split actions are typically publicly announced weeks "
+                f"before the ex-date; early positioning is routine corporate-action "
+                f"arbitrage — not information leakage."
+            )
+        else:
+            explanation = (
+                f"Anomaly on {signal.anomaly_date} occurred {abs(lead_days)} days before "
+                f"the corporate action '{signal.event.label}'. Detected abnormal volume "
+                f"ratio of {avr:.2f}x, cumulative abnormal return of {car*100:+.2f}%, "
+                f"and {anomaly_count} flagged anomaly day(s) in the pre-event window."
+            )
+
+        return CorrelationFinding(
+            anomaly_date=signal.anomaly_date,
+            event=signal.event,
+            strategy_name=self.name,
+            correlation_score=score,
+            lead_lag_days=lead_days,
+            confidence=_confidence_for(score),
+            explanation=explanation,
+            abnormal_return=car,
+        )
+
+
+# ── Post-Macro Shock Strategy ─────────────────────────────────────────────────
+
+
+class PostMacroShockStrategy(CorrelationStrategy):
+    """Detects market price/volatility reaction immediately following a macro
+    event. Scans the window [T, T + W] after a macro trigger date.
+    """
+
+    def __init__(self, window_days: int = 3, min_return_pct: float = 1.5) -> None:
+        self.window_days = window_days
+        self.min_return_pct = min_return_pct
+
+    @property
+    def name(self) -> str:
+        return "Post-Macro Shock Trigger"
+
+    # ── Phase 1: SIGNAL ──────────────────────────────────────────────────────
+    def _detect_signals(
+        self,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+        events: List[CandidateEvent],
+    ) -> List[_Signal]:
+        signals: List[_Signal] = []
+        if not events or df_ohlcv.empty:
+            return signals
+
+        df_ohlcv = df_ohlcv.sort_values("trade_date").reset_index(drop=True)
+        trade_dates = pd.to_datetime(df_ohlcv["trade_date"]).dt.date.tolist()
+
+        for ev in events:
+            ev_date = ev.trade_date
+            matching_dates = [d for d in trade_dates if d >= ev_date]
+            if not matching_dates:
+                continue
+
+            trigger_date = matching_dates[0]
+            trig_idx = trade_dates.index(trigger_date)
+            start_idx = trig_idx
+            end_idx = min(len(df_ohlcv) - 1, trig_idx + self.window_days)
+
+            sub_anomaly = df_anomaly.iloc[start_idx:end_idx + 1]
+
+            # Locate the maximum-move date inside the post-event window.
+            anom_indices: List[int] = []
+            if "is_anomaly" in sub_anomaly.columns:
+                anom_indices = sub_anomaly[sub_anomaly["is_anomaly"] == True].index.tolist()  # noqa: E712
+
+            shock_idx = start_idx
+            max_daily_ret = -1.0
+            iter_indices = anom_indices if anom_indices else list(range(start_idx, end_idx + 1))
+            for idx in iter_indices:
+                close_prev = float(df_ohlcv.iloc[idx - 1]["close"]) if idx > 0 else float(df_ohlcv.iloc[idx]["open"])
+                close_curr = float(df_ohlcv.iloc[idx]["close"])
+                daily_ret = (close_curr / close_prev) - 1.0 if close_prev > 0 else 0.0
+                if abs(daily_ret) > max_daily_ret:
+                    max_daily_ret = abs(daily_ret)
+                    shock_idx = idx
+
+            shock_date = pd.to_datetime(df_ohlcv.iloc[shock_idx]["trade_date"]).date()
+
+            close_prev = float(df_ohlcv.iloc[shock_idx - 1]["close"]) if shock_idx > 0 else float(df_ohlcv.iloc[shock_idx]["open"])
+            close_curr = float(df_ohlcv.iloc[shock_idx]["close"])
+            shock_return = (close_curr / close_prev) - 1.0 if close_prev > 0 else 0.0
+
+            # Benchmark return on the shock date
+            bench_return = 0.0
+            if df_benchmark is not None and not df_benchmark.empty:
+                shock_date_val = df_ohlcv.iloc[shock_idx]["trade_date"]
+                df_bench_match = df_benchmark[df_benchmark["trade_date"] == shock_date_val]
+                if not df_bench_match.empty:
+                    bench_idx_list = df_benchmark.index[df_benchmark["trade_date"] == shock_date_val].tolist()
+                    if bench_idx_list:
+                        b_idx = bench_idx_list[0]
+                        b_close_curr = float(df_benchmark.iloc[b_idx]["close"])
+                        b_close_prev = float(df_benchmark.iloc[b_idx - 1]["close"]) if b_idx > 0 else b_close_curr
+                        bench_return = (b_close_curr / b_close_prev) - 1.0 if b_close_prev > 0 else 0.0
+
+            abnormal_return = shock_return - bench_return
+            is_anomaly_day = bool(sub_anomaly.loc[shock_idx, "is_anomaly"]) \
+                if ("is_anomaly" in sub_anomaly.columns and shock_idx in sub_anomaly.index) \
+                else False
+
+            signals.append(_Signal(
+                anomaly_date=shock_date,
+                event=ev,
+                metrics={
+                    "shock_return": shock_return,
+                    "abnormal_return": abnormal_return,
+                    "is_anomaly_day": is_anomaly_day,
+                    "lag_days": int((shock_date - ev_date).days),
+                },
+            ))
+
+        return signals
+
+    # ── Phase 2: EXECUTION ───────────────────────────────────────────────────
+    def _score_signal(
+        self,
+        signal: _Signal,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+    ) -> Optional[CorrelationFinding]:
+        m = signal.metrics
+        shock_return    = m["shock_return"]
+        abnormal_return = m["abnormal_return"]
+        is_anomaly_day  = m["is_anomaly_day"]
+        lag_days        = m["lag_days"]
+
+        move_val = abs(shock_return) * 100.0
+        # Filter: must have meaningful move OR be a flagged anomaly day
+        if not (move_val >= self.min_return_pct or is_anomaly_day):
+            return None
+
+        score = min(100.0, move_val * 25.0)
+        if is_anomaly_day:
+            score = min(100.0, score + 20.0)
+
+        # Lag-weighted decay
+        lag_weight = np.exp(-abs(lag_days) / 2.0)
+        score = score * lag_weight
+
+        # Direction-consistency check for FX events
+        direction_mismatch = False
+        ev = signal.event
+        if ev.event_type == EventType.MACRO_COMMODITY_SHOCK and ev.metadata:
+            fx_pct = float(ev.metadata.get("fx_pct_change", 0.0))
+            if fx_pct != 0.0 and shock_return != 0.0 and (fx_pct * shock_return) > 0:
+                score *= 0.3
+                direction_mismatch = True
+
+        if score < 15.0:
+            return None
+
+        explanation = (
+            f"Anomaly day/shock on {signal.anomaly_date} mapped {lag_days} days after "
+            f"macro event '{ev.label}'. Asset exhibited maximum absolute return "
+            f"deviation of {shock_return*100:+.2f}% with post-event anomaly flag: "
+            f"{is_anomaly_day}."
+        )
+        if direction_mismatch:
+            explanation += (
+                " ⚠️ Direction mismatch: stock and FX moved in the same direction on "
+                "this date, contradicting a negative-beta relationship — this match "
+                "is likely spurious."
+            )
+        if (
+            abs(abnormal_return) >= 0.02
+            and ev.event_type in (EventType.MACRO_RATE_DECISION, EventType.MACRO_GEOPOLITICAL)
+        ):
+            explanation += (
+                " ⚠️ Note: this is a market-adjusted residual return. A large abnormal "
+                "return alongside a broad macro event suggests idiosyncratic "
+                "amplification or model mis-specification — verify company-specific "
+                "catalysts before attributing to the macro trigger."
+            )
+
+        return CorrelationFinding(
+            anomaly_date=signal.anomaly_date,
+            event=ev,
+            strategy_name=self.name,
+            correlation_score=score,
+            lead_lag_days=lag_days,
+            confidence=_confidence_for(score),
+            explanation=explanation,
+            abnormal_return=abnormal_return,
+        )
+
+
+# ── Cross-Asset Co-Movement Strategy ──────────────────────────────────────────
+
+
+class CrossAssetCoMovementStrategy(CorrelationStrategy):
+    """Correlates stock/ETF anomalies with extreme macro currency or commodity
+    daily shocks. Maps co-movements within a window [T - 1, T + 1].
+    """
+
+    @property
+    def name(self) -> str:
+        return "Cross-Asset Co-Movement"
+
+    # ── Phase 1: SIGNAL ──────────────────────────────────────────────────────
+    def _detect_signals(
+        self,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+        events: List[CandidateEvent],
+    ) -> List[_Signal]:
+        signals: List[_Signal] = []
+
+        shocks = [e for e in events if e.event_type == EventType.MACRO_COMMODITY_SHOCK]
+        if not shocks or df_ohlcv.empty:
+            return signals
+
+        df_ohlcv = df_ohlcv.sort_values("trade_date").reset_index(drop=True)
+
+        for ev in shocks:
+            ev_date = ev.trade_date
+            for idx, row in df_anomaly.iterrows():
+                if not row.get("is_anomaly", False):
+                    continue
+
+                anom_date = pd.to_datetime(row["trade_date"]).date()
+                days_diff = (anom_date - ev_date).days
+                if abs(days_diff) > 1:
+                    continue
+
+                # Compute the raw daily return at this anomaly row
+                prev_idx = max(0, idx - 1)
+                prev_close = float(df_ohlcv.iloc[prev_idx]["close"])
+                curr_close = float(df_ohlcv.iloc[idx]["close"])
+                daily_ret = (curr_close / prev_close) - 1.0 if prev_close > 0 else 0.0
+
+                # Benchmark return on the shock date
+                bench_return = 0.0
+                if df_benchmark is not None and not df_benchmark.empty:
+                    anom_date_val = df_ohlcv.iloc[idx]["trade_date"]
+                    df_bench_match = df_benchmark[df_benchmark["trade_date"] == anom_date_val]
+                    if not df_bench_match.empty:
+                        b_idx_list = df_benchmark.index[df_benchmark["trade_date"] == anom_date_val].tolist()
+                        if b_idx_list:
+                            b_idx = b_idx_list[0]
+                            b_close_curr = float(df_benchmark.iloc[b_idx]["close"])
+                            b_close_prev = float(df_benchmark.iloc[b_idx - 1]["close"]) if b_idx > 0 else b_close_curr
+                            bench_return = (b_close_curr / b_close_prev) - 1.0 if b_close_prev > 0 else 0.0
+
+                abnormal_return = daily_ret - bench_return
+                fx_pct = float(ev.metadata.get("fx_pct_change", 0.0)) if ev.metadata else 0.0
+                fx_magnitude = abs(fx_pct)
+
+                signals.append(_Signal(
+                    anomaly_date=anom_date,
+                    event=ev,
+                    metrics={
+                        "days_diff": days_diff,
+                        "daily_ret": daily_ret,
+                        "abnormal_return": abnormal_return,
+                        "fx_pct": fx_pct,
+                        "fx_magnitude": fx_magnitude,
+                    },
+                ))
+
+        return signals
+
+    # ── Phase 2: EXECUTION ───────────────────────────────────────────────────
+    def _score_signal(
+        self,
+        signal: _Signal,
+        df_ohlcv: pd.DataFrame,
+        df_anomaly: pd.DataFrame,
+        df_benchmark: Optional[pd.DataFrame],
+    ) -> Optional[CorrelationFinding]:
+        m = signal.metrics
+        days_diff       = m["days_diff"]
+        daily_ret       = m["daily_ret"]
+        abnormal_return = m["abnormal_return"]
+        fx_pct          = m["fx_pct"]
+        fx_magnitude    = m["fx_magnitude"]
+
+        # Scale base score by FX shock magnitude (cap at 0.015 = ~1.5% USDINR move)
+        magnitude_scale = min(1.0, fx_magnitude / 0.015) if fx_magnitude > 0 else 0.5
+        base_score = 75.0 if days_diff == 0 else 50.0
+        score = base_score * magnitude_scale
+
+        explanation = (
+            f"Price anomaly on {signal.anomaly_date} correlated with extreme asset "
+            f"shock '{signal.event.label}' on {signal.event.trade_date} "
+            f"(lead/lag offset: {days_diff} days)."
+        )
+
+        # Penalise same-direction co-movement (negative-beta violation)
+        if fx_pct != 0.0 and daily_ret != 0.0 and (fx_pct * daily_ret) > 0:
+            score *= 0.3
+            explanation += (
+                " ⚠️ Direction mismatch: stock and FX moved in the same direction on "
+                "this date, contradicting a negative-beta relationship — this match is "
+                "likely spurious."
+            )
+
+        return CorrelationFinding(
+            anomaly_date=signal.anomaly_date,
+            event=signal.event,
+            strategy_name=self.name,
+            correlation_score=score,
+            lead_lag_days=days_diff,
+            confidence=_confidence_for(score),
+            explanation=explanation,
+            abnormal_return=abnormal_return,
+        )

--- a/src/ml/news_rag.py
+++ b/src/ml/news_rag.py
@@ -1,0 +1,15 @@
+"""
+src/ml/news_rag.py — Backward-compatibility re-export stub.
+
+The implementation has moved to src/ml/correlation/news_rag.py.
+This file preserves the old import path:
+    from src.ml.news_rag import embed_text, score_news_quality, ...
+"""
+
+from src.ml.correlation.news_rag import (  # noqa: F401
+    embed_batch,
+    embed_text,
+    retrieve_articles,
+    score_event_relevance,
+    score_news_quality,
+)

--- a/src/scripts/news_rag_backfill.py
+++ b/src/scripts/news_rag_backfill.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""
+src/scripts/news_rag_backfill.py
+────────────────────────────────
+One-shot backfill: embeds all existing news_articles rows that have
+an empty embedding column.
+
+Usage:
+    python src/scripts/news_rag_backfill.py [--batch-size 32] [--dry-run]
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+import time
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+log = logging.getLogger(__name__)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill news article embeddings")
+    parser.add_argument("--batch-size", type=int, default=32, help="Articles per embed batch")
+    parser.add_argument("--dry-run", action="store_true", help="Count only, don't embed")
+    args = parser.parse_args()
+
+    from src.db.pool import query_df, get_pool
+    from src.ml.news_rag import embed_batch
+
+    # Count unembedded rows
+    df_count = query_df(
+        "SELECT count() AS cnt FROM market_data.news_articles FINAL "
+        "WHERE length(embedding) = 0"
+    )
+    total = int(df_count.iloc[0]["cnt"]) if not df_count.empty else 0
+    log.info("Found %d articles without embeddings", total)
+
+    if total == 0:
+        print("✅ All articles already have embeddings.")
+        return
+
+    if args.dry_run:
+        print(f"DRY RUN: Would embed {total} articles in batches of {args.batch_size}")
+        return
+
+    # Process in batches using OFFSET pagination
+    processed = 0
+    batch_size = args.batch_size
+    start_time = time.time()
+
+    while processed < total:
+        # Fetch a batch of unembedded articles
+        df = query_df(
+            "SELECT fetched_at, title, source, url, published_at, "
+            "       source_type, fetch_source, category, etfs_impacted, "
+            "       sentiment, impact_tier "
+            "FROM market_data.news_articles FINAL "
+            "WHERE length(embedding) = 0 "
+            f"LIMIT {batch_size}"
+        )
+        if df.empty:
+            break
+
+        # Build texts for embedding
+        texts = []
+        for _, row in df.iterrows():
+            text = str(row["title"] or "")
+            texts.append(text[:512])
+
+        # Embed batch
+        try:
+            vectors = embed_batch(texts)
+        except Exception as e:
+            log.error("Embedding batch failed: %s", e)
+            break
+
+        # Write back via INSERT (ReplacingMergeTree will deduplicate)
+        with get_pool().acquire() as client:
+            data = []
+            for i, (_, row) in enumerate(df.iterrows()):
+                data.append([
+                    row["fetched_at"],
+                    row["published_at"],
+                    row["source_type"],
+                    row["fetch_source"],
+                    row["category"],
+                    row["etfs_impacted"],
+                    row["sentiment"],
+                    row["impact_tier"],
+                    row["title"],
+                    row["source"],
+                    row["url"],
+                    vectors[i] if i < len(vectors) else [],
+                ])
+            client.insert(
+                "market_data.news_articles",
+                data,
+                column_names=[
+                    "fetched_at", "published_at", "source_type", "fetch_source",
+                    "category", "etfs_impacted", "sentiment", "impact_tier",
+                    "title", "source", "url", "embedding",
+                ],
+            )
+
+        processed += len(df)
+        elapsed = time.time() - start_time
+        rate = processed / elapsed if elapsed > 0 else 0
+        log.info(
+            "Progress: %d/%d (%.0f articles/sec)",
+            processed, total, rate,
+        )
+
+    elapsed = time.time() - start_time
+    print(f"✅ Backfill complete: {processed} articles embedded in {elapsed:.1f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/news_classifier.py
+++ b/src/tools/news_classifier.py
@@ -1,0 +1,224 @@
+"""
+src/tools/news_classifier.py
+─────────────────────────────
+Constrained causal classifier for anomaly-date news.
+
+Instead of asking the LLM to *reason* over raw articles, we ask it to
+*classify* a pre-summarised snippet against an anomaly:
+
+    "Given a {daily_ret}% move in {asset} on {date}, does the article below
+    plausibly drive that move?  Reply YES or NO on line 1, then one short
+    sentence explaining why on line 2."
+
+Why this shape:
+  • Tiny output budget (~30 tokens) → small models stay coherent.
+  • No JSON / no chain-of-thought → no parse failures.
+  • One classification per article → ThreadPoolExecutor-friendly.
+
+Transport reuses the Ollama OpenAI-compatible endpoint already wired into
+`news_filter.py` (settings.news_filter_llm_*).  Fail-open: any HTTP / parse
+error returns ("MAYBE", "[classifier unavailable]") so the rest of the
+report continues to render.
+
+[NON-SENSITIVE] No credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+Verdict = Literal["YES", "NO", "MAYBE"]
+
+
+# ── Prompt ───────────────────────────────────────────────────────────────────
+
+_SYSTEM = (
+    "You are a financial causality classifier. "
+    "Given an anomaly and a news headline+description, decide whether the "
+    "news plausibly drives that price move. "
+    "Reply with exactly two lines:\n"
+    "  Line 1: YES or NO\n"
+    "  Line 2: one short sentence (≤20 words) explaining why.\n"
+    "Do not output anything else."
+)
+
+_USER_TEMPLATE = """Anomaly:
+- Asset: {asset}
+- Date: {date}
+- Daily return: {ret:+.2f}%
+- Regime: {regime}
+
+News:
+- Title: {title}
+- Description: {description}
+
+Does this news plausibly drive a {ret:+.2f}% move in {asset}?"""
+
+
+# ── Transport (Ollama OpenAI-compatible /chat/completions) ──────────────────
+
+def _call_ollama(
+    title: str,
+    description: str,
+    asset: str,
+    date: str,
+    daily_ret: float,
+    regime: str,
+    base_url: str,
+    model: str,
+    timeout: int,
+) -> tuple[Verdict, str]:
+    """Single round-trip to Ollama.  Returns (verdict, reason) or fail-open."""
+    user_msg = _USER_TEMPLATE.format(
+        asset=asset,
+        date=date,
+        ret=daily_ret,
+        regime=regime or "—",
+        title=(title or "")[:200],
+        description=(description or "")[:500],
+    )
+    payload = json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": _SYSTEM},
+                {"role": "user", "content": user_msg},
+            ],
+            "temperature": 0,
+            "max_tokens": 60,
+            "stream": False,
+        }
+    ).encode()
+
+    url = base_url.rstrip("/") + "/chat/completions"
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            data = json.loads(resp.read())
+        content = (
+            data.get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
+            .strip()
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("news_classifier call failed (%s) — defaulting to MAYBE", exc)
+        return "MAYBE", "[classifier unavailable]"
+
+    if not content:
+        return "MAYBE", "[empty response]"
+
+    # Parse: first line = verdict, remainder = reason
+    lines = [ln.strip() for ln in content.splitlines() if ln.strip()]
+    head = lines[0].upper() if lines else ""
+    reason = " ".join(lines[1:])[:200] if len(lines) > 1 else ""
+
+    if head.startswith("YES"):
+        verdict: Verdict = "YES"
+    elif head.startswith("NO"):
+        verdict = "NO"
+    else:
+        verdict = "MAYBE"
+
+    if not reason:
+        # Some small models put the reason on the same line: "YES. Fed pause supports gold."
+        rest = lines[0][len(head):].lstrip(" .:-—") if lines else ""
+        reason = rest[:200] if rest else "[no reason given]"
+
+    return verdict, reason
+
+
+# ── Public API ───────────────────────────────────────────────────────────────
+
+def classify_price_driver(
+    title: str,
+    description: str,
+    *,
+    asset: str,
+    daily_ret_pct: float,
+    date_str: str,
+    regime: str = "",
+) -> tuple[Verdict, str]:
+    """
+    Classify whether a single article plausibly drives an anomaly.
+
+    Args:
+        title:         Article title (truncated to 200 chars before send).
+        description:   Article description (truncated to 500 chars).
+        asset:         Asset label (e.g. "gold", "Nifty Bank", "Reliance Industries").
+        daily_ret_pct: Anomaly daily return as percent (e.g. +2.3 or -5.1).
+        date_str:      Anomaly date, ISO YYYY-MM-DD.
+        regime:        Optional regime label from the anomaly pipeline.
+
+    Returns:
+        (verdict, reason) where verdict ∈ {"YES","NO","MAYBE"} and reason is
+        a ≤200 char single-line explanation.  On any error returns
+        ("MAYBE", "[classifier unavailable]").
+    """
+    # Lazy import to avoid pulling pydantic settings during unit tests that
+    # patch sys.modules["config.settings"].
+    try:
+        from config.settings import settings  # noqa: PLC0415
+        if not settings.news_classifier_enabled:
+            return "MAYBE", "[classifier disabled]"
+        base_url = settings.news_filter_llm_base_url
+        model = settings.news_filter_llm_model
+        timeout = settings.news_filter_llm_timeout
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("news_classifier: settings unavailable (%s)", exc)
+        return "MAYBE", "[classifier unavailable]"
+
+    return _call_ollama(
+        title=title,
+        description=description,
+        asset=asset,
+        date=date_str,
+        daily_ret=float(daily_ret_pct),
+        regime=regime,
+        base_url=base_url,
+        model=model,
+        timeout=timeout,
+    )
+
+
+def classify_articles_batch(
+    articles: list[dict],
+    *,
+    asset: str,
+    daily_ret_pct: float,
+    date_str: str,
+    regime: str = "",
+    max_workers: int = 4,
+) -> list[tuple[Verdict, str]]:
+    """
+    Classify a list of articles in parallel.
+
+    Each input dict must have keys "title" and "description".
+    Returns a list of (verdict, reason) tuples in the same order as inputs.
+    """
+    if not articles:
+        return []
+
+    def _one(art: dict) -> tuple[Verdict, str]:
+        return classify_price_driver(
+            title=art.get("title", "") or "",
+            description=art.get("description", "") or "",
+            asset=asset,
+            daily_ret_pct=daily_ret_pct,
+            date_str=date_str,
+            regime=regime,
+        )
+
+    with ThreadPoolExecutor(max_workers=min(max_workers, len(articles))) as pool:
+        return list(pool.map(_one, articles))

--- a/src/tools/news_filter.py
+++ b/src/tools/news_filter.py
@@ -1,0 +1,563 @@
+"""
+src/tools/news_filter.py
+────────────────────────
+Pre-LLM news relevance filter.
+
+Two-stage pipeline applied upstream inside fetch_news_for_symbol():
+
+  Stage A — Article gate  : drop articles where neither title nor description
+                            contains any term from the symbol's match vocabulary.
+  Stage B — Sentence trim : for kept articles, replace description with only the
+                            sentences that contain a vocabulary match.
+
+Entity engine:
+  Primary  — spaCy en_core_web_sm NER + sentencizer (entity-aware, ~30 MB model).
+  Fallback — compiled regex + naive sentence split (no extra deps required).
+
+No-starvation guarantee: if Stage A would drop every article, the full original
+list is returned with a WARNING so LLM calls are never silently starved.
+
+Vocabulary is built by combining:
+  • Ticker variants (SYMBOL, SYMBOL.NS, SYMBOL.BO, lowercase forms)
+  • Company name tokens (non-stopword tokens ≥ 3 chars)
+  • ETF-category keywords from ETF_NEWS_TOPICS (reused, no duplication)
+  • Macro-theme keywords from MACRO_THEMES for symbols in their impact_map
+
+Install spaCy model once:
+  python -m spacy download en_core_web_sm
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import re
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+# ── spaCy lazy singleton ──────────────────────────────────────────────────────
+# Probing happens at first call; thereafter _NLP_AVAILABLE is set.
+# Thread-safe in CPython (bool assignment is atomic; worst case is a double-probe).
+
+_nlp = None
+_NLP_AVAILABLE: bool | None = None  # None = not yet probed
+
+
+def _get_nlp():
+    """Load spaCy en_core_web_sm once; return None and set fallback flag if unavailable."""
+    global _nlp, _NLP_AVAILABLE
+    if _NLP_AVAILABLE is not None:
+        return _nlp  # already probed — return cached result (possibly None)
+    try:
+        import spacy  # noqa: F401
+
+        _nlp = spacy.load(
+            "en_core_web_sm",
+            # Keep only NER (entity extraction) + tok2vec (required by NER).
+            # Disabling parser/tagger/lemmatizer cuts load time and memory ~60%.
+            disable=["parser", "tagger", "lemmatizer"],
+        )
+        # Sentencizer splits text into sentences; add it only if nothing already does.
+        if "sentencizer" not in _nlp.pipe_names and "senter" not in _nlp.pipe_names:
+            _nlp.add_pipe("sentencizer")
+
+        _NLP_AVAILABLE = True
+        logger.debug("news_filter: spaCy en_core_web_sm loaded OK")
+    except (OSError, ImportError) as exc:
+        logger.info(
+            "news_filter: spaCy unavailable (%s) — using regex/naive-split fallback",
+            exc,
+        )
+        _NLP_AVAILABLE = False
+    return _nlp
+
+
+# ── Vocabulary builder ────────────────────────────────────────────────────────
+
+_COMPANY_STOPWORDS: frozenset[str] = frozenset(
+    {
+        "ltd", "limited", "pvt", "private", "inc", "corp", "corporation",
+        "company", "co", "the", "of", "and", "india", "indian", "group",
+        "holdings", "enterprises", "industries", "technologies", "solutions",
+    }
+)
+
+
+@dataclass
+class MatchVocab:
+    """All terms that constitute a relevance-match for one symbol lookup."""
+
+    # Compiled case-insensitive regex for fast scanning
+    pattern: re.Pattern
+    # Raw term set (for logging / debugging)
+    terms: set[str] = field(default_factory=set)
+
+
+def _etf_category_keywords(symbol: str) -> set[str]:
+    """Return ETF-category keywords for *symbol* by scanning ETF_NEWS_TOPICS."""
+    try:
+        from src.tools.etf_news_scanner import ETF_NEWS_TOPICS  # type: ignore[import]
+
+        symbol_upper = symbol.upper()
+        for topic in ETF_NEWS_TOPICS:
+            if symbol_upper in [e.upper() for e in topic.get("etfs", [])]:
+                kws: set[str] = set()
+                # Yahoo ticker aliases (e.g. "GC=F", "SI=F") — included verbatim
+                kws.update(topic.get("yf_symbols", []))
+                # Extract meaningful tokens from search queries (≥ 5 chars)
+                for query in topic.get("queries", []):
+                    for tok in query.lower().split():
+                        tok_clean = re.sub(r"[^a-z0-9]", "", tok)
+                        if len(tok_clean) >= 5 and tok_clean not in _COMPANY_STOPWORDS:
+                            kws.add(tok_clean)
+                return kws
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("news_filter: ETF_NEWS_TOPICS lookup failed: %s", exc)
+    return set()
+
+
+def _macro_theme_keywords(symbol: str) -> set[str]:
+    """Return macro-theme keywords for symbols that appear in any theme's impact_map."""
+    try:
+        from src.tools.macro_event_scanner import MACRO_THEMES  # type: ignore[import]
+
+        symbol_upper = symbol.upper()
+        kws: set[str] = set()
+        for theme in MACRO_THEMES:
+            if symbol_upper in theme.get("impact_map", {}):
+                kws.update(theme.get("keywords", set()))
+        return kws
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("news_filter: MACRO_THEMES lookup failed: %s", exc)
+    return set()
+
+
+def build_match_vocab(symbol: str, company_name: str = "") -> MatchVocab:
+    """
+    Build a MatchVocab for *symbol* / *company_name* by combining:
+
+    1. Ticker variants: SYMBOL, SYMBOL.NS, SYMBOL.BO, lowercase, strip-stripped.
+    2. Company name tokens (non-stopword, ≥ 3 chars) split on whitespace / hyphens.
+    3. ETF-category keywords if symbol appears in ETF_NEWS_TOPICS[*].etfs.
+    4. Macro-theme keywords if symbol appears in any MACRO_THEMES[*].impact_map.
+    """
+    terms: set[str] = set()
+
+    # 1. Ticker variants
+    sym_upper = symbol.upper().strip()
+    sym_lower = sym_upper.lower()
+    terms.update(
+        {
+            sym_upper,
+            sym_lower,
+            f"{sym_upper}.NS",
+            f"{sym_upper}.BO",
+            sym_upper.replace("-", ""),
+        }
+    )
+
+    # 2. Company name tokens
+    if company_name:
+        for tok in re.split(r"[\s\-/]+", company_name):
+            tok_clean = re.sub(r"[^a-zA-Z0-9]", "", tok).lower()
+            if len(tok_clean) >= 3 and tok_clean not in _COMPANY_STOPWORDS:
+                terms.add(tok_clean)
+
+    # 3. ETF-category keywords
+    terms.update(_etf_category_keywords(symbol))
+
+    # 4. Macro-theme keywords
+    terms.update(_macro_theme_keywords(symbol))
+
+    # Compile: sort longest-first so alternation works correctly for substrings
+    sorted_terms = sorted((t for t in terms if t), key=len, reverse=True)
+    pattern_str = "|".join(re.escape(t) for t in sorted_terms)
+    try:
+        pattern = re.compile(pattern_str, re.IGNORECASE)
+    except re.error:
+        # Degenerate fallback — only the raw symbol
+        pattern = re.compile(re.escape(sym_upper), re.IGNORECASE)
+
+    logger.debug(
+        "news_filter: vocab for %s — %d terms, sample=%s",
+        symbol,
+        len(terms),
+        list(terms)[:8],
+    )
+    return MatchVocab(pattern=pattern, terms=terms)
+
+
+# ── Core filter functions ─────────────────────────────────────────────────────
+
+
+def is_relevant_text(text: str, vocab: MatchVocab) -> bool:
+    """Return True if *text* contains at least one vocabulary term."""
+    if not text:
+        return False
+    return bool(vocab.pattern.search(text))
+
+
+def _split_sentences_regex(text: str) -> list[str]:
+    """Naive sentence splitter (fallback when spaCy is unavailable)."""
+    parts = re.split(r"(?<=[.!?])\s+", text.strip())
+    return [p.strip() for p in parts if p.strip()]
+
+
+def _split_sentences_spacy(text: str, nlp) -> list[str]:
+    """Use spaCy sentencizer to split text into sentences."""
+    doc = nlp(text)
+    return [sent.text.strip() for sent in doc.sents if sent.text.strip()]
+
+
+def extract_relevant_sentences(description: str, vocab: MatchVocab) -> str:
+    """
+    Return only the sentences from *description* that contain a vocabulary match.
+
+    Falls back to the full description if no individual sentence matches (avoids
+    over-trimming very short descriptions where the match spans a phrase boundary).
+    """
+    if not description:
+        return description
+
+    nlp = _get_nlp()
+    sentences = (
+        _split_sentences_spacy(description, nlp)
+        if nlp is not None
+        else _split_sentences_regex(description)
+    )
+
+    matched = [s for s in sentences if is_relevant_text(s, vocab)]
+    if not matched:
+        # The article-gate passed (title or full description matched), but no
+        # individual sentence matched.  Keep the full description rather than
+        # returning an empty string.
+        return description
+
+    return " ".join(matched)
+
+
+# ── Telemetry helper ──────────────────────────────────────────────────────────
+
+
+def _token_proxy(text: str) -> int:
+    """Approximate token count: word-count × 1.3 (accounts for BPE sub-words)."""
+    return int(len(text.split()) * 1.3)
+
+
+# ── Main filter entrypoint ────────────────────────────────────────────────────
+
+
+@dataclass
+class FilterResult:
+    """Result of a filter_articles() call."""
+
+    kept: list  # Kept article objects (NewsItem or dict), descriptions trimmed
+    dropped_count: int
+    tokens_in: int
+    tokens_out: int
+    starvation_fallback: bool = False  # True when no-starvation guard triggered
+
+
+# ── Mistral / Ollama semantic relevance scorer (Stage C) ─────────────────────
+#
+# Calls mistral:7b-instruct (or any Ollama model) via the OpenAI-compatible
+# chat-completions endpoint.  Returns a list of bool — True means "keep".
+#
+# Enabled when settings.news_filter_llm_enabled is True.
+# Runs in parallel (ThreadPoolExecutor) to minimise latency across a batch.
+#
+# Design:  Stage C is a RESCUE + VALIDATION pass.
+#   • Rescue : articles that FAILED Stage A regex (may be semantically relevant)
+#   • Validate: articles that PASSED Stage A regex (may be false positives)
+# Both sets are re-assessed and merged before Stage B sentence trim.
+
+_LLM_SYSTEM_PROMPT = (
+    "You are a financial news relevance classifier. "
+    "Given a symbol and an article, decide whether the article is financially "
+    "relevant to that symbol or its sector/commodity. "
+    "Respond with exactly one word: YES or NO."
+)
+
+_LLM_USER_TEMPLATE = """Symbol: {symbol}
+Context: {context}
+
+Article title: {title}
+Article description: {description}
+
+Is this article financially relevant to {symbol}? Answer YES or NO."""
+
+
+def _build_llm_context(symbol: str, vocab: MatchVocab) -> str:
+    """Human-readable context string summarising what the symbol represents."""
+    sample_terms = sorted(
+        (t for t in vocab.terms if len(t) >= 4 and not t.endswith(".NS") and not t.endswith(".BO")),
+        key=len,
+        reverse=True,
+    )[:10]
+    return ", ".join(sample_terms) if sample_terms else symbol
+
+
+def _llm_is_relevant(
+    title: str,
+    description: str,
+    symbol: str,
+    context: str,
+    base_url: str,
+    model: str,
+    timeout: int,
+) -> bool:
+    """
+    Call the Ollama OpenAI-compatible endpoint and parse YES/NO.
+
+    Returns True (keep) when the model answers YES or when the call fails
+    (fail-open so we don't silently drop articles on Ollama errors).
+    """
+    import json as _json
+    import urllib.request as _urlreq
+
+    text_body = _LLM_USER_TEMPLATE.format(
+        symbol=symbol,
+        context=context,
+        title=(title or "")[:300],
+        description=(description or "")[:500],
+    )
+    payload = _json.dumps(
+        {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": _LLM_SYSTEM_PROMPT},
+                {"role": "user", "content": text_body},
+            ],
+            "temperature": 0,
+            "max_tokens": 5,
+            "stream": False,
+        }
+    ).encode()
+
+    url = base_url.rstrip("/") + "/chat/completions"
+    req = _urlreq.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with _urlreq.urlopen(req, timeout=timeout) as resp:
+            data = _json.loads(resp.read())
+        answer = (
+            data.get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
+            .strip()
+            .upper()
+        )
+        return not answer.startswith("NO")  # YES / anything else = keep
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("news_filter LLM call failed (%s) — keeping article by default", exc)
+        return True  # fail-open
+
+
+def _batch_llm_score(
+    articles: list,
+    symbol: str,
+    vocab: MatchVocab,
+    base_url: str,
+    model: str,
+    timeout: int,
+) -> list[bool]:
+    """
+    Score *articles* in parallel using ThreadPoolExecutor.
+    Returns a list[bool] of the same length — True = keep.
+    """
+    from concurrent.futures import ThreadPoolExecutor, as_completed  # noqa: PLC0415
+
+    context = _build_llm_context(symbol, vocab)
+    results: list[bool] = [True] * len(articles)
+
+    def _score(idx_article):
+        idx, article = idx_article
+        title = (article.get("title") if isinstance(article, dict) else getattr(article, "title", "")) or ""
+        desc = (article.get("description") if isinstance(article, dict) else getattr(article, "description", "")) or ""
+        return idx, _llm_is_relevant(title, desc, symbol, context, base_url, model, timeout)
+
+    with ThreadPoolExecutor(max_workers=min(len(articles), 6)) as pool:
+        futures = {pool.submit(_score, (i, a)): i for i, a in enumerate(articles)}
+        for fut in as_completed(futures):
+            try:
+                idx, keep = fut.result()
+                results[idx] = keep
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("news_filter: LLM future error: %s", exc)
+
+    return results
+
+
+def _article_text(article) -> str:
+    """Combine title + description from a NewsItem (Pydantic) or raw dict."""
+    if isinstance(article, dict):
+        return (article.get("title") or "") + " " + (article.get("description") or "")
+    return (getattr(article, "title", None) or "") + " " + (
+        getattr(article, "description", None) or ""
+    )
+
+
+def _trim_description(article, trimmed_desc: str):
+    """Return a copy of *article* with description replaced by *trimmed_desc*."""
+    if isinstance(article, dict):
+        result = dict(article)
+        result["description"] = trimmed_desc
+        return result
+    # Pydantic v2
+    try:
+        return article.model_copy(update={"description": trimmed_desc})
+    except AttributeError:
+        pass
+    # Pydantic v1
+    try:
+        return article.copy(update={"description": trimmed_desc})
+    except AttributeError:
+        pass
+    # Plain dataclass / named tuple — shallow copy + attribute set
+    dup = copy.copy(article)
+    dup.description = trimmed_desc
+    return dup
+
+
+def filter_articles(
+    articles: list,
+    vocab: MatchVocab,
+    symbol: str = "",
+) -> FilterResult:
+    """
+    Apply the three-stage pre-LLM relevance filter to *articles*.
+
+    Stage A — Regex/spaCy article gate:
+        Drop articles where neither title nor description contains any term from
+        *vocab*.  This eliminates wholly off-topic articles cheaply.
+
+    Stage C — Mistral/Ollama semantic correlation (optional, off by default):
+        When settings.news_filter_llm_enabled is True, runs two passes in parallel:
+          • Rescue : articles that FAILED Stage A are re-scored — catches semantically
+                     relevant articles that lack explicit keywords (e.g. "Fed pauses
+                     rate hikes" for GOLDBEES because gold correlates with real yields).
+          • Validate: articles that PASSED Stage A are re-scored — drops false positives
+                     (e.g. "Nifty 50 outlook" that mentioned gold in passing).
+        Both passes merge and replace the Stage A output.
+
+    Stage B — Sentence trim:
+        For each kept article, replace description with only the sentences that
+        contain a vocabulary match, reducing irrelevant context passed to the LLM.
+
+    No-starvation:
+        If after all stages no article survives, return the originals unchanged
+        (with a WARNING log) so downstream LLM calls are never silently starved.
+
+    Returns a FilterResult with the kept (and trimmed) articles plus telemetry.
+    """
+    from config.settings import settings  # noqa: PLC0415 — avoid circular at module load
+
+    if not articles:
+        return FilterResult(kept=[], dropped_count=0, tokens_in=0, tokens_out=0)
+
+    # Measure input tokens
+    tokens_in = sum(_token_proxy(_article_text(a)) for a in articles)
+
+    # --- Stage A: regex / spaCy article gate ------------------------------------
+    regex_passed = [a for a in articles if is_relevant_text(_article_text(a), vocab)]
+    regex_failed = [a for a in articles if not is_relevant_text(_article_text(a), vocab)]
+
+    # --- Stage C: Mistral / Ollama semantic correlation pass --------------------
+    if settings.news_filter_llm_enabled and articles:
+        try:
+            llm_url = settings.news_filter_llm_base_url
+            llm_model = settings.news_filter_llm_model
+            llm_timeout = settings.news_filter_llm_timeout
+
+            # Rescue: score articles that the regex gate dropped
+            if regex_failed:
+                rescue_scores = _batch_llm_score(
+                    regex_failed, symbol, vocab, llm_url, llm_model, llm_timeout
+                )
+                rescued = [a for a, keep in zip(regex_failed, rescue_scores) if keep]
+                if rescued:
+                    logger.info(
+                        "news_filter LLM rescue: symbol=%s rescued %d/%d regex-dropped articles",
+                        symbol or "?", len(rescued), len(regex_failed),
+                    )
+            else:
+                rescued = []
+
+            # Validate: re-score articles that the regex gate kept (remove false positives)
+            if regex_passed:
+                validate_scores = _batch_llm_score(
+                    regex_passed, symbol, vocab, llm_url, llm_model, llm_timeout
+                )
+                validated = [a for a, keep in zip(regex_passed, validate_scores) if keep]
+                fp_dropped = len(regex_passed) - len(validated)
+                if fp_dropped:
+                    logger.info(
+                        "news_filter LLM validate: symbol=%s dropped %d false-positive articles",
+                        symbol or "?", fp_dropped,
+                    )
+            else:
+                validated = []
+
+            kept_a = validated + rescued
+            dropped = len(articles) - len(kept_a)
+
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "news_filter: Stage C (LLM) failed (%s) — falling back to regex gate output",
+                exc,
+            )
+            kept_a = regex_passed
+            dropped = len(regex_failed)
+    else:
+        kept_a = regex_passed
+        dropped = len(regex_failed)
+
+    # No-starvation guard
+    starvation_fallback = False
+    if not kept_a:
+        logger.warning(
+            "news_filter: all %d articles dropped for symbol=%s — "
+            "returning originals (vocab may be too strict or symbol unrecognised)",
+            len(articles),
+            symbol or "?",
+        )
+        kept_a = list(articles)
+        starvation_fallback = True
+
+    # --- Stage B: sentence trim --------------------------------------------------
+    kept_b: list = []
+    for article in kept_a:
+        if isinstance(article, dict):
+            raw_desc = article.get("description") or ""
+        else:
+            raw_desc = getattr(article, "description", None) or ""
+
+        trimmed_desc = extract_relevant_sentences(raw_desc, vocab) if raw_desc else raw_desc
+        kept_b.append(_trim_description(article, trimmed_desc))
+
+    # Measure output tokens
+    tokens_out = sum(_token_proxy(_article_text(a)) for a in kept_b)
+    reduction = int((1 - tokens_out / max(tokens_in, 1)) * 100)
+
+    logger.info(
+        "news_filter: symbol=%s kept=%d/%d tokens_in=%d tokens_out=%d reduction=%d%%",
+        symbol or "?",
+        len(kept_b),
+        len(articles),
+        tokens_in,
+        tokens_out,
+        reduction,
+    )
+
+    return FilterResult(
+        kept=kept_b,
+        dropped_count=dropped,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        starvation_fallback=starvation_fallback,
+    )

--- a/src/utils/api_sanitizer.py
+++ b/src/utils/api_sanitizer.py
@@ -1,0 +1,129 @@
+"""
+src/utils/api_sanitizer.py
+───────────────────────────
+Shared prompt-injection protection and field validation for external API
+responses.
+
+All functions return a safe value or ``None`` / ``"[SANITIZED]"`` when
+validation fails, so that adversarially crafted API payloads cannot inject
+instructions into the LLM pipeline or corrupt downstream numeric outputs.
+
+Previously these four validators were private functions duplicated inside
+``src/tools/comex_fetcher.py`` and inlined in ``src/tools/goldhub_intelligence.py``.
+
+[SECURITY] This module is security-critical — do not relax the patterns.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Patterns that indicate an adversarially crafted payload attempting prompt
+# injection.  Checked against any free-text string field from external APIs.
+_INJECTION_PATTERNS = re.compile(
+    r"ignore\s+(previous|above|all)\s+instruction"
+    r"|system\s*:"
+    r"|you\s+are\s+(now|a|an)\s"
+    r"|<\s*/?instructions?\s*>"
+    r"|\bprompt\b.*\binjection\b"
+    r"|\bact\s+as\b"
+    r"|\bdisregard\b",
+    re.IGNORECASE,
+)
+
+
+def safe_str(
+    value: object,
+    max_len: int = 50,
+    field_name: str = "field",
+) -> str:
+    """
+    Validate and sanitise a string field from an external API response.
+
+    - Casts to str, strips whitespace.
+    - Rejects values longer than *max_len* (returns ``"[SANITIZED]"``).
+    - Rejects values matching injection patterns (returns ``"[SANITIZED]"``).
+    - Strips ASCII control characters (0x00–0x1F, 0x7F) except tab/newline.
+
+    Returns a safe string guaranteed not to contain prompt-injection payloads.
+    """
+    raw = str(value).strip()
+    if len(raw) > max_len:
+        logger.warning(
+            "[SECURITY] %s field too long (%d chars) — sanitising", field_name, len(raw)
+        )
+        return "[SANITIZED]"
+    if _INJECTION_PATTERNS.search(raw):
+        logger.warning(
+            "[SECURITY] Prompt-injection pattern detected in %s field — sanitising",
+            field_name,
+        )
+        return "[SANITIZED]"
+    # Remove ASCII control characters (0x00–0x08, 0x0b–0x1f, 0x7f) but keep tab/newline
+    return re.sub(r"[\x00-\x08\x0b-\x1f\x7f]", "", raw)
+
+
+def safe_price(value: object, field_name: str = "price") -> Optional[float]:
+    """
+    Validate a numeric price field from an external API response.
+
+    Returns ``None`` and logs a warning for any non-positive or non-numeric value.
+    """
+    try:
+        price = float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        logger.warning("[SECURITY] Non-numeric %s value: %r — ignoring", field_name, value)
+        return None
+    if price <= 0:
+        logger.warning("[SECURITY] Non-positive %s value: %r — ignoring", field_name, value)
+        return None
+    return round(price, 6)
+
+
+def safe_symbol_from_whitelist(
+    value: object,
+    whitelist: set[str],
+    field_name: str = "symbol",
+) -> Optional[str]:
+    """
+    Validate that a symbol from an API response is in a known *whitelist*.
+
+    This prevents the API from injecting unknown symbols into the pipeline.
+
+    Args:
+        value:     Raw symbol value from the API.
+        whitelist: Set of accepted symbol strings (compared after upper-casing).
+        field_name: Label used in warning log messages.
+
+    Returns:
+        The upper-cased symbol string, or ``None`` if not in *whitelist*.
+    """
+    raw = str(value).strip().upper()
+    if raw not in whitelist:
+        logger.warning("[SECURITY] Unknown %s from API: %r — ignoring", field_name, raw)
+        return None
+    return raw
+
+
+def safe_timestamp(value: object) -> Optional[str]:
+    """
+    Validate an ISO-8601 UTC timestamp string.
+
+    Parses the value and converts to an IST-formatted string
+    (``YYYY-MM-DD HH:MM:SS IST``).  Returns ``None`` if unparseable.
+    """
+    try:
+        dt_str = str(value).strip()
+        if dt_str.endswith("Z"):
+            dt_str = dt_str[:-1] + "+00:00"
+        dt = datetime.fromisoformat(dt_str)
+        from src.utils.ist import utc_to_ist
+        return utc_to_ist(dt).strftime("%Y-%m-%d %H:%M:%S IST")
+    except (TypeError, ValueError) as exc:
+        logger.debug("[SECURITY] Invalid timestamp %r: %s", value, exc)
+        return None

--- a/src/utils/http_client.py
+++ b/src/utils/http_client.py
@@ -1,0 +1,132 @@
+"""
+src/utils/http_client.py
+─────────────────────────
+Minimal HTTP helper with retry logic for JSON/text API calls.
+
+Centralises timeout, retry, and error-logging patterns that were previously
+inlined independently in comex_fetcher.py, goldhub_intelligence.py, and
+quant_scorecard.py.
+
+Usage
+-----
+    from src.utils.http_client import fetch_json, fetch_text
+
+    data = fetch_json("https://api.example.com/data", params={"q": "gold"})
+    if data is None:
+        # request failed (already logged)
+        ...
+
+[SECURITY] Response bodies are returned as-is; callers must validate
+           individual fields via ``src.utils.api_sanitizer`` before use.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT   = 15   # seconds
+_DEFAULT_RETRIES   = 2
+_RETRY_BACKOFF_SEC = 1.0
+
+_DEFAULT_HEADERS: dict[str, str] = {
+    "User-Agent": (
+        "Mozilla/5.0 (compatible; MosaicBot/1.0; "
+        "+https://github.com/mosaic-agent)"
+    ),
+    "Accept": "application/json",
+}
+
+
+def fetch_json(
+    url: str,
+    *,
+    params: Optional[dict[str, Any]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: int = _DEFAULT_TIMEOUT,
+    retries: int = _DEFAULT_RETRIES,
+) -> Optional[dict | list]:
+    """
+    Fetch a URL and parse the response body as JSON.
+
+    Args:
+        url:     Target URL.
+        params:  Optional query-string parameters.
+        headers: Optional extra HTTP headers (merged with defaults).
+        timeout: Per-attempt timeout in seconds.
+        retries: Number of additional retry attempts on failure.
+
+    Returns:
+        Parsed JSON (``dict`` or ``list``), or ``None`` on error.
+    """
+    merged_headers = {**_DEFAULT_HEADERS, **(headers or {})}
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.get(
+                url,
+                params=params,
+                headers=merged_headers,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            last_exc = exc
+            if attempt < retries:
+                logger.debug(
+                    "fetch_json: attempt %d/%d failed for %s — %s; retrying in %.1fs",
+                    attempt + 1, retries + 1, url, exc, _RETRY_BACKOFF_SEC,
+                )
+                time.sleep(_RETRY_BACKOFF_SEC)
+
+    logger.warning("fetch_json: all %d attempts failed for %s — %s", retries + 1, url, last_exc)
+    return None
+
+
+def fetch_text(
+    url: str,
+    *,
+    params: Optional[dict[str, Any]] = None,
+    headers: Optional[dict[str, str]] = None,
+    timeout: int = _DEFAULT_TIMEOUT,
+    retries: int = _DEFAULT_RETRIES,
+) -> Optional[str]:
+    """
+    Fetch a URL and return the raw response text.
+
+    Useful for CSV or HTML endpoints where JSON parsing is not appropriate.
+
+    Returns:
+        Response body as a string, or ``None`` on error.
+    """
+    merged_headers = {**_DEFAULT_HEADERS, **(headers or {})}
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(retries + 1):
+        try:
+            resp = requests.get(
+                url,
+                params=params,
+                headers=merged_headers,
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            return resp.text
+        except Exception as exc:
+            last_exc = exc
+            if attempt < retries:
+                logger.debug(
+                    "fetch_text: attempt %d/%d failed for %s — %s; retrying in %.1fs",
+                    attempt + 1, retries + 1, url, exc, _RETRY_BACKOFF_SEC,
+                )
+                time.sleep(_RETRY_BACKOFF_SEC)
+
+    logger.warning("fetch_text: all %d attempts failed for %s — %s", retries + 1, url, last_exc)
+    return None

--- a/src/utils/matplotlib_theme.py
+++ b/src/utils/matplotlib_theme.py
@@ -1,0 +1,74 @@
+"""
+src/utils/matplotlib_theme.py
+──────────────────────────────
+Shared matplotlib dark-theme helpers.
+
+Previously duplicated as ``_style_axes`` + ``_df_to_png`` in:
+  • src/tools/report_publisher.py
+  • src/tools/visualization/correlation_chart.py
+  • src/tools/chart_tools.py  (partial)
+
+Usage
+-----
+    from src.utils.matplotlib_theme import apply_dark_theme, fig_to_png_b64
+
+    fig, ax = plt.subplots()
+    apply_dark_theme(ax)
+    b64 = fig_to_png_b64(fig)
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+
+# Default dark-background colour used across all Mosaic charts.
+DARK_BG        = "#1a1a2e"
+DARK_BG_DEEP   = "#0d0d1a"   # slightly darker variant used in correlation charts
+TICK_COLOR     = "#cccccc"
+SPINE_COLOR    = "#333355"
+LABEL_COLOR    = "#cccccc"
+TITLE_COLOR    = "#e0e0ff"
+GRID_COLOR     = "#333355"
+DEFAULT_DPI    = 150
+
+
+def apply_dark_theme(ax, bg: str = DARK_BG) -> None:
+    """
+    Apply consistent dark-theme styling to a matplotlib ``Axes`` object.
+
+    Args:
+        ax: ``matplotlib.axes.Axes`` to style.
+        bg: Background hex colour.  Defaults to :data:`DARK_BG`.
+    """
+    ax.set_facecolor(bg)
+    ax.tick_params(colors=TICK_COLOR, labelsize=8)
+    for spine in ax.spines.values():
+        spine.set_edgecolor(SPINE_COLOR)
+    ax.yaxis.label.set_color(LABEL_COLOR)
+    ax.xaxis.label.set_color(LABEL_COLOR)
+    ax.title.set_color(TITLE_COLOR)
+    ax.grid(color=GRID_COLOR, linewidth=0.4, alpha=0.6)
+
+
+def fig_to_png_b64(fig, dpi: int = DEFAULT_DPI) -> str:
+    """
+    Serialize a matplotlib ``Figure`` to a base64-encoded PNG string.
+
+    Args:
+        fig: ``matplotlib.figure.Figure`` to serialize.
+        dpi: Output resolution.  Defaults to :data:`DEFAULT_DPI`.
+
+    Returns:
+        Base64-encoded PNG string (UTF-8).
+    """
+    buf = io.BytesIO()
+    fig.savefig(
+        buf,
+        format="png",
+        dpi=dpi,
+        bbox_inches="tight",
+        facecolor=fig.get_facecolor(),
+    )
+    buf.seek(0)
+    return base64.b64encode(buf.read()).decode()

--- a/src/utils/sentiment.py
+++ b/src/utils/sentiment.py
@@ -1,0 +1,60 @@
+"""
+src/utils/sentiment.py
+──────────────────────
+Shared rule-based sentiment inference used across news tools.
+
+Sentiment is determined by keyword hit counts:
+  positive hits > negative → POSITIVE / BULLISH
+  negative hits > positive → NEGATIVE / BEARISH
+  tied or no signal        → NEUTRAL
+
+Single source of truth for `_POSITIVE_WORDS`, `_NEGATIVE_WORDS`, and
+`infer_sentiment()`.  Previously duplicated across news_search.py,
+etf_news_scanner.py, and macro_event_scanner.py.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.models.portfolio import Sentiment
+
+_POSITIVE_WORDS: frozenset[str] = frozenset({
+    "surge", "rally", "gain", "profit", "record", "growth", "beat",
+    "strong", "upgrade", "buy", "bullish", "outperform", "dividend",
+    "expansion", "robust", "soar", "rise", "high", "positive", "boom",
+})
+
+_NEGATIVE_WORDS: frozenset[str] = frozenset({
+    "fall", "drop", "loss", "crash", "decline", "miss", "weak", "sell",
+    "bearish", "underperform", "cut", "downgrade", "risk", "concern",
+    "fraud", "penalty", "regulatory", "debt", "pressure", "plunge",
+    "slowdown", "warning", "default", "lawsuit",
+})
+
+
+def infer_sentiment(text: str) -> "Sentiment":
+    """
+    Rule-based sentiment from article title + description.
+
+    Scores positive and negative keyword hits and returns the dominant
+    ``Sentiment`` enum value from ``src.models.portfolio``.
+
+    Args:
+        text: Raw article title + description concatenated.
+
+    Returns:
+        ``Sentiment.POSITIVE``, ``Sentiment.NEGATIVE``, or ``Sentiment.NEUTRAL``.
+    """
+    from src.models.portfolio import Sentiment
+
+    words = set(text.lower().split())
+    pos_hits = len(words & _POSITIVE_WORDS)
+    neg_hits = len(words & _NEGATIVE_WORDS)
+
+    if pos_hits > neg_hits:
+        return Sentiment.POSITIVE
+    if neg_hits > pos_hits:
+        return Sentiment.NEGATIVE
+    return Sentiment.NEUTRAL

--- a/tests/test_news_filter.py
+++ b/tests/test_news_filter.py
@@ -1,0 +1,224 @@
+"""
+tests/test_news_filter.py
+──────────────────────────
+Unit tests for src/tools/news_filter.py
+
+Six scenarios:
+  1. Symbol match  — keep on-symbol article, drop unrelated article.
+  2. Commodity match — keep gold article for GOLDBEES, drop IT noise.
+  3. Sentence extraction — only matching sentence survives description trim.
+  4. spaCy-absent fallback — filter still works via regex when _NLP_AVAILABLE=False.
+  5. No-starvation safety — all-drop returns originals with starvation_fallback=True.
+  6. Mistral/Ollama Stage C rescue — articles failed regex but answered YES by LLM
+     are rescued; articles answered NO by LLM are dropped (mocked HTTP).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.models.portfolio import NewsItem, Sentiment
+
+
+# ── Helper ────────────────────────────────────────────────────────────────────
+
+
+def _item(title: str, description: str = "") -> NewsItem:
+    """Construct a minimal NewsItem for testing."""
+    return NewsItem(title=title, description=description, sentiment=Sentiment.NEUTRAL)
+
+
+# ── Test 1: symbol match ──────────────────────────────────────────────────────
+
+
+def test_symbol_match_keeps_and_drops():
+    """Article containing the stock symbol is kept; unrelated article is dropped."""
+    from src.tools.news_filter import build_match_vocab, filter_articles
+
+    vocab = build_match_vocab("RELIANCE", "Reliance Industries")
+    articles = [
+        _item(
+            "RELIANCE Industries Q3 results beat estimates",
+            "Net profit surges for Reliance on strong retail growth.",
+        ),
+        _item(
+            "HDFC Bank raises deposit rates",
+            "Banking sector sees renewed interest as deposit rates climb.",
+        ),
+    ]
+    result = filter_articles(articles, vocab, symbol="RELIANCE")
+
+    assert len(result.kept) == 1, "Only the RELIANCE article should survive the gate"
+    assert "RELIANCE" in result.kept[0].title or "Reliance" in result.kept[0].title
+    assert result.dropped_count == 1
+    assert result.tokens_out < result.tokens_in
+
+
+# ── Test 2: commodity match (ETF category keywords) ───────────────────────────
+
+
+def test_commodity_match_keeps_gold_article():
+    """
+    Gold-related article should pass the GOLDBEES gate via ETF-category keywords
+    (gold, xau, bullion, central bank, etc.) even without the ticker in the title.
+    """
+    from src.tools.news_filter import build_match_vocab, filter_articles
+
+    vocab = build_match_vocab("GOLDBEES")
+    articles = [
+        _item(
+            "Fed rate cut sends gold to record high",
+            "Gold prices surged after the Federal Reserve signalled a pause.",
+        ),
+        _item(
+            "Nifty IT index outlook positive for Q4",
+            "TCS and Infosys results are expected next week.",
+        ),
+    ]
+    result = filter_articles(articles, vocab, symbol="GOLDBEES")
+
+    kept_titles = [a.title.lower() for a in result.kept]
+    assert any("gold" in t for t in kept_titles), "Gold article must be kept for GOLDBEES"
+
+
+# ── Test 3: sentence extraction ───────────────────────────────────────────────
+
+
+def test_sentence_extraction_removes_irrelevant_sentences():
+    """
+    Only the sentence mentioning the stock should survive the description trim.
+    """
+    from src.tools.news_filter import build_match_vocab, extract_relevant_sentences
+
+    vocab = build_match_vocab("INFY", "Infosys")
+    description = (
+        "Global markets ended mixed on Thursday. "
+        "Infosys reported a 12% rise in net profit for Q3 FY26. "
+        "Analysts remain cautious on broader consumer spending."
+    )
+    trimmed = extract_relevant_sentences(description, vocab)
+
+    assert "Infosys" in trimmed or "INFY" in trimmed.upper(), "Infosys sentence must be kept"
+    assert "Global markets" not in trimmed, "Off-topic sentence must be removed"
+
+
+# ── Test 4: spaCy-absent fallback ─────────────────────────────────────────────
+
+
+def test_regex_fallback_when_spacy_unavailable(monkeypatch):
+    """
+    When spaCy is not available (_NLP_AVAILABLE=False), the regex path must
+    still filter correctly — no exceptions, valid FilterResult returned.
+    """
+    import src.tools.news_filter as nf
+
+    monkeypatch.setattr(nf, "_NLP_AVAILABLE", False)
+    monkeypatch.setattr(nf, "_nlp", None)
+
+    from src.tools.news_filter import build_match_vocab, filter_articles
+
+    vocab = build_match_vocab("WIPRO", "Wipro")
+    articles = [
+        _item("Wipro wins $200m deal from US bank", "Wipro expanded its US client base significantly."),
+        _item("OPEC cuts oil production by 1 mb/d", "Crude prices rose on the supply cut announcement."),
+    ]
+    result = filter_articles(articles, vocab, symbol="WIPRO")
+
+    assert not result.starvation_fallback, "Wipro article should pass the gate"
+    assert len(result.kept) >= 1
+    assert any("Wipro" in a.title for a in result.kept)
+
+
+# ── Test 5: no-starvation safety ─────────────────────────────────────────────
+
+
+def test_no_starvation_returns_originals():
+    """
+    When no article matches the vocabulary, all originals are returned with
+    starvation_fallback=True so the LLM is never silently starved.
+    """
+    from src.tools.news_filter import build_match_vocab, filter_articles
+
+    # Deliberately obscure symbol that will never appear in any article text
+    vocab = build_match_vocab("ZZZNOMATCH9999")
+    articles = [
+        _item("General market commentary today", "Markets were volatile across sectors."),
+        _item("Another generic story", "Analysts debated monetary policy outlook."),
+    ]
+    result = filter_articles(articles, vocab, symbol="ZZZNOMATCH9999")
+
+    assert result.starvation_fallback, "Starvation fallback must trigger"
+    assert len(result.kept) == len(articles), "All originals must be returned"
+
+
+# ── Test 6: Mistral/Ollama Stage C — rescue + validate ───────────────────────
+
+
+def test_mistral_stage_c_rescue_and_validate(monkeypatch):
+    """
+    Stage C (Mistral/Ollama):
+    • An article that FAILED the regex gate but is answered YES by Ollama is rescued.
+    • An article that PASSED the regex gate but is answered NO by Ollama is dropped.
+
+    Ollama HTTP calls are mocked — no live Ollama needed.
+    """
+    import json
+    import src.tools.news_filter as nf
+    from src.tools.news_filter import build_match_vocab, filter_articles
+
+    # --- Mock Ollama responses ---------------------------------------------------
+    # We'll track call order: first call → YES (rescue), second call → NO (drop)
+    call_count = {"n": 0}
+
+    def mock_llm_is_relevant(title, description, symbol, context, base_url, model, timeout):
+        call_count["n"] += 1
+        # Rescue call (for the failed article): answer YES
+        if "Fed pauses" in title:
+            return True
+        # Validate call (for the regex-passed article): answer NO
+        if "General mention" in title:
+            return False
+        return True  # default keep
+
+    monkeypatch.setattr(nf, "_llm_is_relevant", mock_llm_is_relevant)
+
+    # Patch settings to enable Stage C
+    import config.settings as cfg_mod
+
+    class FakeSettings:
+        news_filter_llm_enabled = True
+        news_filter_llm_base_url = "http://localhost:11434/v1"
+        news_filter_llm_model = "mistral:7b-instruct"
+        news_filter_llm_timeout = 8
+
+    monkeypatch.setattr(nf, "settings", FakeSettings(), raising=False)
+    # Patch the settings import inside filter_articles
+    import sys
+    fake_settings_module = type(sys)("config.settings")
+    fake_settings_module.settings = FakeSettings()
+    monkeypatch.setitem(sys.modules, "config.settings", fake_settings_module)
+
+    vocab = build_match_vocab("GOLDBEES")
+
+    articles = [
+        # This article FAILS the regex gate (no gold keyword) but LLM says YES → rescued
+        _item(
+            "Fed pauses rate hikes as inflation moderates",
+            "The Federal Reserve held rates steady, real yields fell sharply.",
+        ),
+        # This article PASSES the regex gate (mentions gold) but LLM says NO → dropped
+        _item(
+            "General mention of gold in a broader commodities roundup",
+            "Analysts reviewed oil, gold, and copper prices last week.",
+        ),
+    ]
+
+    result = filter_articles(articles, vocab, symbol="GOLDBEES")
+
+    kept_titles = [
+        (a.get("title") if isinstance(a, dict) else a.title)
+        for a in result.kept
+    ]
+    assert any("Fed pauses" in t for t in kept_titles), "LLM-rescued article must be in kept"
+    assert not any("General mention" in t for t in kept_titles), "LLM-dropped false positive must be absent"
+

--- a/tests/test_news_rag.py
+++ b/tests/test_news_rag.py
@@ -1,0 +1,159 @@
+"""
+tests/test_news_rag.py
+──────────────────────
+Unit tests for the RAG-based news quality scoring and retrieval module.
+"""
+import json
+from datetime import date
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+
+# ── Scoring tests ─────────────────────────────────────────────────────────────
+
+
+class TestScoreNewsQuality:
+    """Test the exemplar-based semantic quality scorer."""
+
+    def test_earnings_headline_scores_high(self):
+        from src.ml.news_rag import score_news_quality
+        score = score_news_quality("Q3 earnings beat estimates by 20%")
+        assert score >= 0.80, f"Earnings headline should score ≥0.80, got {score:.3f}"
+
+    def test_gold_crash_headline_scores_medium_high(self):
+        from src.ml.news_rag import score_news_quality
+        score = score_news_quality("Gold ETFs crash 15% as precious metals tumble")
+        assert score >= 0.60, f"Gold crash headline should score ≥0.60, got {score:.3f}"
+
+    def test_clickbait_scores_low(self):
+        from src.ml.news_rag import score_news_quality
+        score = score_news_quality("5 stocks that could give 20% returns in 3 months")
+        assert score <= 0.50, f"Clickbait should score ≤0.50, got {score:.3f}"
+
+    def test_blog_scores_very_low(self):
+        from src.ml.news_rag import score_news_quality
+        score = score_news_quality("random blog post about penny stock predictions")
+        assert score <= 0.15, f"Blog/penny stock should score ≤0.15, got {score:.3f}"
+
+    def test_empty_string_scores_zero(self):
+        from src.ml.news_rag import score_news_quality
+        assert score_news_quality("") == 0.0
+        assert score_news_quality("   ") == 0.0
+
+    def test_score_in_valid_range(self):
+        from src.ml.news_rag import score_news_quality
+        headlines = [
+            "Company reports strong quarterly results",
+            "Market outlook remains uncertain",
+            "New product launch announcement",
+        ]
+        for h in headlines:
+            s = score_news_quality(h)
+            assert 0.0 <= s <= 1.0, f"Score {s} out of range for: {h}"
+
+    def test_material_news_beats_generic(self):
+        from src.ml.news_rag import score_news_quality
+        material = score_news_quality("RBI cuts repo rate by 25 basis points")
+        generic = score_news_quality("markets closed mixed on low volumes")
+        assert material > generic, (
+            f"Material news ({material:.3f}) should score higher than generic ({generic:.3f})"
+        )
+
+
+# ── Embedding tests ───────────────────────────────────────────────────────────
+
+
+class TestEmbedText:
+    """Test the embedding primitive."""
+
+    def test_returns_correct_dimension(self):
+        from src.ml.news_rag import embed_text
+        vec = embed_text("test sentence")
+        assert len(vec) == 768
+
+    def test_empty_string_returns_zeros(self):
+        from src.ml.news_rag import embed_text
+        vec = embed_text("")
+        assert all(v == 0.0 for v in vec)
+
+    def test_similar_texts_have_high_cosine(self):
+        from src.ml.news_rag import embed_text
+        v1 = np.array(embed_text("gold prices surge on safe haven demand"))
+        v2 = np.array(embed_text("gold rallies as investors seek safety"))
+        sim = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+        assert sim > 0.7, f"Similar texts should have cosine > 0.7, got {sim:.3f}"
+
+    def test_dissimilar_texts_have_lower_cosine(self):
+        from src.ml.news_rag import embed_text
+        v1 = np.array(embed_text("gold prices surge on safe haven demand"))
+        v2 = np.array(embed_text("python programming tutorial for beginners"))
+        sim = np.dot(v1, v2) / (np.linalg.norm(v1) * np.linalg.norm(v2))
+        assert sim < 0.5, f"Dissimilar texts should have cosine < 0.5, got {sim:.3f}"
+
+
+# ── Retrieval tests ───────────────────────────────────────────────────────────
+
+
+class TestRetrieveArticles:
+    """Test semantic retrieval from ClickHouse."""
+
+    def test_retrieval_returns_list(self):
+        from src.ml.news_rag import retrieve_articles
+        results = retrieve_articles("gold ETF price", around_date=date.today(), days=30, k=5)
+        assert isinstance(results, list)
+
+    def test_results_sorted_by_similarity(self):
+        from src.ml.news_rag import retrieve_articles
+        results = retrieve_articles("gold price India", around_date=date.today(), days=30, k=10)
+        if len(results) >= 2:
+            sims = [r["similarity"] for r in results]
+            assert sims == sorted(sims, reverse=True), "Results should be sorted by descending similarity"
+
+    def test_results_have_required_keys(self):
+        from src.ml.news_rag import retrieve_articles
+        results = retrieve_articles("gold ETF", around_date=date.today(), days=30, k=3)
+        required_keys = {"title", "source", "url", "published_at", "category", "sentiment", "similarity"}
+        for r in results:
+            assert required_keys.issubset(r.keys()), f"Missing keys: {required_keys - r.keys()}"
+
+    def test_empty_query_returns_empty(self):
+        from src.ml.news_rag import retrieve_articles
+        results = retrieve_articles("", around_date=date.today(), days=7, k=5)
+        assert results == []
+
+
+# ── Exemplars file tests ──────────────────────────────────────────────────────
+
+
+class TestExemplarsFile:
+    """Validate the exemplars JSON file structure."""
+
+    def test_exemplars_file_exists(self):
+        path = Path(__file__).parent.parent / "data" / "news_quality_exemplars.json"
+        assert path.exists(), f"Exemplars file not found at {path}"
+
+    def test_exemplars_structure(self):
+        path = Path(__file__).parent.parent / "data" / "news_quality_exemplars.json"
+        data = json.loads(path.read_text())
+        assert isinstance(data, list)
+        assert len(data) >= 40, f"Need at least 40 exemplars, got {len(data)}"
+        for item in data:
+            assert "text" in item, "Each exemplar must have 'text'"
+            assert "weight" in item, "Each exemplar must have 'weight'"
+            assert 0.0 <= item["weight"] <= 1.0, f"Weight {item['weight']} out of range"
+
+    def test_exemplars_cover_full_spectrum(self):
+        path = Path(__file__).parent.parent / "data" / "news_quality_exemplars.json"
+        data = json.loads(path.read_text())
+        weights = [e["weight"] for e in data]
+        assert max(weights) >= 0.9, "Should have high-quality exemplars (≥0.9)"
+        assert min(weights) <= 0.1, "Should have low-quality exemplars (≤0.1)"
+        mid_count = sum(1 for w in weights if 0.4 <= w <= 0.7)
+        assert mid_count >= 5, f"Need at least 5 mid-range exemplars, got {mid_count}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

News-RAG correlation engine that maps price/volume anomalies to causal events (corporate actions, macro shocks, cross-asset co-movements) using pluggable strategies and a pre-LLM relevance filter.

## New Modules

### Core Engine — `src/ml/correlation/`
- **`service.py`** — thin orchestrator: EventRegistry → Strategies → FindingsPipeline
- **`event_registry.py`** — loads candidate events (corp actions, macro, news) from ClickHouse
- **`strategies.py`** — pluggable correlation strategies: `PostMacroShockStrategy`, `CrossAssetCoMovementStrategy`
- **`models.py`** — `CandidateEvent`, `CorrelationFinding`, `EventType` data classes
- **`filters.py`** — `FindingsPipeline`: quality weighting, dedup-by-date, episode clustering
- **`news_rag.py`** — embedding-based news retrieval for anomaly dates

### Pre-LLM News Pipeline
- **`src/tools/news_filter.py`** — two-stage relevance filter (spaCy NER primary, regex fallback) with no-starvation guarantee
- **`src/tools/news_classifier.py`** — constrained causal classifier (YES/NO + 1-line reason, ~30 token budget)

### Shared Utilities
- **`src/llm/client.py`** — singleton LLM factory (consolidates duplicated provider-resolution from summarization + company_resolver)
- **`src/utils/http_client.py`** — centralised HTTP with retry logic
- **`src/utils/api_sanitizer.py`** — response body validation
- **`src/utils/matplotlib_theme.py`** — shared chart theming
- **`src/utils/sentiment.py`** — shared sentiment utilities
- **`src/db/queries.py`** — typed ClickHouse query helpers

### Infra
- **`config/clickhouse/migrations/001_add_news_embedding.py`** — schema migration for news embeddings
- **`src/scripts/news_rag_backfill.py`** — backfill script for embedding cache

### Tests
- `tests/test_news_filter.py`
- `tests/test_news_rag.py`

**21 files changed, +3,799 lines**