### PR TITLE
fix(correlation): score on idiosyncratic return and re-center lag decay

### DIFF
--- a/src/ml/correlation/strategies.py
+++ b/src/ml/correlation/strategies.py
@@ -498,8 +498,13 @@ class PostMacroShockStrategy(CorrelationStrategy):
         is_anomaly_day  = m["is_anomaly_day"]
         lag_days        = m["lag_days"]
 
-        move_val = abs(shock_return) * 100.0
-        # Filter: must have meaningful move OR be a flagged anomaly day
+        # Score on the *idiosyncratic* (market-adjusted) move, not the raw
+        # return.  A 5% drop where NIFTY was also down 5% is a market event,
+        # not a stock-specific reaction to the macro trigger.  Falls back to
+        # raw return when no benchmark was provided (abnormal_return is None).
+        signal_return = abnormal_return if abnormal_return is not None else shock_return
+        move_val = abs(signal_return) * 100.0
+        # Filter: must have meaningful idiosyncratic move OR be a flagged anomaly day
         if not (move_val >= self.min_return_pct or is_anomaly_day):
             return None
 
@@ -507,8 +512,15 @@ class PostMacroShockStrategy(CorrelationStrategy):
         if is_anomaly_day:
             score = min(100.0, score + 20.0)
 
-        # Lag-weighted decay
-        lag_weight = np.exp(-abs(lag_days) / 2.0)
+        # Lag-weighted decay — peak weight at lag=+1 (textbook next-day
+        # reaction to a public event). Same-day matches are statistically
+        # easier to hit by coincidence (any anomaly day will likely have
+        # *some* macro headline on the same calendar date), so they receive
+        # a small relative penalty vs. +1.
+        # Curve: weight = exp(-|lag - 1| / 3.0)
+        #   lag = -2 → 0.37   lag = -1 → 0.51   lag =  0 → 0.72
+        #   lag = +1 → 1.00   lag = +2 → 0.72   lag = +3 → 0.51
+        lag_weight = np.exp(-abs(lag_days - 1) / 3.0)
         score = score * lag_weight
 
         # Direction-consistency check for FX events
@@ -648,6 +660,13 @@ class CrossAssetCoMovementStrategy(CorrelationStrategy):
         abnormal_return = m["abnormal_return"]
         fx_pct          = m["fx_pct"]
         fx_magnitude    = m["fx_magnitude"]
+
+        # Require a meaningful *idiosyncratic* move before attributing to FX.
+        # A day where stock = +5.5% but abnormal = +0.16% is the market moving,
+        # not the stock reacting to USDINR — attributing FX here is a textbook
+        # false positive.  Threshold ≈ 0.5% covers ~95% of trading days as noise.
+        if abs(abnormal_return) < 0.005:
+            return None
 
         # Scale base score by FX shock magnitude (cap at 0.015 = ~1.5% USDINR move)
         magnitude_scale = min(1.0, fx_magnitude / 0.015) if fx_magnitude > 0 else 0.5

--- a/tests/test_correlation.py
+++ b/tests/test_correlation.py
@@ -125,7 +125,10 @@ def test_post_macro_shock_strategy():
     f = findings[0]
     assert f.event.label == "RBI Easing"
     assert f.lead_lag_days >= 0  # Anomaly happened AFTER or ON event day
-    assert f.confidence == "MODERATE"
+    # Lag = +1 (event day 4 → anomaly day 5) is the peak of the new lag curve
+    # (exp(-|1-1|/3) = 1.0). With 4.5% shock_return → raw 112.5 capped at 100,
+    # decayed score = 100. Confidence is HIGH.
+    assert f.confidence == "HIGH"
 
 
 def test_correlation_service_fallback_empty_data():

--- a/website/index.html
+++ b/website/index.html
@@ -861,6 +861,20 @@
         </ul>
       </div>
 
+      <div class="feature-card">
+        <span class="feat-tag gold">Correlation</span>
+        <h3>News-RAG Correlation Engine</h3>
+        <p>Four parallel strategies attribute each anomaly to a likely cause — earnings, leak, macro shock, or cross-asset move — with calibrated confidence and direction-consistency checks. No LLM in the scoring loop.</p>
+        <ul class="feat-bullets">
+          <li><strong>Post-Macro Shock:</strong> scores on <em>idiosyncratic</em> return (stock − benchmark), not raw move — a 5% drop on a -5% NIFTY day gets zero credit</li>
+          <li><strong>Pre-Event Leak:</strong> cumulative abnormal return in the 3 days before earnings/dividends/bonuses flags suspicious pre-positioning</li>
+          <li><strong>Cross-Asset Co-Movement:</strong> USDINR &amp; commodity shocks; same-direction co-movement on negative-beta pairs is penalised 70% as a likely false positive</li>
+          <li><strong>News-RAG:</strong> publisher-quality + event-type hierarchy weights; blocked opinion sources auto-filtered</li>
+          <li><strong>Lag-weighted decay:</strong> peak weight at lag = +1 day (textbook next-session reaction); same-day matches penalised for coincidence risk</li>
+          <li><strong>Clustering dedup:</strong> multiple strategies firing on the same anomaly merge into one finding, primary strategy = highest score</li>
+        </ul>
+      </div>
+
       <div class="feature-card blue">
         <span class="feat-tag blue">ML</span>
         <h3>LightGBM 5-Day Forecast</h3>


### PR DESCRIPTION
## Problem

Two false-positive patterns in correlation scoring:

1. **PostMacroShockStrategy** scored on raw return — a stock dropping 5% when NIFTY was also down 5% would get full credit as a "macro shock reaction" when it was just market beta.
2. **CrossAssetCoMovementStrategy** attributed FX co-movement to stocks with near-zero abnormal return (e.g. +5.5% raw but +0.16% abnormal = the market moving, not the stock reacting to USDINR).
3. **Lag decay** peaked at lag=0 (same-day), but same-day matches have high coincidence risk — any anomaly day will have *some* macro headline.

## Fix

- **PostMacroShock**: score on `abnormal_return` (market-adjusted) instead of `shock_return`; falls back to raw when no benchmark provided
- **CrossAssetCoMovement**: gate on `abs(abnormal_return) >= 0.5%` before attributing to FX
- **Lag decay**: re-center curve to peak at lag=+1 (`exp(-|lag-1|/3.0)`) — textbook next-session reaction window
- Update test expectation: lag=+1 now scores HIGH (was MODERATE under old curve)
- Add News-RAG Correlation Engine feature card to website

**3 files changed, +41/−5**