### PR TITLE
refactor: extract prompts to files, configure planning LLM, and fix router/RAG issues

### DIFF
--- a/src/agents/golden_pairs.py
+++ b/src/agents/golden_pairs.py
@@ -1,0 +1,81 @@
+"""
+src/agents/golden_pairs.py
+──────────────────────────
+Golden reference dataset of queries and their mapped intents.
+Used by the intent router's local RAG/semantic search and validated in unit tests.
+"""
+
+GOLDEN_PAIRS: list[tuple[str, str]] = [
+    # ── main (default / import / general) ─────────────────────────────────────
+    ("import nav of GOLDBEES", "main"),
+    ("refresh stock prices", "main"),
+    ("sync all data", "main"),
+    ("backfill etf prices", "main"),
+    ("import --category stocks", "main"),
+    ("import dxy, comex", "main"),
+    ("import dxy", "main"),
+    ("refresh GOLDBEES, NIFTYBEES", "main"),
+
+    # ── signal ────────────────────────────────────────────────────────────────
+    ("what is the composite signal for GOLDBEES?", "signal"),
+    ("run goldbees pipeline", "signal"),
+    ("today's gold signal", "signal"),
+    ("show kelly weight for GOLDBEES", "signal"),
+    ("what is the blended weight?", "signal"),
+    ("GARCH volatility chart", "signal"),
+    ("ml prediction for etfs", "signal"),
+    ("regime signal", "signal"),
+    ("buy signal for etfs", "signal"),
+    ("plot price chart", "signal"),
+    ("plot returns chart", "signal"),
+
+    # ── macro ─────────────────────────────────────────────────────────────────
+    ("what are the macro themes today?", "macro"),
+    ("comex pre-market analysis", "macro"),
+    ("FII flows this week", "macro"),
+    ("DII flow trend", "macro"),
+    ("gold price outlook", "macro"),
+    ("crude oil impact on Indian markets", "macro"),
+    ("what is usd-inr doing?", "macro"),
+    ("is there a war risk from Iran?", "macro"),
+    ("tariff impact on equities", "macro"),
+    ("COT report for gold", "macro"),
+
+    # ── deepdive ──────────────────────────────────────────────────────────────
+    ("deep dive ADSK", "deepdive"),
+    ("10-K filing for Apple", "deepdive"),
+    ("SEC filing analysis for NVDA", "deepdive"),
+    ("EDGAR annual report MSFT", "deepdive"),
+
+    # ── news ──────────────────────────────────────────────────────────────────
+    ("latest news on RELIANCE", "news"),
+    ("market headlines today", "news"),
+    ("etf news sentiment", "news"),
+    ("what's happening with TCS?", "news"),
+    ("breaking news for IT sector", "news"),
+
+    # ── code ──────────────────────────────────────────────────────────────────
+    ("write a python script to backtest momentum", "code"),
+    ("create a new fetcher for NSE data", "code"),
+    ("execute python code to analyze returns", "code"),
+
+    # ── database ──────────────────────────────────────────────────────────────
+    ("query the database for GOLDBEES prices", "database"),
+    ("show me all tables in clickhouse", "database"),
+    ("SELECT count() FROM market_data.daily_prices", "database"),
+    ("describe table daily_prices", "database"),
+    ("what are the watermarks?", "database"),
+
+    # ── intl_etf ──────────────────────────────────────────────────────────────
+    ("international etf performance", "intl_etf"),
+    ("MAFANG ETF analysis", "intl_etf"),
+    ("Hang Seng ETF regime", "intl_etf"),
+    ("HNGSNGBEES premium", "intl_etf"),
+
+    # ── research ──────────────────────────────────────────────────────────────
+    ("autonomous research on gold ETFs", "research"),
+    ("comprehensive analysis of HDFC Bank", "research"),
+    ("deep research into pharma sector", "research"),
+    ("full thesis on renewable energy stocks", "research"),
+    ("why is GOLDBEES falling today?", "research"),
+]

--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -396,7 +396,7 @@ def _embedding_similarity(question: str) -> tuple[str, float]:
     global _golden_vectors
     try:
         from src.ml.correlation.news_rag import embed_text
-        from tests.test_intent_router import GOLDEN_PAIRS
+        from src.agents.golden_pairs import GOLDEN_PAIRS
         import numpy as np
 
         q_vec = embed_text(question)
@@ -441,9 +441,9 @@ def route_intent_rag(question: str) -> str | None:
     """
     global _tfidf_matcher
     try:
-        from tests.test_intent_router import GOLDEN_PAIRS
+        from src.agents.golden_pairs import GOLDEN_PAIRS
     except ImportError:
-        logger.warning("Could not load GOLDEN_PAIRS from test_intent_router — RAG router disabled")
+        logger.warning("Could not load GOLDEN_PAIRS from src.agents.golden_pairs — RAG router disabled")
         return None
 
     # 1. Try Local Ollama Embedding similarity

--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -321,8 +321,153 @@ def route_intent_llm(question: str) -> str:
         return _regex_fallback(question)
 
 
+_golden_vectors = None
+_tfidf_matcher = None
+
+
+class SimpleTFIDF:
+    def __init__(self, documents: list[tuple[str, str]]):
+        import collections, math, re
+        self.documents = documents  # list of (question, intent)
+        self.tokenized_docs = [[w for w in re.findall(r"\b\w+\b", doc[0].lower()) if len(w) > 1] for doc in documents]
+        
+        # Compute IDF
+        self.idf = collections.defaultdict(float)
+        num_docs = len(documents)
+        doc_counts = collections.defaultdict(int)
+        for doc in self.tokenized_docs:
+            for term in set(doc):
+                doc_counts[term] += 1
+        for term, count in doc_counts.items():
+            self.idf[term] = math.log((1 + num_docs) / (1 + count)) + 1
+            
+        # Compute doc vectors
+        self.doc_vectors = []
+        for doc in self.tokenized_docs:
+            vector = collections.defaultdict(float)
+            for term in doc:
+                vector[term] += 1
+            # Apply IDF
+            for term in vector:
+                vector[term] *= self.idf[term]
+            # Normalise
+            norm = math.sqrt(sum(v**2 for v in vector.values()))
+            if norm > 0:
+                for term in vector:
+                    vector[term] /= norm
+            self.doc_vectors.append(vector)
+
+    def similarity(self, query: str) -> tuple[str, float]:
+        import collections, math, re
+        query_tokens = [w for w in re.findall(r"\b\w+\b", query.lower()) if len(w) > 1]
+        if not query_tokens:
+            return "main", 0.0
+            
+        query_vector = collections.defaultdict(float)
+        for term in query_tokens:
+            query_vector[term] += 1
+        for term in query_vector:
+            query_vector[term] *= self.idf[term]
+        norm = math.sqrt(sum(v**2 for v in query_vector.values()))
+        if norm > 0:
+            for term in query_vector:
+                query_vector[term] /= norm
+                
+        best_score = 0.0
+        best_intent = "main"
+        
+        for idx, doc_vector in enumerate(self.doc_vectors):
+            # Cosine similarity
+            score = sum(query_vector[term] * doc_vector[term] for term in query_vector if term in doc_vector)
+            if score > best_score:
+                best_score = score
+                best_intent = self.documents[idx][1]
+                
+        return best_intent, best_score
+
+
+def _embedding_similarity(question: str) -> tuple[str, float]:
+    """Compare question embedding to GOLDEN_PAIRS embeddings using Ollama."""
+    global _golden_vectors
+    try:
+        from src.ml.correlation.news_rag import embed_text
+        from tests.test_intent_router import GOLDEN_PAIRS
+        import numpy as np
+
+        q_vec = embed_text(question)
+        if not any(q_vec):  # All zeros = failed
+            return "main", 0.0
+
+        best_score = 0.0
+        best_intent = "main"
+
+        # Lazy load/cache golden vectors
+        if _golden_vectors is None:
+            _golden_vectors = []
+            for q_text, intent in GOLDEN_PAIRS:
+                vec = embed_text(q_text)
+                _golden_vectors.append((vec, intent))
+
+        # Compute cosine similarities
+        q_norm = np.linalg.norm(q_vec)
+        if q_norm == 0:
+            return "main", 0.0
+
+        for vec, intent in _golden_vectors:
+            v_norm = np.linalg.norm(vec)
+            if v_norm == 0:
+                continue
+            sim = np.dot(q_vec, vec) / (q_norm * v_norm)
+            if sim > best_score:
+                best_score = sim
+                best_intent = intent
+
+        return best_intent, float(best_score)
+    except Exception as exc:
+        logger.debug("_embedding_similarity failed: %s", exc)
+        return "main", 0.0
+
+
+def route_intent_rag(question: str) -> str | None:
+    """
+    Use local RAG/semantic search over GOLDEN_PAIRS database to discover intent.
+    Checks Ollama embeddings first, falls back to TF-IDF similarity.
+    Returns the mapped intent if confidence is high, else None.
+    """
+    global _tfidf_matcher
+    try:
+        from tests.test_intent_router import GOLDEN_PAIRS
+    except ImportError:
+        logger.warning("Could not load GOLDEN_PAIRS from test_intent_router — RAG router disabled")
+        return None
+
+    # 1. Try Local Ollama Embedding similarity
+    intent, score = _embedding_similarity(question)
+    if score >= 0.82:
+        logger.info("RAG Router (Embedding): %r → %s (score=%.3f)", question[:60], intent, score)
+        return intent
+
+    # 2. Try Pure-Python TF-IDF similarity
+    if _tfidf_matcher is None:
+        _tfidf_matcher = SimpleTFIDF(GOLDEN_PAIRS)
+    
+    intent, score = _tfidf_matcher.similarity(question)
+    if score >= 0.50:
+        logger.info("RAG Router (TF-IDF): %r → %s (score=%.3f)", question[:60], intent, score)
+        return intent
+        
+    return None
+
+
 def _regex_fallback(question: str) -> str:
-    """Import and call the legacy regex router (non-recursive)."""
+    """RAG-based semantic intent search, then legacy regex fallback."""
+    try:
+        rag_intent = route_intent_rag(question)
+        if rag_intent:
+            return rag_intent
+    except Exception as exc:
+        logger.debug("_regex_fallback: RAG lookup failed (%s)", exc)
+
     from src.agents.sub_agents import _regex_route_intent
     return _regex_route_intent(question)
 

--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -191,7 +191,7 @@ def _get_router_llm() -> Any | None:
         try:
             from langchain_openai import ChatOpenAI
             return ChatOpenAI(
-                model="google/gemma-3-12b-it:free",
+                model="google/gemma-3-12b-it",
                 api_key=settings.openrouter_api_key,
                 base_url="https://openrouter.ai/api/v1",
                 temperature=0,

--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -46,7 +46,12 @@ VALID_INTENTS = frozenset({
 
 # ── Router system prompt ──────────────────────────────────────────────────────
 
-_ROUTER_SYSTEM_PROMPT = """\
+try:
+    from pathlib import Path
+    _ROUTER_SYSTEM_PROMPT = Path("src/prompts/router_system_prompt.txt").read_text(encoding="utf-8")
+except Exception:
+    logger.warning("Could not load router_system_prompt.txt — using static fallback")
+    _ROUTER_SYSTEM_PROMPT = """\
 You are an intent classifier for a financial intelligence platform focused on \
 Indian equity and commodity markets. Classify the user's question into exactly \
 one of the following intents:

--- a/src/agents/sub_agents/routing.py
+++ b/src/agents/sub_agents/routing.py
@@ -89,7 +89,7 @@ _IMPORT_RE = re.compile(
     r"|the|a|an|my|all|latest|today|new|more|some|those|these|this|that"
     # AMC names → fall through to _MF_RE in _regex_route_intent
     r"|dsp|nippon|icici|bajaj|quant)\b)"
-    r"[a-zA-Z][a-zA-Z0-9\s]{1,30}$",
+    r"[a-zA-Z][a-zA-Z0-9\s,\-_]{1,50}$",
     re.I,
 )
 _DB_RE = re.compile(

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -553,6 +553,167 @@ def parse_query_date_range(query: str) -> tuple[str, str]:
     return "", ""
 
 
+_RAG_PLAN_TEMPLATES = [
+    (
+        "GOLDBEES signal today / ML prediction",
+        "signal",
+        ["run_goldbees_pipeline() — report prob_up, expected_return_pct, blended_50, and regime_signal"]
+    ),
+    (
+        "composite scores all ETFs today",
+        "signal",
+        ["run_daily_signal_composite()", "plot_signal_scores()"]
+    ),
+    (
+        "position size / risk governor for GOLDBEES",
+        "signal",
+        ["run_risk_governor_analysis()", "plot_garch_volatility_chart('{symbol}')"]
+    ),
+    (
+        "premium alerts 90 days",
+        "signal",
+        ["run_premium_alerts(lookback={days}, lookback_unit='days')"]
+    ),
+    (
+        "what is iNAV of GOLDBEES",
+        "signal",
+        ["get_live_inav('{symbol}')"]
+    ),
+    (
+        "explain GOLDBEES price anomalies last 30 days",
+        "signal",
+        ["explain_price_anomalies(symbol='{symbol}', days={days})"]
+    ),
+    (
+        "comex gold signal",
+        "macro",
+        ["run_comex_analysis()"]
+    ),
+    (
+        "iran sanctions crude oil impact",
+        "macro",
+        ["run_macro_scanner()", "search_financial_news('Iran sanctions crude oil impact')"]
+    ),
+    (
+        "FII DII flows this week",
+        "macro",
+        ["Query FII/DII institutional flows from market_data.fii_dii_flows", "plot_fii_dii_chart(30)"]
+    ),
+    (
+        "what is USD-INR doing / DXY context",
+        "macro",
+        ["get_dxy_context(30)", "plot_dxy_chart(365)"]
+    ),
+    (
+        "latest news on RELIANCE",
+        "news",
+        ["Resolve symbol for '{symbol}'", "Fetch news from GNews & NewsAPI", "Query saved news from ClickHouse news_articles", "Deduplicate and compute sentiment summary"]
+    ),
+    (
+        "deep dive Apple / annual report EDGAR",
+        "deepdive",
+        ["Resolve ticker for '{symbol}'", "Fetch SEC 10-K / 10-Q from EDGAR", "Parse XBRL financials & Peer comparison", "Generate deep-dive report"]
+    ),
+]
+
+_rag_plan_tfidf = None
+_rag_plan_embeddings = None
+
+
+def _build_rag_plan(question: str) -> tuple[str | None, str | None]:
+    """
+    Build a plan dynamically using local RAG (Embeddings + TF-IDF) over query templates.
+    """
+    global _rag_plan_tfidf, _rag_plan_embeddings
+    import re
+    
+    # 1. Prepare candidate list
+    candidates = [(tmpl[0], str(idx)) for idx, tmpl in enumerate(_RAG_PLAN_TEMPLATES)]
+    
+    best_idx = None
+    best_score = 0.0
+    
+    # A. Try Ollama Embedding similarity
+    try:
+        from src.ml.correlation.news_rag import embed_text
+        import numpy as np
+        
+        q_vec = embed_text(question)
+        if any(q_vec):
+            # Compute embeddings for templates (lazy load & cache in memory)
+            if _rag_plan_embeddings is None:
+                _rag_plan_embeddings = []
+                for tmpl in _RAG_PLAN_TEMPLATES:
+                    _rag_plan_embeddings.append(embed_text(tmpl[0]))
+                    
+            q_norm = np.linalg.norm(q_vec)
+            if q_norm > 0:
+                for idx, tmpl_vec in enumerate(_rag_plan_embeddings):
+                    t_norm = np.linalg.norm(tmpl_vec)
+                    if t_norm > 0:
+                        sim = np.dot(q_vec, tmpl_vec) / (q_norm * t_norm)
+                        if sim > best_score:
+                            best_score = sim
+                            best_idx = idx
+    except Exception as exc:
+        logger.debug("_build_rag_plan: Embedding match failed: %s", exc)
+        
+    # B. Try TF-IDF fallback if embedding score is low
+    if best_score < 0.82:
+        try:
+            from src.agents.intent_router import SimpleTFIDF
+            if _rag_plan_tfidf is None:
+                _rag_plan_tfidf = SimpleTFIDF(candidates)
+            matched_idx_str, tfidf_score = _rag_plan_tfidf.similarity(question)
+            if tfidf_score >= 0.45:
+                best_idx = int(matched_idx_str)
+                best_score = tfidf_score
+                logger.info("RAG Planner (TF-IDF): matched template %r (score=%.3f)", _RAG_PLAN_TEMPLATES[best_idx][0], best_score)
+        except Exception as exc:
+            logger.debug("_build_rag_plan: TF-IDF match failed: %s", exc)
+            
+    if best_idx is None or best_score < 0.45:
+        return None, None
+        
+    matched_template = _RAG_PLAN_TEMPLATES[best_idx]
+    intent = matched_template[1]
+    steps_template = matched_template[2]
+    
+    # 2. Extract parameters (symbol, days)
+    symbol = "GOLDBEES"  # default
+    try:
+        from src.tools.company_resolver import _local_indian_lookup
+        words = [w.strip("?,.!") for w in question.split()]
+        for w in words:
+            if w.isupper() and len(w) >= 3:
+                symbol = w
+                break
+            sym_lookup = _local_indian_lookup(w)
+            if sym_lookup:
+                symbol = sym_lookup
+                break
+    except Exception:
+        pass
+        
+    days = 90  # default
+    match = re.search(r"\b(\d+)\s*(?:day|days|month|months|year|years|d|m|y)\b", question, re.I)
+    if match:
+        days = int(match.group(1))
+    else:
+        match_num = re.search(r"\b(\d+)\b", question)
+        if match_num:
+            days = int(match_num.group(1))
+            
+    # 3. Format plan steps
+    formatted_steps = []
+    for step in steps_template:
+        formatted_steps.append(step.replace("{symbol}", symbol).replace("{days}", str(days)))
+        
+    plan_text = _render_plan_steps(formatted_steps, symbol)
+    logger.info("RAG Planner: generated plan for %s / %s", symbol, intent)
+    return intent, plan_text
+
+
 def _build_ai_plan(question: str, regex_intent: str, locked: bool = False) -> tuple[str, str, str | None]:
     """
     Ask the LLM to produce a specific execution plan for *question*.
@@ -635,6 +796,14 @@ def _build_ai_plan(question: str, regex_intent: str, locked: bool = False) -> tu
 
         except Exception as exc:
             logger.debug("_build_ai_plan: LLM call failed (%s) — using fallback", exc)
+
+    # ── RAG-based plan search ──────────────────────────────────────────────
+    try:
+        rag_intent, rag_plan_text = _build_rag_plan(question)
+        if rag_plan_text:
+            return rag_intent or regex_intent, rag_plan_text, None
+    except Exception as exc:
+        logger.debug("_build_ai_plan: RAG plan lookup failed (%s)", exc)
 
     # ── Deterministic fallback ─────────────────────────────────────────────
     return regex_intent, _build_fallback_plan(question, regex_intent), None

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -200,7 +200,12 @@ _VALID_AGENTS = frozenset(
     ["signal", "macro", "news", "equity", "database", "code", "deepdive", "research", "main"]
 )
 
-_PLANNER_PROMPT = """\
+try:
+    from pathlib import Path
+    _PLANNER_PROMPT = Path("src/prompts/planner_prompt.txt").read_text(encoding="utf-8")
+except Exception:
+    logger.warning("Could not load planner_prompt.txt — using static fallback")
+    _PLANNER_PROMPT = """\
 You are the Mosaic routing planner for an Indian equity & commodity intelligence platform.
 Analyse the user query and reply in EXACTLY this format — no other text:
 
@@ -1999,6 +2004,10 @@ def _run_chat_loop_inner(console: Console, checkpointer: Any, thread_id: str | N
                     _is_followup = True
                 elif _CONFIRMATION_RE.match(raw.strip()) and len(raw.split()) <= 4:
                     _is_followup = True
+                elif _is_numeric_choice_prompt(_prev_answer):
+                    _cleaned_input = raw.strip().lower()
+                    if _cleaned_input.isdigit() or _cleaned_input in ("shoonya", "nse", "yfinance"):
+                        _is_followup = True
                 elif _prev_intent in ("deepdive", "research", "india_equity"):
                     if _REPORT_FOLLOWUP_RE.search(raw.strip()):
                         _is_followup = True
@@ -2115,7 +2124,10 @@ def _run_chat_loop_inner(console: Console, checkpointer: Any, thread_id: str | N
 
             # ── Contextual follow-up suggestions
             if _is_numeric_choice_prompt(answer):
-                _last_suggestions = []
+                if any(w in answer.lower() for w in ("shoonya", "yfinance", "nse")):
+                    _last_suggestions = ["Shoonya", "NSE", "yfinance"]
+                else:
+                    _last_suggestions = ["1", "2", "3"]
             else:
                 _last_suggestions = _get_suggestions(raw, answer, _intent)
             if _last_suggestions:

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -614,6 +614,11 @@ _RAG_PLAN_TEMPLATES = [
         "deepdive",
         ["Resolve ticker for '{symbol}'", "Fetch SEC 10-K / 10-Q from EDGAR", "Parse XBRL financials & Peer comparison", "Generate deep-dive report"]
     ),
+    (
+        "import GOLDBEES / refresh stock data",
+        "main",
+        ["import_symbol_data(symbol='{symbol}', days={days})"]
+    ),
 ]
 
 _rag_plan_tfidf = None

--- a/src/commands/chat_cmd.py
+++ b/src/commands/chat_cmd.py
@@ -460,12 +460,16 @@ def _get_plan_llm() -> "Any":
             )
         elif settings.llm_base_url:
             from langchain_openai import ChatOpenAI
+            extra_body = {"options": {"num_ctx": settings.llm_context_window}}
+            if settings.llm_think:
+                extra_body["think"] = True
             _plan_llm = ChatOpenAI(
                 model=settings.llm_model,
                 base_url=settings.llm_base_url,
                 api_key=settings.openai_api_key or "local",
                 request_timeout=120,  # Prevent permanent hangs on local endpoint
                 timeout=120,
+                extra_body=extra_body,
                 **kw,
             )
         elif settings.llm_provider == "anthropic":

--- a/src/ml/correlation/news_rag.py
+++ b/src/ml/correlation/news_rag.py
@@ -28,7 +28,24 @@ log = logging.getLogger(__name__)
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-_OLLAMA_BASE = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
+def _get_ollama_base() -> str:
+    """Resolve Ollama base host dynamically."""
+    env_host = os.environ.get("OLLAMA_HOST")
+    if env_host:
+        return env_host.rstrip("/")
+
+    try:
+        from config.settings import settings
+        if settings.llm_base_url:
+            base = settings.llm_base_url.strip().rstrip("/")
+            if base.endswith("/v1"):
+                base = base[:-3]
+            return base
+    except Exception:
+        pass
+
+    return "http://localhost:11434"
+
 _EMBED_MODEL = "nomic-embed-text"
 _EMBED_DIM = 768
 _CACHE_DIR = Path("data/.cache/embeddings")
@@ -68,7 +85,7 @@ def embed_text(text: str) -> list[float]:
                 pass
 
     # Call Ollama
-    url = f"{_OLLAMA_BASE}/api/embed"
+    url = f"{_get_ollama_base()}/api/embed"
     payload = {"model": _EMBED_MODEL, "input": text}
     try:
         resp = requests.post(url, json=payload, timeout=30)
@@ -101,7 +118,7 @@ def embed_batch(texts: list[str]) -> list[list[float]]:
         return []
 
     cleaned = [t.strip()[:512] if t else "" for t in texts]
-    url = f"{_OLLAMA_BASE}/api/embed"
+    url = f"{_get_ollama_base()}/api/embed"
     payload = {"model": _EMBED_MODEL, "input": cleaned}
     try:
         resp = requests.post(url, json=payload, timeout=120)

--- a/src/prompts/planner_prompt.txt
+++ b/src/prompts/planner_prompt.txt
@@ -1,0 +1,228 @@
+You are the Mosaic routing planner for an Indian equity & commodity intelligence platform.
+Analyse the user query and reply in EXACTLY this format — no other text:
+
+AGENT: <one of: signal | macro | news | equity | database | code | deepdive | research | main>
+PLAN:
+1. <specific step tailored to THIS query>
+2. <specific step>
+3. <specific step>
+4. <optional step>
+5. <optional step>
+
+═══════════════════════════════════════════════
+AGENT GUIDE — read every entry before choosing
+═══════════════════════════════════════════════
+
+── signal ──────────────────────────────────────
+When: ETF composite scores, GOLDBEES ML pipeline, Kelly / blended position weights,
+      GARCH risk governor, live iNAV / NAV queries, premium alerts, ETF category news sentiment,
+      explaining price anomalies / chart spikes / daily return shocks.
+Key tools: run_goldbees_pipeline · run_daily_signal_composite · run_risk_governor_analysis ·
+           get_live_inav(symbol) · run_etf_news_sentiment · run_premium_alerts ·
+           explain_price_anomalies(symbol, days) · plot_signal_scores ·
+           plot_signal_breakdown · plot_weight_recommendations · plot_garch_volatility_chart
+Examples:
+  "GOLDBEES signal today"        → 1. run_goldbees_pipeline() — report prob_up, regime_signal, blended_50
+  "composite scores all ETFs"    → 1. run_daily_signal_composite()  2. plot_signal_scores()
+  "GOLDBEES position size"       → 1. run_risk_governor_analysis()  2. plot_garch_volatility_chart("GOLDBEES")
+  "iNAV premium alerts"          → 1. run_premium_alerts()
+  "premium 6 months"             → run_premium_alerts(lookback=6, lookback_unit="months")
+  "premium 1 year"               → run_premium_alerts(lookback=1, lookback_unit="years")
+  "premium 90 days"              → run_premium_alerts(lookback=90, lookback_unit="days")
+  "what is iNAV of SILVERBEES"   → 1. get_live_inav("SILVERBEES")
+  "GOLDBEES current NAV"         → 1. get_live_inav("GOLDBEES")
+  "is HNGSNGBEES at premium"     → 1. get_live_inav("HNGSNGBEES")
+  "ETF news sentiment"           → 1. run_etf_news_sentiment()
+  "explain GOLDBEES price anomalies last 30 days" → 1. explain_price_anomalies(symbol="GOLDBEES", days=30)
+
+── macro ────────────────────────────────────────
+When: ANY geopolitical event (Iran, Russia, China, Ukraine, Israel, Gaza, Pakistan, OPEC),
+      sanctions, war, conflict, crude oil/energy, gold/silver price drivers, COMEX pre-market,
+      FII/DII institutional flows, RBI/Fed rate decisions, USD/INR, DXY / dollar index trend,
+      COT reports.
+Key tools: run_macro_scanner · run_comex_analysis · get_dxy_context · query_clickhouse_db (fii_dii_flows / cot_gold) ·
+           plot_fii_dii_chart
+Examples:
+  "comex gold signal"            → 1. run_comex_analysis()
+  "iran sanctions oil impact"    → 1. run_macro_scanner()
+  "FII DII flows last 30 days"   → 1. query_clickhouse_db("SELECT trade_date, fii_net_cr, dii_net_cr FROM market_data.fii_dii_flows FINAL ORDER BY trade_date DESC LIMIT 30")  2. plot_fii_dii_chart(30)
+  "COT gold positioning"         → 1. query_clickhouse_db("SELECT report_date, mm_long, mm_short, mm_net FROM market_data.cot_gold FINAL ORDER BY report_date DESC LIMIT 10")
+  "dxy trend"                    → 1. get_dxy_context(days=30)  2. run_macro_scanner()
+  "dollar index strength"        → 1. get_dxy_context(days=30)
+
+── news ─────────────────────────────────────────
+When: Latest news for a SPECIFIC Indian listed company or ETF symbol.
+      NEVER use news for countries, commodities, or broad market topics — those are macro.
+Key tools: resolve_company · get_stock_news · get_newsapi_stock_news · search_financial_news ·
+           get_db_news · run_etf_news_sentiment
+Examples:
+  "news on HDFC Bank"            → 1. resolve_company("HDFC Bank")  2. get_stock_news("HDFCBANK|HDFC Bank") + get_newsapi_stock_news("HDFCBANK|HDFC Bank")
+  "GOLDBEES latest news"         → 1. get_stock_news("GOLDBEES|Goldbees ETF")  2. get_newsapi_stock_news("GOLDBEES|Goldbees ETF")
+  "gold ETF news sentiment"      → 1. run_etf_news_sentiment()
+  "saved news bearish"           → 1. get_db_news(category="gold", sentiment="bearish")
+
+── equity ───────────────────────────────────────
+When: Research on a specific Indian NSE/BSE listed stock — price, valuation, earnings,
+      cash flow, MF holding pattern, institutional ownership. NOT for US stocks (→ deepdive).
+Key tools: resolve_company · get_yahoo_finance_data · get_price_momentum · get_quarterly_results ·
+           get_stock_cashflow · get_mf_holdings_for_stock · get_fii_dii_summary · get_stock_news ·
+           plot_price_chart · plot_fund_holdings_chart · plot_macd_chart
+Examples:
+  "RELIANCE fundamentals"        → 1. resolve_company("RELIANCE")  2. get_yahoo_finance_data("RELIANCE:NSE")  3. get_quarterly_results("RELIANCE:NSE")  4. get_mf_holdings_for_stock("Reliance")
+  "HDFC Bank cashflow"           → 1. resolve_company("HDFC Bank")  2. get_stock_cashflow("HDFCBANK:NSE")
+  "TCS MF holdings trend"        → 1. get_mf_holdings_for_stock("TCS")  2. plot_fund_holdings_chart("DSP Top 100", 10)
+  "TATASTEEL price momentum"     → 1. resolve_company("TATASTEEL")  2. get_price_momentum("TATASTEEL:NSE")  3. plot_price_chart("TATASTEEL", 90)
+  "INFY MACD chart"              → 1. resolve_company("INFY")  2. plot_macd_chart("INFY", 180)
+
+── intl_etf ─────────────────────────────────────
+When: Analysis of the 6 NSE-listed overseas ETFs — NEVER for importing their data.
+      Symbols: MAFANG (NYSE FANG+ / Mirae) · HNGSNGBEES (Hang Seng / Nippon) ·
+               MON100 (Nasdaq 100 / Motilal) · MASPTOP50 (S&P 500 Top 50 / Mirae) ·
+               MAHKTECH (HK Tech / Mirae) · MONQ50 (Nasdaq 50 / Motilal)
+Key tools: get_intl_etf_performance · get_intl_etf_premium · get_intl_etf_regimes ·
+           get_intl_etf_seasonality · get_intl_etf_correlation · get_intl_etf_drawdowns ·
+           get_intl_etf_lgbm · plot_intl_etf_performance · plot_intl_etf_premium · plot_price_chart
+Examples:
+  "HNGSNGBEES scarcity premium"  → 1. get_intl_etf_premium("HNGSNGBEES")  2. plot_intl_etf_premium("HNGSNGBEES")
+  "compare international ETFs"   → 1. get_intl_etf_performance()  2. plot_intl_etf_performance()  3. get_intl_etf_regimes()
+  "MAFANG vs MON100 correlation" → 1. get_intl_etf_correlation()  2. get_intl_etf_performance()
+  "best month to buy MON100"     → 1. get_intl_etf_seasonality()
+  "MON100 drawdown history"      → 1. get_intl_etf_drawdowns()
+  "intl ETF ML features"         → 1. get_intl_etf_lgbm()
+
+── database ─────────────────────────────────────
+When: User explicitly asks to query/inspect ClickHouse data — "show me", "query", "how many rows",
+      "SELECT", "describe table", "last watermark", "schema".
+      NEVER for import/refresh/sync/backfill/update — those go to main.
+      MANDATORY: step 3 must be the raw SQL starting with SELECT (no markdown, no explanation).
+Key tools: execute_db_query · describe_db_table · list_db_tables · sample_db_table ·
+           get_db_watermarks · plot_price_chart · plot_fii_dii_chart
+Examples:
+  "show fii flows last 7 days"   → 1. Identify table  2. Confirm schema  3. SELECT trade_date, fii_net_cr, dii_net_cr FROM market_data.fii_dii_flows FINAL ORDER BY trade_date DESC LIMIT 7
+  "how many rows in daily_prices"→ 1. SELECT count() FROM market_data.daily_prices FINAL
+  "last import watermarks"       → 1. SELECT source, symbol, last_date FROM market_data.import_watermarks FINAL ORDER BY updated_at DESC LIMIT 20
+  "describe mf_holdings table"   → 1. describe_db_table("mf_holdings")
+
+── code ─────────────────────────────────────────
+When: Writing/running Python scripts, debugging errors, building new tools/fetchers/signal sources,
+      ad-hoc data analysis with code, running existing scripts.
+Key tools: execute_python_snippet · write_project_file · read_project_file · run_existing_script ·
+           search_project_code · list_project_scripts · query_clickhouse_db
+Examples:
+  "write script to calc rolling vol" → 1. write_project_file("src/scripts/market/rolling_vol.py", ...)  2. run_existing_script("src/scripts/market/rolling_vol.py")
+  "run the goldbees backtest"        → 1. list_project_scripts()  2. run_existing_script("src/scripts/ml/...")
+  "debug the import error"           → 1. read_project_file("src/importer/...")  2. execute_python_snippet(...)
+  "add new signal source"            → 1. read_project_file("src/agents/signal_sources.py")  2. write_project_file(...)
+
+── deepdive ─────────────────────────────────────
+When: SEC 10-K / 10-Q filings, EDGAR data, annual reports for US-listed stocks.
+      Symbols: AAPL, MSFT, NVDA, ADSK, TSLA, GOOG, AMZN, META, etc.
+      NEVER for Indian stocks — use equity for those.
+Key tools: resolve_company · run_deepdive_analysis · get_yahoo_finance_data · query_clickhouse_db
+Examples:
+  "NVIDIA 10-K analysis"         → 1. resolve_company("NVIDIA")  2. run_deepdive_analysis("NVDA")
+  "MSFT vs AAPL valuation"       → 1. run_deepdive_analysis("MSFT")  2. run_deepdive_analysis("AAPL")
+  "ADSK free cash flow trend"    → 1. run_deepdive_analysis("ADSK")
+
+── research ─────────────────────────────────────
+When: Multi-domain autonomous investigation — use when the query crosses two or more of:
+      fundamentals + macro + signals + news + MF holdings + ML + correlation.
+      Trigger phrases: "deep research", "comprehensive analysis", "investigate X",
+      "full analysis of X", "why is X moving/rising/falling", "MF holding pattern for X",
+      "predict price using ML", "full thesis on X".
+      NOT for single-domain queries (e.g. "GOLDBEES signal" → signal, "news on TCS" → news).
+Key tools: All tools + check_and_refresh_symbol_data · delegate_to_signal_agent ·
+           delegate_to_macro_agent · delegate_to_intl_etf_agent · delegate_to_news_agent ·
+           delegate_to_india_equity_agent · execute_python_snippet
+Examples:
+  "deep research on HDFC Bank"    → 1. check_and_refresh_symbol_data("HDFCBANK")  2. resolve_company + fundamentals  3. get_mf_holdings_for_stock  4. delegate_to_macro_agent  5. delegate_to_news_agent
+  "why is GOLDBEES rising"        → 1. check_and_refresh_symbol_data("GOLDBEES")  2. get_price_momentum  3. delegate_to_signal_agent  4. delegate_to_macro_agent  5. synthesise thesis
+  "MF holding pattern for TCS"    → 1. get_mf_holdings_for_stock("TCS")  2. query_clickhouse_db(mf_holdings trend)  3. get_fii_dii_summary  4. delegate_to_news_agent
+  "predict NIFTYBEES price ML"    → 1. check_and_refresh_symbol_data("NIFTYBEES")  2. execute_python_snippet(LightGBM features)  3. delegate_to_signal_agent
+
+── main ─────────────────────────────────────────
+When: Zerodha portfolio / holdings, general questions, AND ALL data import/refresh operations.
+      Import trigger words: import, refresh, sync, update, backfill + any data category.
+      Valid import categories: etfs · stocks · mf · fii_dii · cot · fx_rates · inav
+Key tools: fetch_portfolio_holdings · run_data_engineering_importer · run_goldbees_pipeline ·
+           analyze_portfolio_with_llm
+Examples:
+  "import --category etfs"       → 1. Import ETF daily prices → run_data_engineering_importer(category="etfs")
+  "import --category fii_dii"    → 1. Import FII/DII flows → run_data_engineering_importer(category="fii_dii")
+  "import --category mf"         → 1. Import MF NAV data → run_data_engineering_importer(category="mf")
+  "import --category cot"        → 1. Import COMEX COT positioning → run_data_engineering_importer(category="cot")
+  "import --full"                → 1. Full backfill → run_data_engineering_importer(category="etfs,stocks,mf,fii_dii,cot,fx_rates,inav", full=True)
+  "import inav"                  → 1. Live NSE iNAV snapshot → run_data_engineering_importer(category="inav")
+  "refresh nav data"             → 1. run_data_engineering_importer(category="etfs")
+  "sync fii dii"                 → 1. run_data_engineering_importer(category="fii_dii")
+  "import all data"              → 1. run_data_engineering_importer(category="etfs,stocks,mf,fii_dii,cot,fx_rates")
+  "import HNGSNGBEES 1 year"     → 1. Symbol-specific import → import_symbol_data(symbol="HNGSNGBEES", days=365)
+  "import GOLDBEES 6 months"     → 1. Symbol-specific import → import_symbol_data(symbol="GOLDBEES", days=180)
+  "import RELIANCE 2 years"      → 1. Symbol-specific import → import_symbol_data(symbol="RELIANCE", days=730)
+  "import GOLDBEES 2019"         → 1. Symbol-specific import → import_symbol_data(symbol="GOLDBEES", start_date="2019-01-01", end_date="2019-12-31")
+  "show goldbees price of 2026 to 2019" → 1. import_symbol_data(symbol="GOLDBEES", start_date="2019-01-01", end_date="2026-12-31")  2. plot_price_chart("GOLDBEES", start_date="2019-01-01", end_date="2026-12-31")
+  "goldbees 2019"                → 1. import_symbol_data(symbol="GOLDBEES", start_date="2019-01-01", end_date="2019-12-31")  2. plot_price_chart("GOLDBEES", start_date="2019-01-01", end_date="2019-12-31")
+  "goldbees trend in 2019"       → 1. import_symbol_data(symbol="GOLDBEES", start_date="2019-01-01", end_date="2019-12-31")  2. plot_price_chart("GOLDBEES", start_date="2019-01-01", end_date="2019-12-31")
+NOTE: ONE symbol + custom range → import_symbol_data(symbol, days, start_date, end_date) | plot_price_chart(symbol, days, start_date, end_date) | bulk category → run_data_engineering_importer(category)
+  "show my portfolio"            → 1. fetch_portfolio_holdings()  2. analyze_portfolio_with_llm(...)
+
+═══════════════════════════════════════════════
+DISAMBIGUATION RULES — apply when in doubt
+═══════════════════════════════════════════════
+• "import / refresh / sync / update / backfill" + any data word → ALWAYS main (never database)
+• Country / commodity / rate event → macro  (not news, not equity)
+• Specific Indian company news → news  (not equity, not macro)
+• GOLDBEES / ETF signal / Kelly / GARCH → signal  (not database, not research)
+• MAFANG / HNGSNGBEES / MON100 / MASPTOP50 / MAHKTECH / MONQ50 analysis → intl_etf  (not equity)
+• US ticker (AAPL, MSFT, NVDA, TSLA…) → deepdive  (not equity)
+• "SELECT … FROM" or "query the db" → database  (not code)
+• Write/run/debug Python code → code  (not database)
+• Single-domain question → use the specialist agent, not research
+• Multi-domain or "why is X" or "full analysis" → research
+
+ClickHouse schema (database = market_data, all tables use ReplacingMergeTree — always add FINAL):
+  daily_prices        : symbol(String), category(String), trade_date(Date), open, high, low, close(Float64), volume
+  mf_holdings         : scheme_code, fund_name, as_of_month(Date), isin, security_name, asset_type, market_value_cr, pct_of_nav
+  mf_nav              : symbol, scheme_code, nav_date(Date), nav(Float64)
+  fii_dii_flows       : trade_date(Date), fii_net_cr, dii_net_cr, fii_gross_buy_cr, fii_gross_sell_cr
+  fii_dii_fno_daily   : trade_date(Date), fii_fut_net_oi, fii_opt_call_net_oi, fii_opt_put_net_oi, nifty_close
+  signal_composite    : as_of(Date), etf_symbol, composite_score(Float32), action, macro_score, ml_score
+  ml_predictions      : as_of(Date), expected_return_pct, regime_signal, cv_r2_mean, goldbees_close
+  weight_checkpoints  : as_of(Date), symbol, method, recommended_weight, garch_vol_pct, regime
+  inav_snapshots      : symbol, snapshot_at(DateTime), inav(Float64), market_price(Float64), premium_discount_pct(Float64), source(String)
+  -- NOTE: for current iNAV use get_live_inav(symbol) NOT raw SQL — it auto-refreshes from NSE if DB is stale
+  cot_gold            : report_date(Date), mm_long, mm_short, mm_net, open_interest
+  fx_rates            : trade_date(Date), symbol, close(Float64)
+  macro_indicators    : ref_year, country_code, indicator_code, indicator_name, value
+  news_articles       : fetched_at(DateTime), category, sentiment, impact_tier, title, source
+  import_watermarks   : source, symbol, last_date(Date), updated_at
+  stock_valuation     : symbol, snapshot_date(Date), trailing_pe, forward_pe, price_to_book, market_cap
+  deepdive_financials : ticker, report_date(Date), revenue_usd_m, net_income_usd_m, free_cash_flow_usd_m
+  deepdive_valuation  : ticker, report_date(Date), pe_trailing, ev_ebitda, fcf_yield_pct
+
+SQL rules (CRITICAL — never use placeholder values like YYYY-MM-DD):
+  FINAL modifier : always add FINAL after table name
+  Current date   : today()
+  N days ago     : today() - 30
+  Start of month : toStartOfMonth(today())
+  Specific date  : toDate('2026-05-01')   ← use real dates only, never YYYY-MM-DD
+
+Chart tools available (use when the query involves price, trend, pattern, comparison, flows, weights, or scores):
+  plot_price_chart(symbol, days)              — line chart: price trend
+  plot_multi_price_chart('SYM1,SYM2', days)  — normalised comparison
+  plot_fii_dii_chart(days)                   — bar chart: FII/DII net flows
+  plot_dxy_chart(days)                       — line chart: DXY (US Dollar Index) trend (default 365 = 1 year)
+  plot_signal_scores()                       — bar chart: all ETF composite scores
+  plot_signal_breakdown('SYM1,SYM2')         — grouped: pillar weights per ETF
+  plot_fund_holdings_chart(fund, top_n)      — horizontal bar: holdings by pct_of_nav
+  plot_weight_recommendations(method)        — horizontal bar: position weights
+  plot_nav_chart(symbol_or_scheme, days)     — line chart: MF/ETF NAV trend (pass NSE symbol e.g. 'GOLDBEES' or numeric scheme code)
+  plot_intl_etf_performance()                — bar chart: 3-year total return % for all 6 intl ETFs (intl_etf agent)
+  plot_intl_etf_premium(symbol, days)        — line chart: scarcity premium/discount trend for one intl ETF (intl_etf agent)
+
+IMPORTANT: Always include chart tools as explicit numbered plan steps when visualisation adds value.
+If a chart is requested but no specific chart tool exists in the list above, route to the `code` or `research` agent and plan to write Python code to build/plot the chart using `plotext` at run time.
+Example: "5. Plot 90-day price trend → plot_price_chart('GOLDBEES', 90)"
+
+Today's Date: {today}
+User query: "{query}"

--- a/src/prompts/router_system_prompt.txt
+++ b/src/prompts/router_system_prompt.txt
@@ -1,0 +1,28 @@
+You are an intent classifier for a financial intelligence platform focused on \
+Indian equity and commodity markets. Classify the user's question into exactly \
+one of the following intents:
+
+| Intent        | Route when the user asks about                                    |
+|---------------|-------------------------------------------------------------------|
+| deepdive      | US stock SEC filings, 10-K/10-Q, XBRL, annual reports, EDGAR     |
+| research      | Autonomous/deep/comprehensive multi-domain research on a topic    |
+| india_equity  | Indian stock fundamentals, earnings, price, financials, MF hold.  |
+| signal        | ETF signals, GOLDBEES ML pipeline, Kelly weight, GARCH, iNAV     |
+| macro         | COMEX, FII/DII flows, macro themes, geopolitics, crude, gold/USD  |
+| mf            | Mutual-fund holdings, NAV returns, fund consensus, fund managers  |
+| intl_etf      | International ETFs (MAFANG, HNGSNGBEES, Hang Seng, Nasdaq ETF)   |
+| news          | Latest news, headlines, news sentiment for a stock/ETF/market     |
+| code          | Write/run/debug Python code, create scripts, ad-hoc analysis      |
+| database      | ClickHouse queries, SQL, table schema, watermarks, row counts     |
+| main          | Portfolio analysis, general questions, or anything not above      |
+
+Special routing rules:
+- "import", "refresh", "sync", "backfill" data → always "main" (import runs there)
+- Questions about a SPECIFIC mutual fund (DSP / Nippon / Bajaj / Quant / ICICI Multi Asset, scheme codes, fund managers, MF holdings, fund cross-ownership, NAV returns, "which funds hold X", "smart-money consensus across funds") → "mf"
+- Questions mentioning specific Indian companies (RELIANCE, TCS, HDFC) → "india_equity"
+- "plot" or "chart" + macro keyword → "macro"; + ETF keyword → "signal"
+- "plot" or "chart" + Indian stock name (RELIANCE, TCS, ADVENZYMES, etc.) → "india_equity"
+- When uncertain, prefer "main" over guessing
+
+Respond with ONLY a JSON object (no markdown, no explanation):
+{"intent": "<intent>", "confidence": <0.0-1.0>}

--- a/tests/test_chat_followup.py
+++ b/tests/test_chat_followup.py
@@ -84,5 +84,18 @@ class TestChatFollowupRouting(unittest.TestCase):
         self.assertFalse(_is_numeric_choice_prompt("Here is the GOLDBEES ML prediction report."))
         self.assertFalse(_is_numeric_choice_prompt(""))
 
+    def test_numeric_choice_inputs(self):
+        """Test that inputs like digits or source names are correctly routed as follow-ups for numeric choice prompts."""
+        prev_answer = "DATA_SOURCE_REQUIRED: Ask the user which data source to use before importing:\n1. Shoonya\n2. NSE\n3. yfinance"
+        self.assertTrue(_is_numeric_choice_prompt(prev_answer))
+        
+        # Digits/sources should match
+        self.assertTrue(prev_answer and (_is_numeric_choice_prompt(prev_answer) and ("3".strip().lower().isdigit() or "3".strip().lower() in ("shoonya", "nse", "yfinance"))))
+        self.assertTrue(prev_answer and (_is_numeric_choice_prompt(prev_answer) and ("yfinance".strip().lower().isdigit() or "yfinance".strip().lower() in ("shoonya", "nse", "yfinance"))))
+        self.assertTrue(prev_answer and (_is_numeric_choice_prompt(prev_answer) and ("nse".strip().lower().isdigit() or "nse".strip().lower() in ("shoonya", "nse", "yfinance"))))
+        
+        # Arbitrary queries should not be matched as choices
+        self.assertFalse(prev_answer and (_is_numeric_choice_prompt(prev_answer) and ("what is goldbees price".strip().lower().isdigit() or "what is goldbees price".strip().lower() in ("shoonya", "nse", "yfinance"))))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_intent_router.py
+++ b/tests/test_intent_router.py
@@ -13,88 +13,8 @@ These 50+ test cases serve as a regression net: any change to routing logic
 from __future__ import annotations
 
 import pytest
-
 from src.agents.sub_agents import route_intent
-
-
-# ── Golden pairs: (question, expected_intent) ─────────────────────────────────
-# Grouped by expected intent for readability.
-
-GOLDEN_PAIRS: list[tuple[str, str]] = [
-    # ── main (default / import / general) ─────────────────────────────────────
-
-    ("import nav of GOLDBEES", "main"),
-    ("refresh stock prices", "main"),
-    ("sync all data", "main"),
-    ("backfill etf prices", "main"),
-    ("import --category stocks", "main"),
-    ("import dxy, comex", "main"),
-    ("import dxy", "main"),
-    ("refresh GOLDBEES, NIFTYBEES", "main"),
-
-    # ── signal ────────────────────────────────────────────────────────────────
-    ("what is the composite signal for GOLDBEES?", "signal"),
-    ("run goldbees pipeline", "signal"),
-    ("today's gold signal", "signal"),
-    ("show kelly weight for GOLDBEES", "signal"),
-    ("what is the blended weight?", "signal"),
-    ("GARCH volatility chart", "signal"),
-    ("ml prediction for etfs", "signal"),
-    ("regime signal", "signal"),
-    ("buy signal for etfs", "signal"),
-    ("plot price chart", "signal"),
-    ("plot returns chart", "signal"),
-
-    # ── macro ─────────────────────────────────────────────────────────────────
-    ("what are the macro themes today?", "macro"),
-    ("comex pre-market analysis", "macro"),
-    ("FII flows this week", "macro"),
-    ("DII flow trend", "macro"),
-    ("gold price outlook", "macro"),
-    ("crude oil impact on Indian markets", "macro"),
-    ("what is usd-inr doing?", "macro"),
-    ("is there a war risk from Iran?", "macro"),
-    ("tariff impact on equities", "macro"),
-    ("COT report for gold", "macro"),
-
-    # ── deepdive ──────────────────────────────────────────────────────────────
-    ("deep dive ADSK", "deepdive"),
-    ("10-K filing for Apple", "deepdive"),
-    ("SEC filing analysis for NVDA", "deepdive"),
-    ("EDGAR annual report MSFT", "deepdive"),
-
-    # ── news ──────────────────────────────────────────────────────────────────
-    ("latest news on RELIANCE", "news"),
-    ("market headlines today", "news"),
-    ("etf news sentiment", "news"),
-    ("what's happening with TCS?", "news"),
-    ("breaking news for IT sector", "news"),
-
-    # ── code ──────────────────────────────────────────────────────────────────
-    ("write a python script to backtest momentum", "code"),
-    ("create a new fetcher for NSE data", "code"),
-    ("execute python code to analyze returns", "code"),
-
-    # ── database ──────────────────────────────────────────────────────────────
-    ("query the database for GOLDBEES prices", "database"),
-    ("show me all tables in clickhouse", "database"),
-    ("SELECT count() FROM market_data.daily_prices", "database"),
-    ("describe table daily_prices", "database"),
-    ("what are the watermarks?", "database"),
-
-    # ── intl_etf ──────────────────────────────────────────────────────────────
-    ("international etf performance", "intl_etf"),
-    ("MAFANG ETF analysis", "intl_etf"),
-    ("Hang Seng ETF regime", "intl_etf"),
-    ("HNGSNGBEES premium", "intl_etf"),
-
-    # ── research ──────────────────────────────────────────────────────────────
-    ("autonomous research on gold ETFs", "research"),
-    ("comprehensive analysis of HDFC Bank", "research"),
-    ("deep research into pharma sector", "research"),
-    ("full thesis on renewable energy stocks", "research"),
-    ("why is GOLDBEES falling today?", "research"),
-]
+from src.agents.golden_pairs import GOLDEN_PAIRS
 
 
 class TestRegexRouter:

--- a/tests/test_intent_router.py
+++ b/tests/test_intent_router.py
@@ -28,6 +28,9 @@ GOLDEN_PAIRS: list[tuple[str, str]] = [
     ("sync all data", "main"),
     ("backfill etf prices", "main"),
     ("import --category stocks", "main"),
+    ("import dxy, comex", "main"),
+    ("import dxy", "main"),
+    ("refresh GOLDBEES, NIFTYBEES", "main"),
 
     # ── signal ────────────────────────────────────────────────────────────────
     ("what is the composite signal for GOLDBEES?", "signal"),


### PR DESCRIPTION
This PR extracts hardcoded prompts to standalone files under `src/prompts/`, enables dynamic thinking mode & context window size configuration in the planning LLM, resolves the `GOLDEN_PAIRS` import error (by placing it in production module), and dynamically resolves Ollama base URL in news RAG.