### PR TITLE
fix: move local scope imports to global in agent_server.py

### DIFF
--- a/src/ui/agent_server.py
+++ b/src/ui/agent_server.py
@@ -2,6 +2,8 @@ import os
 import sys
 import json
 import urllib.parse
+import urllib.request
+import xml.etree.ElementTree as ET
 import webbrowser
 from http.server import SimpleHTTPRequestHandler, HTTPServer
 from socketserver import ThreadingTCPServer
@@ -220,7 +222,6 @@ class StudioRequestHandler(SimpleHTTPRequestHandler):
                     if promoter_delta < 0:
                         analysis += "🔴 **Promoter % Drop Detected.** Running dilution audit checklist:\n\n"
                         # Perform automated check for QIP or Preferential allotment news
-                        import urllib.request
                         query = urllib.parse.quote(f"{symbol} QIP preferential allotment debt reduction share capital")
                         url = f"https://news.google.com/rss/search?q={query}"
                         
@@ -229,7 +230,6 @@ class StudioRequestHandler(SimpleHTTPRequestHandler):
                             req = urllib.request.Request(url, headers={'User-Agent': 'Mozilla/5.0'})
                             with urllib.request.urlopen(req, timeout=5) as response:
                                 html = response.read().decode('utf-8')
-                                import xml.etree.ElementTree as ET
                                 root = ET.fromstring(html)
                                 for item in root.findall('.//item')[:5]:
                                     title = item.find('title').text


### PR DESCRIPTION
Fixes a classic Python UnboundLocalError inside the do_POST handler, where importing urllib.request locally inside do_POST marked the global urllib module name as unbound at the beginning of the function scope.