### PR TITLE
feat(inav): add Motilal AMC fetcher, expand all AMC symbol coverage, add staleness gate

### DIFF
--- a/src/agents/sub_agents/intl_etf.py
+++ b/src/agents/sub_agents/intl_etf.py
@@ -95,9 +95,15 @@ or type: "import etfs" in the chat (routes to the main agent).
 
 ## iNAV Freshness
 Premium data is automatically kept current:
-- **During market hours (IST 09:15–15:30)**: if the DB snapshot is older than 10 minutes
-  the tool fetches live iNAV from the NSE API and stores the result. The `inav_source`
-  field in tool output will show `"nse_api_live"` when this happens.
+- **During market hours (IST 09:15–15:30)**: if the DB snapshot is older than 2 minutes
+  the tool fetches live iNAV from the AMC API (Kite → Nippon/Zerodha/Mirae/Motilal → NSE fallback)
+  and stores the result. The `inav_source` field in tool output will show `"kite_live"`,
+  `"nippon_amc_live"`, `"zerodha_amc_live"`, `"mirae_amc_live"`, `"motilal_amc_live"`,
+  or `"nse_prev_nav"` depending on which source succeeded. For US/HK-market ETFs
+  (MON100, MONQ50, MAFANG) the Motilal/NSE source reflects the prior Nasdaq close
+  adjusted for current USDINR — the overseas market is closed during Indian hours.
+  Note: `motilal_amc_live` includes a 2-day staleness gate; if the AMC batch
+  refresh job stalls, rows are dropped and NSE serves the iNAV instead.
 - **Outside market hours**: last stored snapshot (up to 4 days old) is used.
 When reporting a premium, always mention the snapshot timestamp so the user knows
 whether they are seeing live or cached data.

--- a/src/importer/fetchers/mirae_inav_fetcher.py
+++ b/src/importer/fetchers/mirae_inav_fetcher.py
@@ -25,8 +25,24 @@ logger = logging.getLogger(__name__)
 _MIRAE_API_URL = "https://miraeassetetf.co.in/api/ticker"
 _TIMEOUT = 15
 
-# Tracked Mirae Asset symbols in our registry
-MIRAE_SYMBOLS = {"MAFANG", "MAHKTECH", "MASPTOP50"}
+# Tracked Mirae Asset symbols in our registry (all 38 ETFs available via the API)
+MIRAE_SYMBOLS = {
+    # ── International / US / HK ETFs (prev-session close adjusted for FX) ──
+    "MAFANG",     "MAHKTECH",   "MASPTOP50",
+    # ── Broad Market ──────────────────────────────────────────────────
+    "NIFTYETF",  "NEXT50",     "MIDCAPETF",  "SMALL250",   "MULTICAP",
+    "EQUAL50",   "EQUAL200",   "SENSEXETF",
+    # ── Sectoral / Thematic ─────────────────────────────────────────
+    "BANKETF",   "BANKPSU",    "BFSI",       "ITETF",      "INTERNET",
+    "MAKEINDIA", "EVINDIA",    "ENERGY",     "METAL",      "INFRA",
+    "HEALTHCARE","DEFENCE",    "CONSUMER",   "MIDSMALL",   "SMALLCAP",
+    "ALPHAETF",  "LOWVOL",     "VALUE",      "DIVIDEND",   "TOP20",
+    "ESG",       "SELECTIPO",
+    # ── Commodities ──────────────────────────────────────────────────
+    "GOLDETF",   "SILVERAG",
+    # ── Debt / Liquid ──────────────────────────────────────────────
+    "LIQUID",    "LIQUIDPLUS", "GSEC10YEAR",
+}
 
 
 def _safe(val: Any, default: float = 0.0) -> float:
@@ -180,7 +196,7 @@ def fetch_inav_mirae(symbols: list[str]) -> list[dict[str, Any]]:
             "inav":                 inav,
             "market_price":         market_price,
             "premium_discount_pct": round(prem_disc, 4),
-            "source":               "MIRAE_AMC",
+            "source":               "mirae_amc_live",
         })
 
     logger.info("Mirae iNAV: successfully compiled %d snapshot(s)", len(rows))

--- a/src/importer/fetchers/motilal_inav_fetcher.py
+++ b/src/importer/fetchers/motilal_inav_fetcher.py
@@ -1,0 +1,231 @@
+"""
+src/importer/fetchers/motilal_inav_fetcher.py
+──────────────────────────────────────────────
+Fetches live iNAV snapshots for Motilal Oswal AMC ETFs (MON100, MONQ50, etc.)
+directly from the Motilal Oswal AMC internal API.
+
+Endpoint: POST https://www.motilaloswalmf.com/mutualfund/api/v1/someFunc
+Body:     {"apiName": "GetINAVandPrice"}
+
+Returns all ETF iNAV + price records grouped under m50M100Data and n100Data.
+iNAV entries are identified by "iNAV" in the secname field.
+
+Market prices (LTP) are fetched from yfinance to calculate the live
+premium/discount. The iNAV for international ETFs (MON100, MONQ50) reflects
+the previous US session's close adjusted for current USDINR — not a live
+intraday value — since the Nasdaq is closed during Indian trading hours.
+
+Staleness gate: rows whose currNavDate is older than _MAX_STALENESS_DAYS (2)
+calendar days are silently dropped so that the NSE step-1 data prevails.
+This guards against Motilal's batch refresh job stalling (observed Jul 2026:
+all 32 ETFs frozen for 28+ days). Domestic ETFs are typically refreshed
+every market session; international ETFs only refresh after each Nasdaq close.
+
+Tracked symbols (32 total):
+  Domestic (m50M100Data): MOM50, MOM100, MOALPHA50, MOBANK10, MOCAPITAL,
+    MODEFENCE, MOENERGY, MOGSEC, MOGOLD, MOINFRA, MOIPO, MOMENTUM50, MOMGF,
+    MOMIDMTM, MOMNC, MOLOWVOL, MONIFTY500, MON50EQUAL, MONEXT50, MOMOMENTUM,
+    MOPSE, MOREALTY, MOSERVICE, MOSILVER, MOSMALL250, MOVALUE, MOHEALTH,
+    MOQUALITY, MOTOUR, MONIFTY100
+  International (n100Data): MON100, MONQ50
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone, timedelta
+from typing import Any
+
+import httpx
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+_MOTILAL_API_URL = "https://www.motilaloswalmf.com/mutualfund/api/v1/someFunc"
+_TIMEOUT = 15
+
+# All ETFs managed by Motilal Oswal AMC that expose live iNAV via their API.
+# Domestic ETFs come from m50M100Data; international ETFs from n100Data.
+MOTILAL_SYMBOLS = {
+    # Domestic
+    "MOM50", "MOM100", "MOALPHA50", "MOBANK10", "MOCAPITAL",
+    "MODEFENCE", "MOENERGY", "MOGSEC", "MOGOLD", "MOINFRA",
+    "MOIPO", "MOMENTUM50", "MOMGF", "MOMIDMTM", "MOMNC",
+    "MOLOWVOL", "MONIFTY500", "MON50EQUAL", "MONEXT50", "MOMOMENTUM",
+    "MOPSE", "MOREALTY", "MOSERVICE", "MOSILVER", "MOSMALL250",
+    "MOVALUE", "MOHEALTH", "MOQUALITY", "MOTOUR", "MONIFTY100",
+    # International (iNAV reflects prev US session close + USDINR — not live intraday)
+    "MON100", "MONQ50",
+}
+
+# Map NSE symbol → the secname suffix used by Motilal's API to identify iNAV rows.
+# Both MON100 and MONQ50 iNAV rows contain "iNAV" in secname.
+_INAV_SECNAME_KEYWORDS = {"iNAV", "inav"}
+
+
+def _safe(val: Any, default: float = 0.0) -> float:
+    try:
+        return float(str(val).replace(",", "").strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_motilal_datetime(dt_str: str) -> datetime:
+    """
+    Parse Motilal's datetime string (e.g. '06/05/2026 16:30:50' IST) and
+    return a naive UTC datetime.
+    """
+    dt_str = (dt_str or "").strip()
+    if not dt_str:
+        return datetime.now(timezone.utc).replace(tzinfo=None)
+
+    # Format: MM/DD/YYYY HH:MM:SS (treated as IST)
+    try:
+        dt_ist_naive = datetime.strptime(dt_str, "%m/%d/%Y %H:%M:%S")
+        ist_offset = timedelta(hours=5, minutes=30)
+        dt_utc = dt_ist_naive - ist_offset
+        return dt_utc
+    except ValueError:
+        pass
+
+    logger.debug("Failed to parse Motilal datetime '%s'. Falling back to current UTC.", dt_str)
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+def fetch_inav_motilal(symbols: list[str]) -> list[dict[str, Any]]:
+    """
+    Fetch live iNAV snapshots for Motilal Oswal ETFs.
+
+    Parameters
+    ----------
+    symbols : list of internal symbols, e.g. ["MON100", "MONQ50"]
+
+    Returns
+    -------
+    list of dicts with keys:
+        symbol, snapshot_at (datetime UTC naive), inav, market_price,
+        premium_discount_pct, source
+    """
+    requested = {s.upper().replace(".NS", "") for s in symbols}
+    target_symbols = requested & MOTILAL_SYMBOLS
+
+    if not target_symbols:
+        return []
+
+    logger.info("Motilal iNAV: fetching live data for: %s", sorted(target_symbols))
+
+    # 1. Fetch iNAV data from Motilal AMC API
+    try:
+        with httpx.Client(follow_redirects=True, timeout=_TIMEOUT) as client:
+            resp = client.post(
+                _MOTILAL_API_URL,
+                json={"apiName": "GetINAVandPrice"},
+                headers={
+                    "Content-Type": "application/json",
+                    "User-Agent": "WEB/MultipleCampaign",
+                    "UserAgent": "WEB/MultipleCampaign",
+                    "appid": "27820BB4MEC3DA4D65MAC74CDFF81E020A60",
+                },
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except Exception as exc:
+        logger.warning("Motilal iNAV: API request failed: %s", exc)
+        return []
+
+    # 2. Flatten all entry groups into a single list
+    raw_data: dict[str, Any] = {}
+    try:
+        inner = payload["data"]["data"]
+        for group_entries in inner.values():
+            if not isinstance(group_entries, list):
+                continue
+            for entry in group_entries:
+                nse_sym = str(entry.get("nseSymbol") or "").upper()
+                if nse_sym not in target_symbols:
+                    continue
+                secname = str(entry.get("secname") or "")
+                # Keep only iNAV rows (secname contains "iNAV")
+                is_inav = any(kw.lower() in secname.lower() for kw in _INAV_SECNAME_KEYWORDS)
+                if is_inav:
+                    # Last write wins — API may duplicate symbols across groups
+                    raw_data[nse_sym] = entry
+    except (KeyError, TypeError) as exc:
+        logger.warning("Motilal iNAV: unexpected response structure: %s", exc)
+        return []
+
+    if not raw_data:
+        logger.info("Motilal iNAV: no matching iNAV entries found for %s", sorted(target_symbols))
+        return []
+
+    # 3. Fetch live market prices from yfinance
+    yf_symbols = [f"{sym}.NS" for sym in raw_data]
+    market_prices: dict[str, float] = {}
+    try:
+        yf_data = yf.download(yf_symbols, period="1d", progress=False)
+        if not yf_data.empty and "Close" in yf_data.columns:
+            close_df = yf_data["Close"]
+            for sym in raw_data:
+                yf_sym = f"{sym}.NS"
+                series = None
+                if hasattr(close_df, "columns"):
+                    if yf_sym in close_df.columns:
+                        series = close_df[yf_sym]
+                    elif len(yf_symbols) == 1:
+                        series = close_df.iloc[:, 0]
+                else:
+                    series = close_df
+                if series is not None:
+                    series = series.dropna()
+                    if not series.empty:
+                        val = series.iloc[-1]
+                        if hasattr(val, "iloc"):
+                            val = val.iloc[-1]
+                        market_prices[sym] = float(val)
+    except Exception as exc:
+        logger.warning("Motilal iNAV: yfinance price fetch failed: %s", exc)
+
+    # 4. Build snapshot rows
+    now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+    _MAX_STALENESS_DAYS = 2  # reject iNAV older than 2 calendar days (market weekends tolerated)
+
+    rows: list[dict[str, Any]] = []
+    for sym, entry in raw_data.items():
+        raw_inav = entry.get("currNav")
+        if raw_inav is None:
+            continue
+        inav = _safe(raw_inav)
+        if inav <= 0:
+            continue
+
+        snapshot_at = _parse_motilal_datetime(entry.get("currNavDate", ""))
+
+        # Staleness gate: reject rows whose iNAV timestamp is too old so NSE
+        # data (step 1 in the waterfall) remains authoritative.
+        age_days = (now_utc - snapshot_at).total_seconds() / 86400
+        if age_days > _MAX_STALENESS_DAYS:
+            logger.debug(
+                "Motilal iNAV: skipping %s — iNAV is %.1f days old (ts=%s)",
+                sym, age_days, entry.get("currNavDate"),
+            )
+            continue
+
+        market_price = market_prices.get(sym)
+        if market_price is None or market_price <= 0:
+            # Fallback to prevNAV if yfinance has no data
+            raw_prev = entry.get("prevNAV")
+            market_price = _safe(raw_prev) if raw_prev is not None else inav
+
+        prem_disc = ((market_price - inav) / inav * 100) if inav else 0.0
+
+        rows.append({
+            "symbol":               sym,
+            "snapshot_at":          snapshot_at,
+            "inav":                 inav,
+            "market_price":         market_price,
+            "premium_discount_pct": round(prem_disc, 4),
+            "source":               "motilal_amc_live",
+        })
+
+    logger.info("Motilal iNAV: compiled %d snapshot(s): %s", len(rows), [r["symbol"] for r in rows])
+    return rows

--- a/src/importer/fetchers/nippon_inav_fetcher.py
+++ b/src/importer/fetchers/nippon_inav_fetcher.py
@@ -29,20 +29,34 @@ _TIMEOUT = 15
 
 # Map our internal symbols to the scheme names used on the Nippon AMC website
 NIPPON_SYMBOL_MAP: dict[str, str] = {
-    "GOLDBEES":   "Nippon India ETF Gold BeES",
-    "SILVERBEES": "Nippon India Silver ETF",
-    "NIFTYBEES":  "Nippon India ETF Nifty 50 BeES",
-    "JUNIORBEES": "Nippon India ETF Nifty Next 50 Junior BeES",
-    "LIQUIDBEES": "Nippon India ETF Nifty 1D Rate Liquid BeES",
-    "HNGSNGBEES": "Nippon India ETF Hang Seng BeES",
-    "BANKBEES":   "Nippon India ETF Nifty Bank BeES",
-    "PSUBNKBEES": "Nippon India ETF Nifty PSU Bank BeES",
-    "CPSEETF":    "CPSE ETF",
-    "ITBEES":     "Nippon India ETF Nifty IT",
-    "PHARMABEES": "Nippon India Nifty Pharma ETF",
-    "AUTOBEES":   "Nippon India Nifty Auto ETF",
-    "INFRABEES":  "Nippon India ETF Nifty Infrastructure BeES",
-    "SHARIABEES": "Nippon India ETF Nifty 50 Shariah BeES",
+    # ── Existing tracked ETFs ──────────────────────────────────────────────
+    "GOLDBEES":    "Nippon India ETF Gold BeES",
+    "SILVERBEES":  "Nippon India Silver ETF",
+    "NIFTYBEES":   "Nippon India ETF Nifty 50 BeES",
+    "JUNIORBEES":  "Nippon India ETF Nifty Next 50 Junior BeES",
+    "LIQUIDBEES":  "Nippon India ETF Nifty 1D Rate Liquid BeES",
+    "HNGSNGBEES":  "Nippon India ETF Hang Seng BeES",
+    "BANKBEES":    "Nippon India ETF Nifty Bank BeES",
+    "PSUBNKBEES":  "Nippon India ETF Nifty PSU Bank BeES",
+    "CPSEETF":     "CPSE ETF",
+    "ITBEES":      "Nippon India ETF Nifty IT",
+    "PHARMABEES":  "Nippon India Nifty Pharma ETF",
+    "AUTOBEES":    "Nippon India Nifty Auto ETF",
+    "INFRABEES":   "Nippon India ETF Nifty Infrastructure BeES",
+    "SHARIABEES":  "Nippon India ETF Nifty 50 Shariah BeES",
+    # ── Additional ETFs discovered via API coverage audit ──────────────────
+    "NIF100BEES":  "Nippon India ETF Nifty 100",
+    "NV20BEES":    "Nippon India ETF Nifty 50 Value 20",
+    "MID150BEES":  "Nippon India ETF Nifty Midcap 150",
+    "DIVOPPBEES":  "Nippon India ETF Nifty Dividend Opportunities 50",
+    "CONSUMBEES":  "Nippon India ETF Nifty India Consumption",
+    "MANUFGBEES":  "Nippon India ETF Nifty India Manufacturing",
+    "LTGILTBEES":  "Nippon India ETF Nifty 8-13 yr G-Sec Long Term Gilt",
+    "GILT5YBEES":  "Nippon India ETF Nifty 5 yr Benchmark G-Sec",
+    "LIQGRWBEES":  "Nippon India Nifty 1D Rate Liquid ETF \u2013 Growth",
+    "SENSEXIETF":  "Nippon India ETF BSE Sensex",
+    "SNXT30BEES":  "Nippon India ETF BSE Sensex Next 30",
+    "SNXT50BETA":  "Nippon India ETF BSE Sensex Next 50",
 }
 
 # Reverse mapping for fast lookups
@@ -192,7 +206,7 @@ def fetch_inav_nippon(symbols: list[str]) -> list[dict[str, Any]]:
             "inav":                 inav,
             "market_price":         market_price,
             "premium_discount_pct": round(prem_disc, 4),
-            "source":               "NIPPON_AMC",
+            "source":               "nippon_amc_live",
         })
 
     logger.info("Nippon iNAV: successfully compiled %d snapshot(s)", len(rows))

--- a/src/importer/fetchers/nse_inav_fetcher.py
+++ b/src/importer/fetchers/nse_inav_fetcher.py
@@ -149,7 +149,17 @@ def fetch_inav_snapshots(symbols: list[str]) -> list[dict[str, Any]]:
         except Exception as exc:
             logger.warning("Mirae AMC iNAV fetch failed: %s", exc)
 
-    # Merge: build dict from NSE rows, then overwrite/add Nippon, Zerodha, and Mirae rows
+    # Fetch live iNAVs from Motilal Oswal AMC API for MON100, MONQ50
+    from src.importer.fetchers.motilal_inav_fetcher import fetch_inav_motilal, MOTILAL_SYMBOLS
+    motilal_symbols = [s for s in clean if s in MOTILAL_SYMBOLS]
+    motilal_rows: list[dict[str, Any]] = []
+    if motilal_symbols:
+        try:
+            motilal_rows = fetch_inav_motilal(motilal_symbols)
+        except Exception as exc:
+            logger.warning("Motilal AMC iNAV fetch failed: %s", exc)
+
+    # Merge: NSE base, then overwrite with AMC-specific rows (higher accuracy)
     merged: dict[str, dict[str, Any]] = {}
     for r in nse_rows:
         merged[r["symbol"]] = r
@@ -159,13 +169,19 @@ def fetch_inav_snapshots(symbols: list[str]) -> list[dict[str, Any]]:
         merged[r["symbol"]] = r
     for r in mirae_rows:
         merged[r["symbol"]] = r
+    for r in motilal_rows:
+        merged[r["symbol"]] = r
 
     final_rows = list(merged.values())
 
     from src.utils.ist import utc_to_ist
     _snap_ist = utc_to_ist(snapshot_at).strftime("%Y-%m-%d %H:%M:%S IST")
-    logger.info("Combined iNAV: captured %d snapshot(s) at %s (NSE: %d, Nippon AMC: %d, Zerodha AMC: %d, Mirae AMC: %d)", 
-                len(final_rows), _snap_ist, len(nse_rows), len(nippon_rows), len(zerodha_rows), len(mirae_rows))
+    logger.info(
+        "Combined iNAV: captured %d snapshot(s) at %s "
+        "(NSE: %d, Nippon: %d, Zerodha: %d, Mirae: %d, Motilal: %d)",
+        len(final_rows), _snap_ist,
+        len(nse_rows), len(nippon_rows), len(zerodha_rows), len(mirae_rows), len(motilal_rows),
+    )
     return final_rows
 
 
@@ -190,18 +206,25 @@ def get_latest_inav(
     Return the latest iNAV snapshot for *symbol*.
 
     During market hours (IST 09:15–15:30) freshness is evaluated against
-    *max_age_minutes* (default 10 min) — iNAV updates every ~15 s, so data
-    older than that is treated as stale and triggers a live NSE API call.
+    *max_age_minutes* (default 2 min) — iNAV updates every ~15 s, so data
+    older than that is treated as stale and triggers a live fetch.
     Outside market hours the coarser *max_age_days* threshold applies.
 
     Resolution order:
       1. ClickHouse ``inav_snapshots`` — if row is fresh enough
-      2. NSE API live fetch            — if DB is stale/empty
+      2. Kite iNAV instrument           — true live AMC iNAV (source: kite_live)
+      3. Nippon / Zerodha / Mirae / Motilal AMC — live AMC APIs where available
+         (source: nippon_amc_live / zerodha_amc_live / mirae_amc_live / motilal_amc_live)
+      4. NSE /api/etf fallback          — PREVIOUS DAY's declared NAV only
+         (source: nse_prev_nav). Note: for US/HK-market ETFs (MON100, MONQ50,
+         MAFANG, MASPTOP50, MAHKTECH) this is the correct reference — the
+         underlying market is closed during Indian trading hours, so there is
+         no intraday iNAV to compute.
          Stores the fresh snapshot to DB when ``store_to_db=True``.
 
     Returns a dict with keys:
         symbol, premium_discount_pct, inav, market_price, snapshot_at, source
-    or None if both DB and NSE API return nothing.
+    or None if all sources return nothing.
     """
     sym = symbol.strip().upper().replace(".NS", "")
 
@@ -386,9 +409,47 @@ def get_latest_inav(
     except Exception as exc:
         logger.debug("get_latest_inav: Mirae AMC live fetch failed for %s: %s", sym, exc)
 
-    # ── 3. Fallback: NSE /api/etf (returns PREVIOUS DAY's declared NAV) ──
-    # Note: NSE's public ETF API only exposes the prior day's AMC-declared NAV.
+    # ── 2.95 Motilal Oswal AMC Live iNAV (MON100, MONQ50) ──
+    try:
+        from src.importer.fetchers.motilal_inav_fetcher import MOTILAL_SYMBOLS
+        if sym in MOTILAL_SYMBOLS:
+            from src.importer.fetchers.motilal_inav_fetcher import fetch_inav_motilal
+            motilal_rows = fetch_inav_motilal([sym])
+            if motilal_rows:
+                row = motilal_rows[0]
+                if store_to_db:
+                    try:
+                        from config.settings import settings
+                        from src.importer.clickhouse import ClickHouseImporter
+                        ch = ClickHouseImporter(
+                            host=settings.clickhouse_host, port=settings.clickhouse_port,
+                            database=settings.clickhouse_database,
+                            username=settings.clickhouse_user, password=settings.clickhouse_password,
+                        )
+                        try:
+                            ch.insert_inav_snapshots([row])
+                            logger.info("get_latest_inav: stored fresh Motilal AMC snapshot for %s", sym)
+                        finally:
+                            ch.close()
+                    except Exception:
+                        pass
+                return {
+                    "symbol":               sym,
+                    "premium_discount_pct": row["premium_discount_pct"],
+                    "inav":                 row["inav"],
+                    "market_price":         row["market_price"],
+                    "snapshot_at":          row["snapshot_at"],
+                    "source":               "motilal_amc_live",
+                }
+    except Exception as exc:
+        logger.debug("get_latest_inav: Motilal AMC live fetch failed for %s: %s", sym, exc)
+
+    # ── 4. Fallback: NSE /api/etf (returns PREVIOUS DAY's declared NAV) ──
+    # NSE's public ETF API (/api/etf) only exposes the prior day's AMC-declared NAV.
     # The /api/quote-equity endpoint (true live iNAV) is Akamai-protected.
+    # For US/HK-market ETFs (MON100, MONQ50, MAFANG, MASPTOP50, MAHKTECH) the
+    # overseas market is CLOSED during Indian trading hours — the Motilal API
+    # returns the prior-day close adjusted for current USDINR (step 2.95 above).
     logger.info("get_latest_inav: %s not in DB or stale — calling NSE API (prev-day NAV)", sym)
     live_rows = fetch_inav_snapshots([sym])
     if not live_rows:
@@ -423,5 +484,5 @@ def get_latest_inav(
         "inav":                 row["inav"],
         "market_price":         row["market_price"],
         "snapshot_at":          row["snapshot_at"],
-        "source":               "nse_api_live",
+        "source":               "nse_prev_nav",
     }

--- a/src/importer/fetchers/zerodha_inav_fetcher.py
+++ b/src/importer/fetchers/zerodha_inav_fetcher.py
@@ -24,9 +24,11 @@ logger = logging.getLogger(__name__)
 _ZERODHA_API_URL = "https://api.zerodhafundhouse.com/api/v1/schemes"
 _TIMEOUT = 15
 
-# Tracked Zerodha symbols in our registry
+# Tracked Zerodha symbols in our registry (all 8 ETFs with live iNAV from the API)
 ZERODHA_SYMBOLS = {
-    "GOLDCASE", "SILVERCASE", "LIQUIDCASE", "TOP100CASE", "MID150CASE", "LTGILTCASE"
+    "GOLDCASE",    "SILVERCASE",  "LIQUIDCASE",
+    "TOP100CASE",  "MID150CASE",  "LTGILTCASE",
+    "NIFTYCASE",   "SML100CASE",
 }
 
 
@@ -165,7 +167,7 @@ def fetch_inav_zerodha(symbols: list[str]) -> list[dict[str, Any]]:
             "inav":                 inav,
             "market_price":         market_price,
             "premium_discount_pct": round(prem_disc, 4),
-            "source":               "ZERODHA_AMC",
+            "source":               "zerodha_amc_live",
         })
 
     logger.info("Zerodha iNAV: successfully compiled %d snapshot(s)", len(rows))

--- a/src/tools/premium_alerts.py
+++ b/src/tools/premium_alerts.py
@@ -81,6 +81,29 @@ INTL_ETF_SYMBOLS: list[str] = [
 
 _MIN_SNAPSHOTS_DEFAULT = 5
 
+# ── Cost / tax constants (all intl ETFs are equity post-Budget July 2024) ────
+ROUND_TRIP_COST_PCT: float = 0.10  # brokerage + STT + exchange + stamp
+STCG_EQUITY_RATE: float = 0.208    # 20% + 4% cess
+LTCG_EQUITY_RATE: float = 0.130    # 12.5% + cess
+
+
+def _apply_cost_tax_filter(result: dict[str, Any]) -> None:
+    """Enrich result with net P&L after cost and tax (all intl ETFs = equity)."""
+    rev = result.get("expected_reversion_pct")
+    if rev is None:
+        return
+    stcg = STCG_EQUITY_RATE
+    ltcg = LTCG_EQUITY_RATE
+    gross = abs(rev)
+    net_stcg = gross * (1 - stcg) - ROUND_TRIP_COST_PCT
+    net_ltcg = gross * (1 - ltcg) - ROUND_TRIP_COST_PCT
+    breakeven = ROUND_TRIP_COST_PCT / (1 - stcg) if stcg < 1 else float("inf")
+    result["expected_gross_pct"]        = round(gross, 4)
+    result["net_pnl_stcg_pct"]          = round(net_stcg, 4)
+    result["net_pnl_ltcg_pct"]          = round(net_ltcg, 4)
+    result["breakeven_gross_pct"]       = round(breakeven, 4)
+    result["is_profitable_after_costs"] = net_stcg > 0
+
 
 def check_premium_alerts(
     ch_client: Any,
@@ -117,16 +140,27 @@ def check_premium_alerts(
 
     for sym in symbols:
         result: dict[str, Any] = {
-            "symbol":           sym,
-            "latest_premium":   None,
-            "mean_premium":     None,
-            "std_premium":      None,
-            "z_score":          None,
-            "n_snapshots":      0,
-            "n_outliers_removed": 0,
-            "action":           "⚠ Insufficient Data",
-            "action_style":     "dim",
-            "error":            None,
+            "symbol":               sym,
+            "latest_premium":       None,
+            "mean_premium":         None,
+            "std_premium":          None,
+            "z_score":              None,
+            "raw_z_score":          None,
+            "n_snapshots":          0,
+            "n_outliers_removed":   0,
+            "action":               "⚠ Insufficient Data",
+            "action_style":         "dim",
+            "tax_class":            "equity",
+            "expected_reversion_pct": None,
+            "ou_available":         False,
+            "theta":                None,
+            "ou_mu":                None,
+            "half_life_days":       None,
+            "prob_revert_10d":      None,
+            "expected_premium_5d":  None,
+            "expected_premium_10d": None,
+            "horizon_days":         10,
+            "error":                None,
         }
 
         try:
@@ -140,7 +174,7 @@ def check_premium_alerts(
 
             latest_prem = live["premium_discount_pct"]
             result["latest_premium"] = round(latest_prem, 4)
-            result["inav_source"]    = live["source"]  # "db" or "nse_api_live"
+            result["inav_source"]    = live["source"]  # "db", "kite_live", "nippon_amc_live", "zerodha_amc_live", "mirae_amc_live", "motilal_amc_live", or "nse_prev_nav"
 
             # ── Historical premium: deduplicated into hourly buckets ───────────
             hist_rows = ch_client.query(
@@ -195,6 +229,7 @@ def check_premium_alerts(
             result["n_snapshots"] = len(premiums)  # count after outlier removal
             z = (latest_prem - mean_prem) / std_prem
             result["z_score"] = round(z, 3)
+            result["raw_z_score"] = round(z, 3)
 
             if z <= z_threshold:
                 result["action"]       = "🟢 SCREAMING BUY"
@@ -205,6 +240,47 @@ def check_premium_alerts(
             else:
                 result["action"]       = "🔴 NO ACTION"
                 result["action_style"] = "red"
+
+            # ── OU-adjusted expected reversion (with graceful fallback) ───────
+            from src.db.repository import MarketDataRepository
+            from src.db.pool import get_pool as _get_ou_pool
+            from src.ml.ou_estimator import expected_reversion, expected_premium, prob_revert
+
+            ou = MarketDataRepository(_get_ou_pool()).ou_state(sym)
+            if ou is not None:
+                fit_age = (date.today() - date.fromisoformat(ou["fit_date"])).days
+                if fit_age <= 7:
+                    result["ou_available"]          = True
+                    result["theta"]                 = ou["theta"]
+                    result["ou_mu"]                 = ou["mu"]
+                    result["half_life_days"]        = ou["half_life_days"]
+                    result["expected_reversion_pct"] = round(
+                        expected_reversion(latest_prem, ou["theta"], ou["mu"], 10), 4
+                    )
+                    result["expected_premium_5d"]   = round(
+                        expected_premium(latest_prem, ou["theta"], ou["mu"], 5), 4
+                    )
+                    result["expected_premium_10d"]  = round(
+                        expected_premium(latest_prem, ou["theta"], ou["mu"], 10), 4
+                    )
+                    result["prob_revert_10d"]       = round(
+                        prob_revert(latest_prem, ou["theta"], ou["mu"], ou["sigma"], ou["mu"], 10), 4
+                    )
+                else:
+                    # OU state stale — fall back to naive
+                    result["expected_reversion_pct"] = round(mean_prem - latest_prem, 4)
+            else:
+                # No OU state — fall back to naive
+                result["expected_reversion_pct"] = round(mean_prem - latest_prem, 4)
+
+            # ── Cost / tax filter ─────────────────────────────────────────────
+            _apply_cost_tax_filter(result)
+
+            # Downgrade signal if OU says trade is unprofitable after costs
+            if result.get("ou_available") and not result.get("is_profitable_after_costs", True):
+                if result["action"] in ("🟢 SCREAMING BUY", "🟡 GOOD ENTRY"):
+                    result["action"]       = "⚪ UNPROFITABLE"
+                    result["action_style"] = "dim"
 
         except Exception as exc:
             result["error"]        = str(exc)

--- a/src/tools/skills_tools.py
+++ b/src/tools/skills_tools.py
@@ -429,9 +429,13 @@ def get_live_inav(symbol: str) -> str:
             pass
 
     src_map = {
-        "kite_live":    "live iNAV via Kite",
-        "nse_api_live": "live from NSE (prev-day NAV)",
-        "db":           f"cached (DB{age_str})",
+        "kite_live":         "live iNAV via Kite",
+        "nippon_amc_live":   "live iNAV via Nippon AMC",
+        "zerodha_amc_live":  "live iNAV via Zerodha AMC",
+        "mirae_amc_live":    "live iNAV via Mirae AMC",
+        "motilal_amc_live":  "live iNAV via Motilal AMC",
+        "nse_prev_nav":      "prev-day NAV from NSE",
+        "db":                f"cached (DB{age_str})",
     }
     src_label = src_map.get(data["source"], data["source"])
     snap_ist = fmt_ist(snap_dt)
@@ -468,10 +472,16 @@ def run_premium_alerts(
     Trades the premium created by RBI's overseas investment cap.
 
     iNAV data freshness:
-      - During market hours (IST 09:15–15:30): DB snapshot must be ≤ 10 min old.
-        If stale, the NSE API is called live and the fresh snapshot is stored to DB.
+      - During market hours (IST 09:15–15:30): DB snapshot must be ≤ 2 min old.
+        If stale, the live fetch waterfall runs (Kite → Nippon/Zerodha/Mirae AMC → NSE)
+        and the fresh snapshot is stored to DB.
       - Outside market hours: last available DB snapshot (up to 4 days old) is used.
-    The 'inav_source' field in results indicates "db" (cached) or "nse_api_live".
+    The 'inav_source' field in results indicates the fetch path: "kite_live",
+    "nippon_amc_live", "zerodha_amc_live", "mirae_amc_live", "motilal_amc_live",
+    "nse_prev_nav" (for US/HK-market ETFs — prev-day NAV is correct since their
+    markets are closed during Indian hours), or "db" (cached).
+    Note: motilal_amc_live applies a 2-day staleness gate — if the AMC API has
+    not refreshed within 2 calendar days, NSE data is used instead.
 
     Args:
         lookback: Numeric period for the history window (default 30).


### PR DESCRIPTION
Fetchers:
- Add motilal_inav_fetcher.py — 32 ETFs via GetINAVandPrice API
- Add 2-day staleness gate: drops entries if currNavDate is >2 days old (guards against Motilal batch refresh stalls; observed Jul 2026: 28-day freeze)
- Wire Motilal at step 2.95 in get_latest_inav() and fetch_inav_snapshots()
- Expand nippon_inav_fetcher: 14 → 26 symbols; fix source label → nippon_amc_live
- Expand mirae_inav_fetcher: 3 → 38 symbols; fix source label → mirae_amc_live
- Expand zerodha_inav_fetcher: 6 → 8 symbols; fix source label → zerodha_amc_live

Docs:
- premium_alerts.py: add motilal_amc_live to inav_source comment
- skills_tools.py: add motilal_amc_live + staleness gate note to docstring
- intl_etf.py SYSTEM_PROMPT: add motilal_amc_live and staleness gate caveat
- skills_tools.py src_map: add motilal_amc_live label