### PR TITLE
feat(importer): add amc_holdings_fetcher as canonical AMC holdings API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ python src/scripts/portfolio/inr_hedge_report.py
 python src/scripts/db/fix_bad_data.py                              # deduplication, watermark & price repair
 python src/scripts/dsp/import_all_dsp_equity.py                    # DSP holdings import
 python src/scripts/dsp/import_latest_dsp.py                        # latest month only
-python src/scripts/fund_imports/run.py <icici|nippon|all>          # Nippon: dynamic URL discovery from 2024 onward
+python src/scripts/fund_imports/run.py <icici|nippon|dsp|all>      # direct CLI; Nippon: dynamic URL discovery from 2024 onward
+# preferred: python src/main.py import --category nippon            # via amc_holdings_fetcher (canonical fetcher layer)
 python src/scripts/market/analyze_news_trend.py
 python src/scripts/goldbees_report.py                              # GOLDBEES signal (pre-baked, ~2s, use instead of MCP)
 python src/scripts/market/whale_tracker.py                         # all 7 multi-asset funds
@@ -147,7 +148,8 @@ All use `ReplacingMergeTree` — always query with `FINAL` to deduplicate.
   - `search_anomaly_events(symbol, days)` (`market/equity.py`) — equity-generic; loads corp actions from ClickHouse → runs pipeline with suppression → **parallel** Google News (ThreadPoolExecutor, ±1d fallback, NewsAPI for <30d dates). Call for any NSE/BSE stock anomaly investigation.
   - `get_corporate_actions(symbol)` (`market/equity.py`) — fetches NSE corporate actions, upserts to `corporate_actions` table, returns history. Call when chart shows extreme (>20%) price move or user asks about splits/bonuses.
 - **Chart markers:** `plot_price_chart` renders 🔴 GARCH+IF+PELT genuine anomalies and 🏦 corporate action ex-dates as separate scatter layers. Result is session-cached by `(symbol, category, n_rows)` in `_ANOMALY_DATES_CACHE`.
-- **Scripts subdirs:** `dsp/` (DSP AMC import + analysis), `fund_imports/` (factory-pattern AMC importers), `etf/` (ETF comparison, CAGR, risk), `ml/` (prediction backfill/eval), `portfolio/` (health checks, opportunity scan, MoM returns, parallel stock import), `market/` (macro, FII/DII, metals, sentiment), `db/` (ClickHouse backup/restore/sanity/repair).
+- **Scripts subdirs:** `dsp/` (DSP AMC import + analysis), `fund_imports/` (factory-pattern AMC importers — wrapped by `src/importer/fetchers/amc_holdings_fetcher.py`), `etf/` (ETF comparison, CAGR, risk), `ml/` (prediction backfill/eval), `portfolio/` (health checks, opportunity scan, MoM returns, parallel stock import), `market/` (macro, FII/DII, metals, sentiment), `db/` (ClickHouse backup/restore/sanity/repair).
+- **AMC holdings fetcher:** `src/importer/fetchers/amc_holdings_fetcher.py` — canonical entry point for all 4 AMC importers (nippon, dsp, icici, icici-index). Use `fetch_amc_holdings(amc, full_reimport=, dry_run=)` or `python src/main.py import --category nippon|dsp|icici|icici-index`. The `scripts/fund_imports/` factory is the implementation layer; `amc_holdings_fetcher` is the public API.
 
 ## Critical: Grounding Rules — DO NOT Hallucinate
 

--- a/src/importer/cli.py
+++ b/src/importer/cli.py
@@ -727,19 +727,13 @@ def run_import(
             console.print("  [yellow]⚠ No monthly rows returned.[/yellow]")
 
 
-    # ── AMC Fund-Holdings Importers (factory pattern) ────────────────────────
-    # Delegates to src/scripts/fund_imports/ for icici, nippon, icici-index, dsp.
-    # Each importer manages its own ClickHouse connection and watermarks.
+    # ── AMC Fund-Holdings Importers ───────────────────────────────────────────
     _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp") if c in categories]
     if _amc_cats:
-        from src.scripts.fund_imports.factory import create_importer as _create_fund_importer
+        from src.importer.fetchers.amc_holdings_fetcher import fetch_amc_holdings
 
         for _amc_cat in _amc_cats:
-            _kwargs: dict = {}
-            if _amc_cat in ("nippon", "dsp"):
-                _kwargs = {"full_reimport": full_reimport}
-            _imp = _create_fund_importer(_amc_cat, **_kwargs)
-            _imp.run(dry_run=dry_run)
+            fetch_amc_holdings(_amc_cat, full_reimport=full_reimport, dry_run=dry_run)
 
     ch.close()
 

--- a/src/importer/fetchers/amc_holdings_fetcher.py
+++ b/src/importer/fetchers/amc_holdings_fetcher.py
@@ -1,0 +1,60 @@
+"""
+src/importer/fetchers/amc_holdings_fetcher.py
+──────────────────────────────────────────────
+Canonical fetcher entry point for AMC monthly fund-holdings importers.
+
+Wraps the BaseFundImporter factory in src/scripts/fund_imports/ so that
+cli.py can invoke AMC holdings the same way it calls every other fetcher:
+
+    from src.importer.fetchers.amc_holdings_fetcher import fetch_amc_holdings
+    fetch_amc_holdings("nippon", full_reimport=False, dry_run=False)
+
+Supported AMC keys
+──────────────────
+    "nippon"      Nippon India AMC — monthly XLS files (2017 → present)
+    "dsp"         DSP Mutual Fund   — monthly ZIP files (2022 → present)
+    "icici"       ICICI Prudential MF — Morningstar API snapshot
+    "icici-index" ICICI Prudential index constituents — Azure Blob
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Valid values for the `amc` argument — mirrors factory.REGISTRY keys.
+AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index"})
+
+
+def fetch_amc_holdings(
+    amc: str,
+    *,
+    full_reimport: bool = False,
+    dry_run: bool = False,
+) -> None:
+    """
+    Run the AMC holdings importer for *amc*.
+
+    Parameters
+    ----------
+    amc           : one of ``AMC_KEYS``
+    full_reimport : ignore watermarks and re-fetch all history (nippon/dsp only)
+    dry_run       : parse data but skip DB writes
+
+    Raises
+    ------
+    ValueError    : unknown amc key
+    """
+    if amc not in AMC_KEYS:
+        raise ValueError(f"Unknown AMC key '{amc}'. Valid: {sorted(AMC_KEYS)}")
+
+    from src.scripts.fund_imports.factory import create_importer
+
+    kwargs: dict = {}
+    if amc in ("nippon", "dsp"):
+        kwargs["full_reimport"] = full_reimport
+
+    logger.info("fetch_amc_holdings: %s full=%s dry=%s", amc, full_reimport, dry_run)
+    create_importer(amc, **kwargs).run(dry_run=dry_run)
+

--- a/src/importer/fetchers/base_inav_fetcher.py
+++ b/src/importer/fetchers/base_inav_fetcher.py
@@ -1,0 +1,229 @@
+"""
+src/importer/fetchers/base_inav_fetcher.py
+───────────────────────────────────────────
+Template Method base class for AMC iNAV fetchers.
+
+All four AMC fetchers (Nippon, Zerodha, Mirae, Motilal) share the same
+pipeline structure:
+
+    1. Normalise requested symbols against the fetcher's known set
+    2. HTTP call to the AMC API  →  raw response
+    3. Parse raw response  →  {nse_symbol: api_item} map
+    4. Batch-fetch market prices from yfinance
+    5. Build output rows (inav, market_price, premium_discount_pct, source)
+
+Steps 1, 4, and 5 are identical across fetchers and live here.
+Steps 2 and 3 differ per AMC and are implemented by concrete subclasses.
+
+Public API (unchanged from before):
+    fetch_inav_nippon / fetch_inav_mirae / fetch_inav_zerodha / fetch_inav_motilal
+    — each is a thin module-level wrapper calling the corresponding class.
+
+Adding a new AMC fetcher:
+    1. Subclass BaseInavFetcher
+    2. Implement the 4 abstract methods
+    3. Export a module-level function that calls instance.fetch_inav()
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from datetime import datetime, timezone
+from typing import Any
+
+import yfinance as yf
+
+logger = logging.getLogger(__name__)
+
+_COMMON_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+}
+
+
+def _safe(val: Any, default: float = 0.0) -> float:
+    """Parse a possibly-stringified number, stripping commas and percent signs."""
+    try:
+        return float(str(val).replace(",", "").replace("%", "").strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _fetch_yfinance_prices(symbols: list[str]) -> dict[str, float]:
+    """
+    Batch-fetch the most recent closing price for each NSE symbol.
+
+    Parameters
+    ----------
+    symbols : bare NSE symbols, e.g. ["GOLDBEES", "SILVERBEES"]
+
+    Returns
+    -------
+    dict mapping symbol → last close price (absent if unavailable)
+    """
+    if not symbols:
+        return {}
+
+    yf_syms = [f"{s}.NS" for s in symbols]
+    prices: dict[str, float] = {}
+    try:
+        data = yf.download(yf_syms, period="1d", progress=False)
+        if data.empty or "Close" not in data.columns:
+            return prices
+        close_df = data["Close"]
+        for sym in symbols:
+            yf_sym = f"{sym}.NS"
+            series = None
+            if hasattr(close_df, "columns"):
+                if yf_sym in close_df.columns:
+                    series = close_df[yf_sym]
+                elif len(yf_syms) == 1:
+                    series = close_df.iloc[:, 0]
+            else:
+                series = close_df
+            if series is not None:
+                series = series.dropna()
+                if not series.empty:
+                    val = series.iloc[-1]
+                    if hasattr(val, "iloc"):
+                        val = val.iloc[-1]
+                    prices[sym] = float(val)
+    except Exception as exc:
+        logger.warning("yfinance batch price fetch failed: %s", exc)
+    return prices
+
+
+class BaseInavFetcher(ABC):
+    """
+    Template Method base for AMC iNAV fetchers.
+
+    Subclasses must set `source_label` and `symbols` as class attributes,
+    and implement the four abstract methods below.
+    """
+
+    #: Source label written into each output row, e.g. "nippon_amc_live"
+    source_label: str
+
+    #: Set of NSE symbols this fetcher covers
+    symbols: frozenset[str]
+
+    # ── Abstract hooks ────────────────────────────────────────────────────
+
+    @abstractmethod
+    def _fetch_raw(self) -> Any:
+        """
+        Perform the HTTP request(s) to the AMC API.
+
+        Returns the parsed JSON body (dict or list).
+        Must raise an exception on failure (caught by the template method).
+        """
+
+    @abstractmethod
+    def _match_symbols(self, raw: Any, target: set[str]) -> dict[str, Any]:
+        """
+        Extract the subset of items from the raw API response that correspond
+        to symbols in `target`.
+
+        Returns {nse_symbol (upper): api_item}.
+        """
+
+    @abstractmethod
+    def _extract_inav(self, item: Any) -> float | None:
+        """
+        Pull the iNAV value out of a single api_item.
+
+        Return None to skip the row entirely.
+        """
+
+    @abstractmethod
+    def _extract_timestamp(self, item: Any) -> datetime:
+        """
+        Parse the timestamp from a single api_item and return a naive UTC datetime.
+        """
+
+    def _extract_fallback_price(self, item: Any) -> float | None:
+        """
+        Return the declared NAV (or any other price) to use when yfinance has
+        no data.  Default: None (falls back to iNAV itself).
+        """
+        return None
+
+    def _staleness_check(self, sym: str, snapshot_at: datetime, inav: float) -> bool:
+        """
+        Return True to *keep* this row, False to discard it.
+
+        Default: always keep.  Override to add staleness gates (e.g. Motilal).
+        """
+        return True
+
+    # ── Template method ───────────────────────────────────────────────────
+
+    def fetch_inav(self, symbols: list[str]) -> list[dict[str, Any]]:
+        """
+        Full pipeline: filter → fetch raw → match → yfinance prices → build rows.
+
+        Parameters
+        ----------
+        symbols : NSE symbols requested by the caller
+
+        Returns
+        -------
+        list of row dicts: symbol, snapshot_at, inav, market_price,
+        premium_discount_pct, source
+        """
+        target = {s.upper().replace(".NS", "") for s in symbols} & set(self.symbols)
+        if not target:
+            return []
+
+        logger.info("%s iNAV: fetching for %s", self.source_label, sorted(target))
+
+        try:
+            raw = self._fetch_raw()
+        except Exception as exc:
+            logger.warning("%s iNAV: fetch failed: %s", self.source_label, exc)
+            return []
+
+        matched = self._match_symbols(raw, target)
+        if not matched:
+            logger.info("%s iNAV: no matching symbols in API response", self.source_label)
+            return []
+
+        prices = _fetch_yfinance_prices(list(matched))
+
+        rows: list[dict[str, Any]] = []
+        for sym, item in matched.items():
+            raw_inav = self._extract_inav(item)
+            if raw_inav is None:
+                continue
+            inav = _safe(raw_inav)
+            if inav <= 0:
+                continue
+
+            snapshot_at = self._extract_timestamp(item)
+
+            if not self._staleness_check(sym, snapshot_at, inav):
+                continue
+
+            market_price = prices.get(sym)
+            if market_price is None or market_price <= 0:
+                fb = self._extract_fallback_price(item)
+                market_price = _safe(fb) if fb is not None else inav
+
+            prem_disc = (market_price - inav) / inav * 100
+
+            rows.append({
+                "symbol":               sym,
+                "snapshot_at":          snapshot_at,
+                "inav":                 inav,
+                "market_price":         market_price,
+                "premium_discount_pct": round(prem_disc, 4),
+                "source":               self.source_label,
+            })
+
+        logger.info("%s iNAV: compiled %d row(s)", self.source_label, len(rows))
+        return rows

--- a/src/importer/fetchers/mirae_inav_fetcher.py
+++ b/src/importer/fetchers/mirae_inav_fetcher.py
@@ -1,13 +1,14 @@
 """
 src/importer/fetchers/mirae_inav_fetcher.py
 ────────────────────────────────────────────
-Fetches live iNAV snapshots for Mirae Asset ETFs (MAFANG, MAHKTECH, MASPTOP50)
+Fetches live iNAV snapshots for Mirae Asset ETFs (MAFANG, MAHKTECH, MASPTOP50, etc.)
 directly from the Mirae Asset AMC API.
 
-Endpoint: https://miraeassetetf.co.in/api/ticker
-which returns a list of all schemes with their real-time iNAV values.
+Endpoint: GET https://miraeassetetf.co.in/api/ticker
+Returns a JSON list of all schemes with their real-time iNAV values.
 
-Market prices (LTP) are fetched from yfinance to calculate the live premium/discount.
+All 38 ETFs tracked by this fetcher are available via the single endpoint.
+Market prices (LTP) are fetched from yfinance via the shared base class.
 """
 
 from __future__ import annotations
@@ -18,15 +19,16 @@ from typing import Any
 
 import httpx
 import pytz
-import yfinance as yf
+
+from src.importer.fetchers.base_inav_fetcher import BaseInavFetcher, _COMMON_HEADERS
 
 logger = logging.getLogger(__name__)
 
 _MIRAE_API_URL = "https://miraeassetetf.co.in/api/ticker"
 _TIMEOUT = 15
 
-# Tracked Mirae Asset symbols in our registry (all 38 ETFs available via the API)
-MIRAE_SYMBOLS = {
+# All 38 Mirae Asset ETFs available via the API
+MIRAE_SYMBOLS = frozenset({
     # ── International / US / HK ETFs (prev-session close adjusted for FX) ──
     "MAFANG",     "MAHKTECH",   "MASPTOP50",
     # ── Broad Market ──────────────────────────────────────────────────
@@ -42,14 +44,7 @@ MIRAE_SYMBOLS = {
     "GOLDETF",   "SILVERAG",
     # ── Debt / Liquid ──────────────────────────────────────────────
     "LIQUID",    "LIQUIDPLUS", "GSEC10YEAR",
-}
-
-
-def _safe(val: Any, default: float = 0.0) -> float:
-    try:
-        return float(str(val).replace(",", "").strip())
-    except (TypeError, ValueError):
-        return default
+})
 
 
 def _parse_mirae_datetime(ts_str: str) -> datetime:
@@ -61,143 +56,69 @@ def _parse_mirae_datetime(ts_str: str) -> datetime:
     ts_str = ts_str.strip()
     if not ts_str:
         return datetime.now(timezone.utc).replace(tzinfo=None)
-
     if ts_str.endswith("Z"):
         try:
             return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).astimezone(timezone.utc).replace(tzinfo=None)
         except Exception:
             pass
-
-    # Try parsing format: "03-Jul-2026 23:41:28" in IST
     try:
         dt_ist = datetime.strptime(ts_str, "%d-%b-%Y %H:%M:%S")
         ist_tz = pytz.timezone("Asia/Kolkata")
-        dt_with_tz = ist_tz.localize(dt_ist)
-        dt_utc = dt_with_tz.astimezone(timezone.utc)
+        dt_utc = ist_tz.localize(dt_ist).astimezone(timezone.utc)
         return dt_utc.replace(tzinfo=None)
     except Exception as exc:
-        logger.debug("Failed to parse Mirae datetime string '%s': %s. Falling back to current UTC.", ts_str, exc)
+        logger.debug("Failed to parse Mirae datetime '%s': %s", ts_str, exc)
         return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class _MiraeInavFetcher(BaseInavFetcher):
+    source_label = "mirae_amc_live"
+    symbols = MIRAE_SYMBOLS
+
+    def _fetch_raw(self) -> Any:
+        resp = httpx.get(
+            _MIRAE_API_URL,
+            headers=_COMMON_HEADERS,
+            follow_redirects=True,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        raw = resp.json()
+        if not isinstance(raw, list):
+            raise ValueError("Mirae API returned non-list response")
+        return raw
+
+    def _match_symbols(self, raw: Any, target: set[str]) -> dict[str, Any]:
+        return {
+            str(item.get("NSE_Symbol") or item.get("nse_symbol") or "").upper(): item
+            for item in raw
+            if str(item.get("NSE_Symbol") or item.get("nse_symbol") or "").upper() in target
+        }
+
+    def _extract_inav(self, item: Any) -> float | None:
+        return item.get("INAV") or item.get("inav")
+
+    def _extract_timestamp(self, item: Any) -> datetime:
+        return _parse_mirae_datetime(item.get("timestamp") or "")
+
+    def _extract_fallback_price(self, item: Any) -> float | None:
+        return item.get("NAV") or item.get("nav")
+
+
+_fetcher = _MiraeInavFetcher()
 
 
 def fetch_inav_mirae(symbols: list[str]) -> list[dict[str, Any]]:
     """
-    Fetch live iNAV snapshots for Mirae Asset ETFs from the Mirae AMC API.
+    Fetch live iNAV snapshots for Mirae Asset ETFs.
 
     Parameters
     ----------
-    symbols : list of internal symbols, e.g. ["MAFANG", "MAHKTECH"]
+    symbols : list of NSE symbols, e.g. ["MAFANG", "MAHKTECH"]
 
     Returns
     -------
-    list of dicts with keys:
-        symbol, snapshot_at (datetime UTC), inav, market_price,
-        premium_discount_pct, source
+    list of dicts: symbol, snapshot_at (naive UTC), inav, market_price,
+    premium_discount_pct, source
     """
-    requested_clean = {s.upper().replace(".NS", "") for s in symbols}
-    target_symbols = [s for s in requested_clean if s in MIRAE_SYMBOLS]
-
-    if not target_symbols:
-        return []
-
-    logger.info("Mirae iNAV: fetching live data for target symbols: %s", target_symbols)
-
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
-        ),
-        "Accept": "application/json",
-    }
-
-    # 1. Fetch live iNAV data from Mirae Asset API
-    try:
-        with httpx.Client(headers=headers, follow_redirects=True, timeout=_TIMEOUT) as client:
-            resp = client.get(_MIRAE_API_URL)
-            resp.raise_for_status()
-            response_json = resp.json()
-    except Exception as exc:
-        logger.warning("Mirae iNAV ticker GET failed: %s", exc)
-        return []
-
-    if not isinstance(response_json, list):
-        logger.warning("Mirae iNAV API returned non-list data structure")
-        return []
-
-    # Map target tickers to their raw API items
-    matched_items: dict[str, dict[str, Any]] = {}
-    for item in response_json:
-        nse_symbol = str(item.get("NSE_Symbol") or item.get("nse_symbol") or "").upper()
-        if nse_symbol in target_symbols:
-            matched_items[nse_symbol] = item
-
-    if not matched_items:
-        logger.info("No matching Mirae ETFs found in API response")
-        return []
-
-    # 2. Fetch corresponding live market prices from yfinance
-    yf_symbols = [f"{sym}.NS" for sym in matched_items.keys()]
-    market_prices: dict[str, float] = {}
-
-    try:
-        logger.debug("Mirae iNAV: fetching live market prices for: %s", yf_symbols)
-        yf_data = yf.download(yf_symbols, period="1d", progress=False)
-        
-        if not yf_data.empty and "Close" in yf_data.columns:
-            close_df = yf_data["Close"]
-            for sym in matched_items.keys():
-                yf_sym = f"{sym}.NS"
-                series = None
-                
-                if hasattr(close_df, "columns"):  # DataFrame
-                    if yf_sym in close_df.columns:
-                        series = close_df[yf_sym]
-                    elif len(yf_symbols) == 1:
-                        series = close_df.iloc[:, 0]
-                else:  # Series
-                    series = close_df
-                
-                if series is not None:
-                    series = series.dropna()
-                    if not series.empty:
-                        val = series.iloc[-1]
-                        if hasattr(val, "iloc"):
-                            val = val.iloc[-1]
-                        market_prices[sym] = float(val)
-    except Exception as exc:
-        logger.warning("Mirae iNAV: failed to fetch market prices from yfinance: %s", exc)
-
-    # 3. Build snapshot rows
-    rows: list[dict[str, Any]] = []
-    for sym, item in matched_items.items():
-        raw_inav = item.get("INAV") or item.get("inav")
-        if raw_inav is None:
-            continue
-
-        inav = _safe(raw_inav)
-        if inav <= 0:
-            continue
-
-        # Use yfinance market price if available; fallback to declared NAV or current iNAV
-        market_price = market_prices.get(sym)
-        if market_price is None or market_price <= 0:
-            raw_nav = item.get("NAV") or item.get("nav")
-            market_price = _safe(raw_nav) if raw_nav is not None else inav
-
-        prem_disc = ((market_price - inav) / inav * 100)
-        
-        ts_str = item.get("timestamp") or ""
-        snapshot_at = _parse_mirae_datetime(ts_str)
-
-        rows.append({
-            "symbol":               sym,
-            "snapshot_at":          snapshot_at,
-            "inav":                 inav,
-            "market_price":         market_price,
-            "premium_discount_pct": round(prem_disc, 4),
-            "source":               "mirae_amc_live",
-        })
-
-    logger.info("Mirae iNAV: successfully compiled %d snapshot(s)", len(rows))
-    return rows
+    return _fetcher.fetch_inav(symbols)

--- a/src/importer/fetchers/motilal_inav_fetcher.py
+++ b/src/importer/fetchers/motilal_inav_fetcher.py
@@ -37,16 +37,18 @@ from datetime import datetime, timezone, timedelta
 from typing import Any
 
 import httpx
-import yfinance as yf
+
+from src.importer.fetchers.base_inav_fetcher import BaseInavFetcher
 
 logger = logging.getLogger(__name__)
 
 _MOTILAL_API_URL = "https://www.motilaloswalmf.com/mutualfund/api/v1/someFunc"
 _TIMEOUT = 15
+_MAX_STALENESS_DAYS = 2  # reject iNAV older than 2 calendar days (weekends tolerated)
 
 # All ETFs managed by Motilal Oswal AMC that expose live iNAV via their API.
 # Domestic ETFs come from m50M100Data; international ETFs from n100Data.
-MOTILAL_SYMBOLS = {
+MOTILAL_SYMBOLS = frozenset({
     # Domestic
     "MOM50", "MOM100", "MOALPHA50", "MOBANK10", "MOCAPITAL",
     "MODEFENCE", "MOENERGY", "MOGSEC", "MOGOLD", "MOINFRA",
@@ -56,40 +58,92 @@ MOTILAL_SYMBOLS = {
     "MOVALUE", "MOHEALTH", "MOQUALITY", "MOTOUR", "MONIFTY100",
     # International (iNAV reflects prev US session close + USDINR — not live intraday)
     "MON100", "MONQ50",
-}
+})
 
-# Map NSE symbol → the secname suffix used by Motilal's API to identify iNAV rows.
-# Both MON100 and MONQ50 iNAV rows contain "iNAV" in secname.
 _INAV_SECNAME_KEYWORDS = {"iNAV", "inav"}
 
-
-def _safe(val: Any, default: float = 0.0) -> float:
-    try:
-        return float(str(val).replace(",", "").strip())
-    except (TypeError, ValueError):
-        return default
+_MOTILAL_HEADERS = {
+    "Content-Type": "application/json",
+    "User-Agent": "WEB/MultipleCampaign",
+    "UserAgent": "WEB/MultipleCampaign",
+    "appid": "27820BB4MEC3DA4D65MAC74CDFF81E020A60",
+}
 
 
 def _parse_motilal_datetime(dt_str: str) -> datetime:
     """
-    Parse Motilal's datetime string (e.g. '06/05/2026 16:30:50' IST) and
-    return a naive UTC datetime.
+    Parse Motilal's datetime string (e.g. '06/05/2026 16:30:50' IST) →
+    naive UTC datetime.
     """
     dt_str = (dt_str or "").strip()
     if not dt_str:
         return datetime.now(timezone.utc).replace(tzinfo=None)
-
-    # Format: MM/DD/YYYY HH:MM:SS (treated as IST)
     try:
         dt_ist_naive = datetime.strptime(dt_str, "%m/%d/%Y %H:%M:%S")
-        ist_offset = timedelta(hours=5, minutes=30)
-        dt_utc = dt_ist_naive - ist_offset
-        return dt_utc
+        return dt_ist_naive - timedelta(hours=5, minutes=30)
     except ValueError:
         pass
-
     logger.debug("Failed to parse Motilal datetime '%s'. Falling back to current UTC.", dt_str)
     return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class _MotilalInavFetcher(BaseInavFetcher):
+    source_label = "motilal_amc_live"
+    symbols = MOTILAL_SYMBOLS
+
+    def _fetch_raw(self) -> Any:
+        """
+        Returns a flat dict {nse_symbol: api_entry} for iNAV rows only,
+        so that _match_symbols can simply intersect with target.
+        """
+        resp = httpx.post(
+            _MOTILAL_API_URL,
+            json={"apiName": "GetINAVandPrice"},
+            headers=_MOTILAL_HEADERS,
+            follow_redirects=True,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        payload = resp.json()
+        # Flatten all groups (m50M100Data, n100Data, …) and keep only iNAV rows
+        flat: dict[str, Any] = {}
+        inner = payload["data"]["data"]
+        for group_entries in inner.values():
+            if not isinstance(group_entries, list):
+                continue
+            for entry in group_entries:
+                nse_sym = str(entry.get("nseSymbol") or "").upper()
+                secname = str(entry.get("secname") or "")
+                if any(kw.lower() in secname.lower() for kw in _INAV_SECNAME_KEYWORDS):
+                    flat[nse_sym] = entry  # last write wins if duplicate
+        return flat
+
+    def _match_symbols(self, raw: Any, target: set[str]) -> dict[str, Any]:
+        # raw is already a {nse_sym: entry} dict filtered to iNAV rows
+        return {sym: entry for sym, entry in raw.items() if sym in target}
+
+    def _extract_inav(self, item: Any) -> float | None:
+        return item.get("currNav")
+
+    def _extract_timestamp(self, item: Any) -> datetime:
+        return _parse_motilal_datetime(item.get("currNavDate", ""))
+
+    def _extract_fallback_price(self, item: Any) -> float | None:
+        return item.get("prevNAV")
+
+    def _staleness_check(self, sym: str, snapshot_at: datetime, inav: float) -> bool:
+        now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+        age_days = (now_utc - snapshot_at).total_seconds() / 86400
+        if age_days > _MAX_STALENESS_DAYS:
+            logger.debug(
+                "Motilal iNAV: skipping %s — iNAV is %.1f days old (snapshot_at=%s)",
+                sym, age_days, snapshot_at,
+            )
+            return False
+        return True
+
+
+_fetcher = _MotilalInavFetcher()
 
 
 def fetch_inav_motilal(symbols: list[str]) -> list[dict[str, Any]]:
@@ -98,134 +152,11 @@ def fetch_inav_motilal(symbols: list[str]) -> list[dict[str, Any]]:
 
     Parameters
     ----------
-    symbols : list of internal symbols, e.g. ["MON100", "MONQ50"]
+    symbols : list of NSE symbols, e.g. ["MON100", "MONQ50"]
 
     Returns
     -------
-    list of dicts with keys:
-        symbol, snapshot_at (datetime UTC naive), inav, market_price,
-        premium_discount_pct, source
+    list of dicts: symbol, snapshot_at (naive UTC), inav, market_price,
+    premium_discount_pct, source
     """
-    requested = {s.upper().replace(".NS", "") for s in symbols}
-    target_symbols = requested & MOTILAL_SYMBOLS
-
-    if not target_symbols:
-        return []
-
-    logger.info("Motilal iNAV: fetching live data for: %s", sorted(target_symbols))
-
-    # 1. Fetch iNAV data from Motilal AMC API
-    try:
-        with httpx.Client(follow_redirects=True, timeout=_TIMEOUT) as client:
-            resp = client.post(
-                _MOTILAL_API_URL,
-                json={"apiName": "GetINAVandPrice"},
-                headers={
-                    "Content-Type": "application/json",
-                    "User-Agent": "WEB/MultipleCampaign",
-                    "UserAgent": "WEB/MultipleCampaign",
-                    "appid": "27820BB4MEC3DA4D65MAC74CDFF81E020A60",
-                },
-            )
-            resp.raise_for_status()
-            payload = resp.json()
-    except Exception as exc:
-        logger.warning("Motilal iNAV: API request failed: %s", exc)
-        return []
-
-    # 2. Flatten all entry groups into a single list
-    raw_data: dict[str, Any] = {}
-    try:
-        inner = payload["data"]["data"]
-        for group_entries in inner.values():
-            if not isinstance(group_entries, list):
-                continue
-            for entry in group_entries:
-                nse_sym = str(entry.get("nseSymbol") or "").upper()
-                if nse_sym not in target_symbols:
-                    continue
-                secname = str(entry.get("secname") or "")
-                # Keep only iNAV rows (secname contains "iNAV")
-                is_inav = any(kw.lower() in secname.lower() for kw in _INAV_SECNAME_KEYWORDS)
-                if is_inav:
-                    # Last write wins — API may duplicate symbols across groups
-                    raw_data[nse_sym] = entry
-    except (KeyError, TypeError) as exc:
-        logger.warning("Motilal iNAV: unexpected response structure: %s", exc)
-        return []
-
-    if not raw_data:
-        logger.info("Motilal iNAV: no matching iNAV entries found for %s", sorted(target_symbols))
-        return []
-
-    # 3. Fetch live market prices from yfinance
-    yf_symbols = [f"{sym}.NS" for sym in raw_data]
-    market_prices: dict[str, float] = {}
-    try:
-        yf_data = yf.download(yf_symbols, period="1d", progress=False)
-        if not yf_data.empty and "Close" in yf_data.columns:
-            close_df = yf_data["Close"]
-            for sym in raw_data:
-                yf_sym = f"{sym}.NS"
-                series = None
-                if hasattr(close_df, "columns"):
-                    if yf_sym in close_df.columns:
-                        series = close_df[yf_sym]
-                    elif len(yf_symbols) == 1:
-                        series = close_df.iloc[:, 0]
-                else:
-                    series = close_df
-                if series is not None:
-                    series = series.dropna()
-                    if not series.empty:
-                        val = series.iloc[-1]
-                        if hasattr(val, "iloc"):
-                            val = val.iloc[-1]
-                        market_prices[sym] = float(val)
-    except Exception as exc:
-        logger.warning("Motilal iNAV: yfinance price fetch failed: %s", exc)
-
-    # 4. Build snapshot rows
-    now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
-    _MAX_STALENESS_DAYS = 2  # reject iNAV older than 2 calendar days (market weekends tolerated)
-
-    rows: list[dict[str, Any]] = []
-    for sym, entry in raw_data.items():
-        raw_inav = entry.get("currNav")
-        if raw_inav is None:
-            continue
-        inav = _safe(raw_inav)
-        if inav <= 0:
-            continue
-
-        snapshot_at = _parse_motilal_datetime(entry.get("currNavDate", ""))
-
-        # Staleness gate: reject rows whose iNAV timestamp is too old so NSE
-        # data (step 1 in the waterfall) remains authoritative.
-        age_days = (now_utc - snapshot_at).total_seconds() / 86400
-        if age_days > _MAX_STALENESS_DAYS:
-            logger.debug(
-                "Motilal iNAV: skipping %s — iNAV is %.1f days old (ts=%s)",
-                sym, age_days, entry.get("currNavDate"),
-            )
-            continue
-
-        market_price = market_prices.get(sym)
-        if market_price is None or market_price <= 0:
-            # Fallback to prevNAV if yfinance has no data
-            raw_prev = entry.get("prevNAV")
-            market_price = _safe(raw_prev) if raw_prev is not None else inav
-
-        prem_disc = ((market_price - inav) / inav * 100) if inav else 0.0
-
-        rows.append({
-            "symbol":               sym,
-            "snapshot_at":          snapshot_at,
-            "inav":                 inav,
-            "market_price":         market_price,
-            "premium_discount_pct": round(prem_disc, 4),
-            "source":               "motilal_amc_live",
-        })
-
-    logger.info("Motilal iNAV: compiled %d snapshot(s): %s", len(rows), [r["symbol"] for r in rows])
-    return rows
+    return _fetcher.fetch_inav(symbols)

--- a/src/importer/fetchers/nippon_inav_fetcher.py
+++ b/src/importer/fetchers/nippon_inav_fetcher.py
@@ -4,23 +4,21 @@ src/importer/fetchers/nippon_inav_fetcher.py
 Fetches live iNAV snapshots for Nippon India Mutual Fund ETFs (like GOLDBEES,
 SILVERBEES, NIFTYBEES, etc.) directly from the Nippon India AMC website.
 
-This fetcher hits the RealtimeNAV endpoint:
-https://etf.nipponindiaim.com/RealtimeNAV/Nav/DetailsFill
-which returns live intraday iNAV values calculated by the AMC.
+Endpoint: POST https://etf.nipponindiaim.com/RealtimeNAV/Nav/DetailsFill (body: {})
+Response: {"RVDetailsList": [{SchName, CNav, PNav, Realdt, ...}, ...]}
 
-Since the AMC site does not provide market prices, we batch-fetch the latest
-market prices (LTP) from yfinance to calculate the live premium/discount.
+Market prices (LTP) are fetched from yfinance via the shared base class.
 """
 
 from __future__ import annotations
 
 import logging
-import time
 from datetime import datetime, timezone, timedelta
 from typing import Any
 
 import httpx
-import yfinance as yf
+
+from src.importer.fetchers.base_inav_fetcher import BaseInavFetcher, _COMMON_HEADERS
 
 logger = logging.getLogger(__name__)
 
@@ -59,155 +57,78 @@ NIPPON_SYMBOL_MAP: dict[str, str] = {
     "SNXT50BETA":  "Nippon India ETF BSE Sensex Next 50",
 }
 
-# Reverse mapping for fast lookups
-_SCHEME_TO_SYMBOL = {v: k for k, v in NIPPON_SYMBOL_MAP.items()}
-
-
-def _safe(val: Any, default: float = 0.0) -> float:
-    try:
-        return float(str(val).replace(",", "").replace("%", "").strip())
-    except (TypeError, ValueError):
-        return default
+# Reverse mapping: scheme name → NSE symbol
+_SCHEME_TO_SYMBOL: dict[str, str] = {v: k for k, v in NIPPON_SYMBOL_MAP.items()}
 
 
 def _parse_nippon_datetime(realdt_str: str) -> datetime:
-    """Parse Nippon's Realdt string (e.g. 'Friday, 03 July 2026 11:21:32 PM') and return naive UTC datetime."""
+    """Parse Nippon's Realdt string (e.g. 'Friday, 03 July 2026 11:21:32 PM') → naive UTC datetime."""
     try:
-        # Nippon returns dates in IST
         dt_local = datetime.strptime(realdt_str.strip(), "%A, %d %B %Y %I:%M:%S %p")
         ist_tz = timezone(timedelta(hours=5, minutes=30))
-        dt_local = dt_local.replace(tzinfo=ist_tz)
-        return dt_local.astimezone(timezone.utc).replace(tzinfo=None)
+        return dt_local.replace(tzinfo=ist_tz).astimezone(timezone.utc).replace(tzinfo=None)
     except Exception as exc:
-        logger.debug("Failed to parse Nippon datetime string '%s': %s. Falling back to current UTC.", realdt_str, exc)
+        logger.debug("Failed to parse Nippon datetime '%s': %s", realdt_str, exc)
         return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class _NipponInavFetcher(BaseInavFetcher):
+    source_label = "nippon_amc_live"
+    symbols = frozenset(NIPPON_SYMBOL_MAP)
+
+    _nippon_headers = {
+        **_COMMON_HEADERS,
+        "Content-Type": "application/json",
+        "X-Requested-With": "XMLHttpRequest",
+    }
+
+    def _fetch_raw(self) -> Any:
+        resp = httpx.post(
+            _NIPPON_DETAILS_URL,
+            json={},
+            headers=self._nippon_headers,
+            follow_redirects=True,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        details = resp.json().get("RVDetailsList", [])
+        if not details:
+            raise ValueError("Nippon API returned empty RVDetailsList")
+        return details
+
+    def _match_symbols(self, raw: Any, target: set[str]) -> dict[str, Any]:
+        matched: dict[str, Any] = {}
+        for item in raw:
+            sch_name = item.get("SchName", "")
+            sym = _SCHEME_TO_SYMBOL.get(sch_name)
+            if sym and sym in target:
+                matched[sym] = item
+        return matched
+
+    def _extract_inav(self, item: Any) -> float | None:
+        return item.get("CNav")
+
+    def _extract_timestamp(self, item: Any) -> datetime:
+        return _parse_nippon_datetime(item.get("Realdt") or "")
+
+    def _extract_fallback_price(self, item: Any) -> float | None:
+        return item.get("PNav")
+
+
+_fetcher = _NipponInavFetcher()
 
 
 def fetch_inav_nippon(symbols: list[str]) -> list[dict[str, Any]]:
     """
-    Fetch live iNAV snapshots for Nippon ETFs from the Nippon India AMC website.
+    Fetch live iNAV snapshots for Nippon India ETFs.
 
     Parameters
     ----------
-    symbols : list of internal symbols, e.g. ["GOLDBEES", "SILVERBEES"]
+    symbols : list of NSE symbols, e.g. ["GOLDBEES", "SILVERBEES"]
 
     Returns
     -------
-    list of dicts with keys:
-        symbol, snapshot_at (datetime UTC), inav, market_price,
-        premium_discount_pct, source
+    list of dicts: symbol, snapshot_at (naive UTC), inav, market_price,
+    premium_discount_pct, source
     """
-    # Filter requested symbols that are actually managed by Nippon
-    requested_clean = {s.upper().replace(".NS", "") for s in symbols}
-    target_symbols = [s for s in requested_clean if s in NIPPON_SYMBOL_MAP]
-
-    if not target_symbols:
-        return []
-
-    logger.info("Nippon iNAV: fetching live data for target symbols: %s", target_symbols)
-
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
-        ),
-        "Content-Type": "application/json",
-        "Accept": "application/json, text/javascript, */*; q=0.01",
-        "X-Requested-With": "XMLHttpRequest",
-    }
-
-    # 1. Fetch live iNAV data from Nippon AMC
-    try:
-        with httpx.Client(headers=headers, follow_redirects=True, timeout=_TIMEOUT) as client:
-            resp = client.post(_NIPPON_DETAILS_URL, json={})
-            resp.raise_for_status()
-            data = resp.json()
-    except Exception as exc:
-        logger.warning("Nippon iNAV details fill POST failed: %s", exc)
-        return []
-
-    details_list = data.get("RVDetailsList", [])
-    if not details_list:
-        logger.warning("Nippon iNAV API returned empty details list")
-        return []
-
-    # Map target scheme names to their raw API items
-    matched_items: dict[str, dict[str, Any]] = {}
-    for item in details_list:
-        sch_name = item.get("SchName", "")
-        if sch_name in _SCHEME_TO_SYMBOL:
-            sym = _SCHEME_TO_SYMBOL[sch_name]
-            if sym in target_symbols:
-                matched_items[sym] = item
-
-    if not matched_items:
-        logger.info("No matching Nippon ETFs found in DetailsFill response")
-        return []
-
-    # 2. Fetch corresponding live market prices from yfinance
-    yf_symbols = [f"{sym}.NS" for sym in matched_items.keys()]
-    market_prices: dict[str, float] = {}
-
-    try:
-        logger.debug("Nippon iNAV: fetching live market prices for: %s", yf_symbols)
-        # Fetch EOD/live quote using period="1d"
-        yf_data = yf.download(yf_symbols, period="1d", progress=False)
-        
-        if not yf_data.empty and "Close" in yf_data.columns:
-            close_df = yf_data["Close"]
-            for sym in matched_items.keys():
-                yf_sym = f"{sym}.NS"
-                series = None
-                
-                if hasattr(close_df, "columns"):  # DataFrame
-                    if yf_sym in close_df.columns:
-                        series = close_df[yf_sym]
-                    elif len(yf_symbols) == 1:
-                        series = close_df.iloc[:, 0]
-                else:  # Series
-                    series = close_df
-                
-                if series is not None:
-                    series = series.dropna()
-                    if not series.empty:
-                        val = series.iloc[-1]
-                        if hasattr(val, "iloc"):
-                            val = val.iloc[-1]
-                        market_prices[sym] = float(val)
-    except Exception as exc:
-        logger.warning("Nippon iNAV: failed to fetch market prices from yfinance: %s", exc)
-
-    # 3. Build snapshot rows
-    rows: list[dict[str, Any]] = []
-    for sym, item in matched_items.items():
-        raw_inav = item.get("CNav")
-        if raw_inav is None:
-            continue
-
-        inav = _safe(raw_inav)
-        if inav <= 0:
-            continue
-
-        # Use yfinance market price if available; fallback to previous day's NAV or current iNAV
-        market_price = market_prices.get(sym)
-        if market_price is None or market_price <= 0:
-            raw_pnav = item.get("PNav")
-            market_price = _safe(raw_pnav) if raw_pnav is not None else inav
-
-        prem_disc = ((market_price - inav) / inav * 100)
-        
-        realdt = item.get("Realdt") or ""
-        snapshot_at = _parse_nippon_datetime(realdt)
-
-        rows.append({
-            "symbol":               sym,
-            "snapshot_at":          snapshot_at,
-            "inav":                 inav,
-            "market_price":         market_price,
-            "premium_discount_pct": round(prem_disc, 4),
-            "source":               "nippon_amc_live",
-        })
-
-    logger.info("Nippon iNAV: successfully compiled %d snapshot(s)", len(rows))
-    return rows
+    return _fetcher.fetch_inav(symbols)

--- a/src/importer/fetchers/zerodha_inav_fetcher.py
+++ b/src/importer/fetchers/zerodha_inav_fetcher.py
@@ -4,10 +4,10 @@ src/importer/fetchers/zerodha_inav_fetcher.py
 Fetches live iNAV snapshots for Zerodha Fund House ETFs (GOLDCASE, SILVERCASE,
 LIQUIDCASE, etc.) directly from the Zerodha AMC API.
 
-Endpoint: https://api.zerodhafundhouse.com/api/v1/schemes
-which returns live scheme stats including the real-time iNAV values.
+Endpoint: GET https://api.zerodhafundhouse.com/api/v1/schemes
+Response: {"data": [{ticker, schemeStats: {inav: {val, ts}, nav}}, ...]}
 
-Market prices (LTP) are fetched from yfinance to calculate the live premium/discount.
+Market prices (LTP) are fetched from yfinance via the shared base class.
 """
 
 from __future__ import annotations
@@ -17,158 +17,80 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-import yfinance as yf
+
+from src.importer.fetchers.base_inav_fetcher import BaseInavFetcher, _COMMON_HEADERS
 
 logger = logging.getLogger(__name__)
 
 _ZERODHA_API_URL = "https://api.zerodhafundhouse.com/api/v1/schemes"
 _TIMEOUT = 15
 
-# Tracked Zerodha symbols in our registry (all 8 ETFs with live iNAV from the API)
-ZERODHA_SYMBOLS = {
+# All 8 Zerodha Fund House ETFs with live iNAV from the API
+ZERODHA_SYMBOLS = frozenset({
     "GOLDCASE",    "SILVERCASE",  "LIQUIDCASE",
     "TOP100CASE",  "MID150CASE",  "LTGILTCASE",
     "NIFTYCASE",   "SML100CASE",
-}
-
-
-def _safe(val: Any, default: float = 0.0) -> float:
-    try:
-        return float(str(val).replace(",", "").strip())
-    except (TypeError, ValueError):
-        return default
+})
 
 
 def _parse_zerodha_datetime(ts_str: str) -> datetime:
-    """Parse Zerodha's ISO UTC timestamp (e.g. '2026-07-03T10:29:49Z') and return naive UTC datetime."""
+    """Parse Zerodha's ISO UTC timestamp (e.g. '2026-07-03T10:29:49Z') → naive UTC datetime."""
     try:
         return datetime.fromisoformat(ts_str.replace("Z", "+00:00")).astimezone(timezone.utc).replace(tzinfo=None)
     except Exception as exc:
-        logger.debug("Failed to parse Zerodha datetime string '%s': %s. Falling back to current UTC.", ts_str, exc)
+        logger.debug("Failed to parse Zerodha datetime '%s': %s", ts_str, exc)
         return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+class _ZerodhaInavFetcher(BaseInavFetcher):
+    source_label = "zerodha_amc_live"
+    symbols = ZERODHA_SYMBOLS
+
+    def _fetch_raw(self) -> Any:
+        resp = httpx.get(
+            _ZERODHA_API_URL,
+            headers=_COMMON_HEADERS,
+            follow_redirects=True,
+            timeout=_TIMEOUT,
+        )
+        resp.raise_for_status()
+        schemes = resp.json().get("data", [])
+        if not schemes:
+            raise ValueError("Zerodha API returned empty data list")
+        return schemes
+
+    def _match_symbols(self, raw: Any, target: set[str]) -> dict[str, Any]:
+        return {
+            str(item.get("ticker", "")).upper(): item
+            for item in raw
+            if str(item.get("ticker", "")).upper() in target
+        }
+
+    def _extract_inav(self, item: Any) -> float | None:
+        return item.get("schemeStats", {}).get("inav", {}).get("val")
+
+    def _extract_timestamp(self, item: Any) -> datetime:
+        ts = item.get("schemeStats", {}).get("inav", {}).get("ts") or ""
+        return _parse_zerodha_datetime(ts)
+
+    def _extract_fallback_price(self, item: Any) -> float | None:
+        return item.get("schemeStats", {}).get("nav")
+
+
+_fetcher = _ZerodhaInavFetcher()
 
 
 def fetch_inav_zerodha(symbols: list[str]) -> list[dict[str, Any]]:
     """
-    Fetch live iNAV snapshots for Zerodha ETFs from the Zerodha AMC API.
+    Fetch live iNAV snapshots for Zerodha Fund House ETFs.
 
     Parameters
     ----------
-    symbols : list of internal symbols, e.g. ["GOLDCASE", "SILVERCASE"]
+    symbols : list of NSE symbols, e.g. ["GOLDCASE", "SILVERCASE"]
 
     Returns
     -------
-    list of dicts with keys:
-        symbol, snapshot_at (datetime UTC), inav, market_price,
-        premium_discount_pct, source
+    list of dicts: symbol, snapshot_at (naive UTC), inav, market_price,
+    premium_discount_pct, source
     """
-    requested_clean = {s.upper().replace(".NS", "") for s in symbols}
-    target_symbols = [s for s in requested_clean if s in ZERODHA_SYMBOLS]
-
-    if not target_symbols:
-        return []
-
-    logger.info("Zerodha iNAV: fetching live data for target symbols: %s", target_symbols)
-
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
-        ),
-        "Accept": "application/json",
-    }
-
-    # 1. Fetch live iNAV data from Zerodha API
-    try:
-        with httpx.Client(headers=headers, follow_redirects=True, timeout=_TIMEOUT) as client:
-            resp = client.get(_ZERODHA_API_URL)
-            resp.raise_for_status()
-            response_json = resp.json()
-    except Exception as exc:
-        logger.warning("Zerodha iNAV schemes GET failed: %s", exc)
-        return []
-
-    schemes_list = response_json.get("data", [])
-    if not schemes_list:
-        logger.warning("Zerodha iNAV API returned empty data list")
-        return []
-
-    # Map target tickers to their raw API items
-    matched_items: dict[str, dict[str, Any]] = {}
-    for item in schemes_list:
-        ticker = str(item.get("ticker", "")).upper()
-        if ticker in target_symbols:
-            matched_items[ticker] = item
-
-    if not matched_items:
-        logger.info("No matching Zerodha ETFs found in API response")
-        return []
-
-    # 2. Fetch corresponding live market prices from yfinance
-    yf_symbols = [f"{sym}.NS" for sym in matched_items.keys()]
-    market_prices: dict[str, float] = {}
-
-    try:
-        logger.debug("Zerodha iNAV: fetching live market prices for: %s", yf_symbols)
-        yf_data = yf.download(yf_symbols, period="1d", progress=False)
-        
-        if not yf_data.empty and "Close" in yf_data.columns:
-            close_df = yf_data["Close"]
-            for sym in matched_items.keys():
-                yf_sym = f"{sym}.NS"
-                series = None
-                
-                if hasattr(close_df, "columns"):  # DataFrame
-                    if yf_sym in close_df.columns:
-                        series = close_df[yf_sym]
-                    elif len(yf_symbols) == 1:
-                        series = close_df.iloc[:, 0]
-                else:  # Series
-                    series = close_df
-                
-                if series is not None:
-                    series = series.dropna()
-                    if not series.empty:
-                        val = series.iloc[-1]
-                        if hasattr(val, "iloc"):
-                            val = val.iloc[-1]
-                        market_prices[sym] = float(val)
-    except Exception as exc:
-        logger.warning("Zerodha iNAV: failed to fetch market prices from yfinance: %s", exc)
-
-    # 3. Build snapshot rows
-    rows: list[dict[str, Any]] = []
-    for sym, item in matched_items.items():
-        stats = item.get("schemeStats", {})
-        inav_info = stats.get("inav", {})
-        raw_inav = inav_info.get("val")
-        if raw_inav is None:
-            continue
-
-        inav = _safe(raw_inav)
-        if inav <= 0:
-            continue
-
-        # Use yfinance market price if available; fallback to declared NAV or current iNAV
-        market_price = market_prices.get(sym)
-        if market_price is None or market_price <= 0:
-            raw_nav = stats.get("nav")
-            market_price = _safe(raw_nav) if raw_nav is not None else inav
-
-        prem_disc = ((market_price - inav) / inav * 100)
-        
-        ts_str = inav_info.get("ts") or ""
-        snapshot_at = _parse_zerodha_datetime(ts_str)
-
-        rows.append({
-            "symbol":               sym,
-            "snapshot_at":          snapshot_at,
-            "inav":                 inav,
-            "market_price":         market_price,
-            "premium_discount_pct": round(prem_disc, 4),
-            "source":               "zerodha_amc_live",
-        })
-
-    logger.info("Zerodha iNAV: successfully compiled %d snapshot(s)", len(rows))
-    return rows
+    return _fetcher.fetch_inav(symbols)


### PR DESCRIPTION
- Add src/importer/fetchers/amc_holdings_fetcher.py — thin public entry point over scripts/fund_imports/ factory; exposes fetch_amc_holdings(amc, full_reimport, dry_run) and AMC_KEYS frozenset
- Update cli.py: import AMC importers through amc_holdings_fetcher instead of reaching directly into scripts/fund_imports/factory
- Update AGENTS.md: document amc_holdings_fetcher as public API, add dsp to fund_imports/run.py CLI reference, add canonical main.py import path