### PR TITLE
feat: fix Sensibull FII/DII API, stream tool progress, and force dete…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,10 +45,8 @@ services:
       OLLAMA_HOST: http://ollama:11434
     entrypoint: ["/bin/sh", "-c"]
     command: >
-      "ollama pull gemma4:latest &&
-       ollama create mosaic-gemma4 -f /modelfiles/Modelfile;
-       ollama pull nomic-embed-text &&
-       echo 'mosaic-gemma4 + nomic-embed-text ready'"
+      "ollama pull nomic-embed-text &&
+       echo 'nomic-embed-text ready'"
     restart: "no"
 
   clickhouse:

--- a/mosaic.sh
+++ b/mosaic.sh
@@ -35,10 +35,10 @@ if [[ $# -eq 0 ]]; then
         docker compose build studio 2>/dev/null
         docker compose up -d clickhouse qdrant ui files studio 2>/dev/null
     else
-        echo "Starting services (first run pulls gemma4 ~5-8 GB — grab a coffee)..."
-        docker compose build studio 2>/dev/null
-        docker compose up -d clickhouse qdrant ollama ui files studio 2>/dev/null
-        docker compose run --rm ollama-init 2>/dev/null || true   # no-op if already done
+        echo "Starting services (pulling local embedding models on first run — grab a coffee)..."
+        docker compose build studio
+        docker compose up -d clickhouse qdrant ollama ui files studio
+        docker compose run --rm ollama-init || true   # no-op if already done
     fi
     echo ""
     echo "  🖥️  UI (Data Hub):    http://localhost:8501

--- a/src/agents/intent_router.py
+++ b/src/agents/intent_router.py
@@ -238,7 +238,7 @@ def _get_router_llm() -> Any | None:
         try:
             from langchain_anthropic import ChatAnthropic
             return ChatAnthropic(
-                model="claude-haiku-4-20250414",
+                model="claude-haiku-4-5-20251001",
                 api_key=settings.anthropic_api_key,
                 temperature=0,
                 max_tokens=50,

--- a/src/agents/news_sentiment_agent.py
+++ b/src/agents/news_sentiment_agent.py
@@ -260,7 +260,7 @@ class NewsSentimentAgent:
                 model=settings.llm_model,
                 api_key=settings.openrouter_api_key,
                 base_url="https://openrouter.ai/api/v1",
-                temperature=0.1,
+                temperature=0,
                 max_tokens=settings.llm_token_budget,
             )
 
@@ -275,7 +275,7 @@ class NewsSentimentAgent:
                 model=settings.llm_model,
                 base_url=settings.llm_base_url,
                 api_key=settings.openai_api_key or "local",
-                temperature=0.1,
+                temperature=0,
                 max_tokens=settings.llm_token_budget,
                 extra_body={"options": {"num_ctx": settings.llm_context_window}},
             )
@@ -285,7 +285,7 @@ class NewsSentimentAgent:
             return ChatAnthropic(
                 model=settings.llm_model,
                 api_key=settings.anthropic_api_key,
-                temperature=0.1,
+                temperature=0,
                 max_tokens=settings.llm_token_budget,
                 extra_headers={"anthropic-beta": "prompt-caching-2024-07-31"},
             )
@@ -294,7 +294,7 @@ class NewsSentimentAgent:
         return ChatOpenAI(
             model=settings.llm_model,
             api_key=settings.openai_api_key,
-            temperature=0.1,
+            temperature=0,
             max_tokens=settings.llm_token_budget,
         )
 

--- a/src/importer/fetchers/fii_dii_fetcher.py
+++ b/src/importer/fetchers/fii_dii_fetcher.py
@@ -54,48 +54,20 @@ def _key_to_ord(key: str) -> tuple[int, int]:
 
 logger = logging.getLogger(__name__)
 
-_SENSIBULL_DAILY   = "https://oxide.sensibull.com/v1/compute/cache/fii_dii_daily"
-_SENSIBULL_MONTHLY = "https://oxide.sensibull.com/v1/compute/cache/fii_dii_cash"
+_SENSIBULL_DAILY    = "https://oxide.sensibull.com/v1/compute/cache/fii_dii_daily"
+_SENSIBULL_MONTHLY  = "https://oxide.sensibull.com/v1/compute/cache/fii_dii_cash"
+_SENSIBULL_IDENTIFY = "https://oxide.sensibull.com/v1/pluto/auth/web/session/a/platform/identify"
 
-import uuid
-import random
-import string
-
-def _get_sensibull_session() -> tuple[httpx.Client, dict[str, str]]:
-    """
-    Initialize an anonymous Sensibull Pluto session.
-    
-    Generates a unique x-device-id and random frt-ref, then calls Pluto
-    identify to establish the session. Returns the httpx.Client containing
-    session cookies and the headers dictionary.
-    """
-    device_id = str(uuid.uuid4())
-    frt_ref = "".join(random.choices(string.ascii_lowercase + string.digits, k=12))
-    
-    headers = {
-        "User-Agent": (
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-            "AppleWebKit/537.36 (KHTML, like Gecko) "
-            "Chrome/120.0.0.0 Safari/537.36"
-        ),
-        "Referer": "https://web.sensibull.com/",
-        "Origin": "https://web.sensibull.com",
-        "x-device-id": device_id,
-        "frt-ref": frt_ref,
-        "Accept": "application/json",
-    }
-    
-    client = httpx.Client(headers=headers, follow_redirects=True)
-    try:
-        r = client.get("https://oxide.sensibull.com/v1/pluto/auth/web/session/a/platform/identify", timeout=15)
-        r.raise_for_status()
-        token = client.cookies.get("access_token")
-        if token:
-            client.headers["X-Auth-Token"] = token
-    except Exception as exc:
-        logger.warning("Sensibull session initialization failed: %s", exc)
-        
-    return client, headers
+_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json",
+    "Referer": "https://web.sensibull.com/",
+    "Origin": "https://web.sensibull.com",
+}
 
 # Polite delay between paginated month requests
 _REQUEST_DELAY = 0.5
@@ -106,6 +78,21 @@ _REQUEST_DELAY = 0.5
 def _month_key(d: date) -> str:
     """Convert a date to Sensibull's year_month format: '2026-March'."""
     return f"{d.year}-{_MONTH_NAMES[d.month]}"
+
+
+def _establish_session(client: httpx.Client) -> None:
+    """
+    Sensibull now fronts oxide.sensibull.com with bot-protection that 403s
+    ("access denied") any request lacking a valid anon session cookie.
+    Hitting the platform "identify" endpoint first mints that cookie
+    (access_token/_cfuvid), which httpx's client-level cookie jar then
+    attaches to subsequent requests on the same client automatically.
+    """
+    try:
+        resp = client.get(_SENSIBULL_IDENTIFY, timeout=15)
+        resp.raise_for_status()
+    except Exception as exc:
+        logger.warning("Sensibull session identify call failed: %s", exc)
 
 
 def _row_from_sensibull(trade_date: date, day_data: dict) -> dict | None:
@@ -280,8 +267,8 @@ def fetch_fii_dii(from_date: date | None = None) -> list[dict]:
     all_rows: list[dict] = []
 
     try:
-        client, headers = _get_sensibull_session()
-        try:
+        with httpx.Client(headers=_HEADERS, follow_redirects=True) as client:
+            _establish_session(client)
             if from_date is None:
                 # Current month only
                 all_rows = _fetch_month(client, year_month=None)
@@ -306,11 +293,9 @@ def fetch_fii_dii(from_date: date | None = None) -> list[dict]:
                         all_rows.extend(batch)
                         if i < len(needed) - 1:
                             time.sleep(_REQUEST_DELAY)
-        finally:
-            client.close()
 
     except Exception as exc:
-        logger.error("Sensibull FII/DII fetch failed: %s", exc)
+        logger.error("Sensibull FII/DII fetch failed with unrecoverable error: %s", exc)
         return []
 
     # Deduplicate by trade_date (last-seen wins), then filter and sort
@@ -347,16 +332,16 @@ def fetch_fii_dii_monthly() -> list[dict]:
         dii_buy_cr, dii_sell_cr, dii_net_cr, nifty_close, nifty_change_pct
     """
     try:
-        client, _ = _get_sensibull_session()
-        try:
+        with httpx.Client(headers=_HEADERS, follow_redirects=True) as client:
+            _establish_session(client)
             resp = client.get(_SENSIBULL_MONTHLY, timeout=20)
             resp.raise_for_status()
             payload = resp.json()
-        finally:
-            client.close()
     except Exception as exc:
         logger.error("Sensibull monthly FII/DII fetch failed: %s", exc)
         return []
+
+    # Response is either {"data": {"YYYY-MM-DD": {...}}} or directly {"YYYY-MM-DD": {...}}
     raw = payload.get("data", payload)
     if not isinstance(raw, dict):
         logger.error("Unexpected monthly payload shape: %r", type(raw))
@@ -414,8 +399,8 @@ def fetch_fii_dii_fno(from_date: date | None = None) -> list[dict]:
     all_rows: list[dict] = []
 
     try:
-        client, headers = _get_sensibull_session()
-        try:
+        with httpx.Client(headers=_HEADERS, follow_redirects=True) as client:
+            _establish_session(client)
             if from_date is None:
                 months = [None]  # type: ignore[list-item]
             else:
@@ -448,8 +433,6 @@ def fetch_fii_dii_fno(from_date: date | None = None) -> list[dict]:
 
                 if i < len(months) - 1:
                     time.sleep(_REQUEST_DELAY)
-        finally:
-            client.close()
 
     except Exception as exc:
         logger.error("Sensibull F&O fetch failed: %s", exc)

--- a/src/importer/fetchers/fii_dii_fetcher.py
+++ b/src/importer/fetchers/fii_dii_fetcher.py
@@ -57,16 +57,45 @@ logger = logging.getLogger(__name__)
 _SENSIBULL_DAILY   = "https://oxide.sensibull.com/v1/compute/cache/fii_dii_daily"
 _SENSIBULL_MONTHLY = "https://oxide.sensibull.com/v1/compute/cache/fii_dii_cash"
 
-_HEADERS = {
-    "User-Agent": (
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
-        "AppleWebKit/537.36 (KHTML, like Gecko) "
-        "Chrome/120.0.0.0 Safari/537.36"
-    ),
-    "Accept": "application/json",
-    "Referer": "https://web.sensibull.com/",
-    "Origin": "https://web.sensibull.com",
-}
+import uuid
+import random
+import string
+
+def _get_sensibull_session() -> tuple[httpx.Client, dict[str, str]]:
+    """
+    Initialize an anonymous Sensibull Pluto session.
+    
+    Generates a unique x-device-id and random frt-ref, then calls Pluto
+    identify to establish the session. Returns the httpx.Client containing
+    session cookies and the headers dictionary.
+    """
+    device_id = str(uuid.uuid4())
+    frt_ref = "".join(random.choices(string.ascii_lowercase + string.digits, k=12))
+    
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+            "AppleWebKit/537.36 (KHTML, like Gecko) "
+            "Chrome/120.0.0.0 Safari/537.36"
+        ),
+        "Referer": "https://web.sensibull.com/",
+        "Origin": "https://web.sensibull.com",
+        "x-device-id": device_id,
+        "frt-ref": frt_ref,
+        "Accept": "application/json",
+    }
+    
+    client = httpx.Client(headers=headers, follow_redirects=True)
+    try:
+        r = client.get("https://oxide.sensibull.com/v1/pluto/auth/web/session/a/platform/identify", timeout=15)
+        r.raise_for_status()
+        token = client.cookies.get("access_token")
+        if token:
+            client.headers["X-Auth-Token"] = token
+    except Exception as exc:
+        logger.warning("Sensibull session initialization failed: %s", exc)
+        
+    return client, headers
 
 # Polite delay between paginated month requests
 _REQUEST_DELAY = 0.5
@@ -251,7 +280,8 @@ def fetch_fii_dii(from_date: date | None = None) -> list[dict]:
     all_rows: list[dict] = []
 
     try:
-        with httpx.Client(headers=_HEADERS, follow_redirects=True) as client:
+        client, headers = _get_sensibull_session()
+        try:
             if from_date is None:
                 # Current month only
                 all_rows = _fetch_month(client, year_month=None)
@@ -276,9 +306,11 @@ def fetch_fii_dii(from_date: date | None = None) -> list[dict]:
                         all_rows.extend(batch)
                         if i < len(needed) - 1:
                             time.sleep(_REQUEST_DELAY)
+        finally:
+            client.close()
 
     except Exception as exc:
-        logger.error("Sensibull FII/DII fetch failed with unrecoverable error: %s", exc)
+        logger.error("Sensibull FII/DII fetch failed: %s", exc)
         return []
 
     # Deduplicate by trade_date (last-seen wins), then filter and sort
@@ -315,15 +347,16 @@ def fetch_fii_dii_monthly() -> list[dict]:
         dii_buy_cr, dii_sell_cr, dii_net_cr, nifty_close, nifty_change_pct
     """
     try:
-        with httpx.Client(headers=_HEADERS, follow_redirects=True) as client:
+        client, _ = _get_sensibull_session()
+        try:
             resp = client.get(_SENSIBULL_MONTHLY, timeout=20)
             resp.raise_for_status()
             payload = resp.json()
+        finally:
+            client.close()
     except Exception as exc:
         logger.error("Sensibull monthly FII/DII fetch failed: %s", exc)
         return []
-
-    # Response is either {"data": {"YYYY-MM-DD": {...}}} or directly {"YYYY-MM-DD": {...}}
     raw = payload.get("data", payload)
     if not isinstance(raw, dict):
         logger.error("Unexpected monthly payload shape: %r", type(raw))
@@ -381,7 +414,8 @@ def fetch_fii_dii_fno(from_date: date | None = None) -> list[dict]:
     all_rows: list[dict] = []
 
     try:
-        with httpx.Client(headers=_HEADERS, follow_redirects=True) as client:
+        client, headers = _get_sensibull_session()
+        try:
             if from_date is None:
                 months = [None]  # type: ignore[list-item]
             else:
@@ -414,6 +448,8 @@ def fetch_fii_dii_fno(from_date: date | None = None) -> list[dict]:
 
                 if i < len(months) - 1:
                     time.sleep(_REQUEST_DELAY)
+        finally:
+            client.close()
 
     except Exception as exc:
         logger.error("Sensibull F&O fetch failed: %s", exc)

--- a/src/importer/fetchers/nselib_fetcher.py
+++ b/src/importer/fetchers/nselib_fetcher.py
@@ -48,7 +48,8 @@ def fetch_nselib_ohlcv(
 
     rows: list[dict[str, Any]] = []
 
-    for nse_sym, _yahoo_sym in symbols:
+    for idx, (nse_sym, _yahoo_sym) in enumerate(symbols, 1):
+        print(f"    [{idx}/{len(symbols)}] Fetching {nse_sym} via nselib...", flush=True)
         try:
             df = capital_market.price_volume_and_deliverable_position_data(
                 nse_sym,

--- a/src/importer/fetchers/shoonya_fetcher.py
+++ b/src/importer/fetchers/shoonya_fetcher.py
@@ -260,7 +260,8 @@ def fetch_shoonya_ohlcv(
 
     rows: list[dict[str, Any]] = []
 
-    for nse_sym, _yahoo_sym in symbols:
+    for idx, (nse_sym, _yahoo_sym) in enumerate(symbols, 1):
+        print(f"    [{idx}/{len(symbols)}] Fetching {nse_sym} via Shoonya...", flush=True)
         tradingsymbol = f"{nse_sym}-EQ"
         try:
             data = api.get_daily_price_series(

--- a/src/llm/client.py
+++ b/src/llm/client.py
@@ -73,7 +73,7 @@ def _build_llm(context: Context) -> Any:
         from config.settings import settings
 
         is_resolver = context == "resolver"
-        temperature = 0 if is_resolver else 0.2
+        temperature = 0
         max_tokens = 20 if is_resolver else settings.llm_token_budget
 
         # Determine active provider, respecting llm_local_disabled for resolver


### PR DESCRIPTION
…rministic LLM

Importers
- Implement anonymous Pluto session handshake to bypass 401 Unauthorized errors on Sensibull FII/DII endpoints
- Stream real-time symbol-by-symbol progress in NSElib and Shoonya fetchers to avoid console hang appearance during long fetches

LLM Client
- Force temperature=0 by default across news sentiment and intent router clients for deterministic, repeatable predictions
- Resolve router 404 error by updating fallback model name to `claude-haiku-4-5-20251001`

DevOps & Setup
- Bypass Gemma 4 weights pull on startup in docker-compose, retaining only lightweight nomic-embed-text for local RAG
- Unsuppress compose startup prints in wrapper script to expose Docker image build and pull progress