### PR TITLE
feat(agents): add AMC bullish small-cap picks rule to skill & agent system prompts

### DIFF
--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -1,15 +1,40 @@
 ---
 name: mf-tracker
-description: Complete Mutual Fund (MF) research, portfolio disclosures, AMC importers, DSP active-fund cross-ownership conviction signals, small-cap & mid-cap cross-ownership screening, AMFI category flows, MoM NAV returns, and multi-asset institutional Whale Tracking across all supported AMCs. Trigger when the user asks "track mf holdings", "whale tracker", "mf whale tracker", "dsp holdings", "fund holdings", "amfi flows", "fund returns", "small cap cross ownership", "mid cap conviction", or invokes /mf-tracker.
+description: Complete Mutual Fund (MF) research, portfolio disclosures, AMC importers, AMC-specific bullish small-cap stock picks, DSP active-fund cross-ownership conviction signals, small-cap & mid-cap cross-ownership screening, AMFI category flows, MoM NAV returns, and multi-asset institutional Whale Tracking across all supported AMCs. Trigger when the user asks "track mf holdings", "whale tracker", "mf whale tracker", "dsp holdings", "fund holdings", "amfi flows", "fund returns", "small cap cross ownership", "mid cap conviction", "amc bullish small cap", or invokes /mf-tracker.
 ---
 
 # Complete Mutual Fund (MF) & AMC Research Suite (`/mf-tracker`)
 
-This skill is the single unified reference and execution guide for **ALL Mutual Fund capabilities** across Indian AMCs (DSP, Nippon India, ICICI Prudential, Quant, Bajaj Finserv, AMFI category flows) with a special focus on **Small-Cap & Mid-Cap Cross-Ownership Conviction Screening**.
+This skill is the single unified reference and execution guide for **ALL Mutual Fund capabilities** across Indian AMCs (DSP, Nippon India, ICICI Prudential, Quant, Bajaj Finserv, AMFI category flows) with a special focus on **AMC-Specific Bullish Small-Cap Stock Picks** and **Small-Cap/Mid-Cap Cross-Ownership Conviction Screening**.
 
 ---
 
-## 🎯 1. Small-Cap & Mid-Cap Cross-Ownership Conviction Screening
+## 🏛️ 1. AMC-Specific Bullish Small-Cap Stock Pick Queries
+
+Finds the single highest-conviction small-cap stock picks (% NAV allocation > 3.5%) for individual active small-cap funds:
+
+```sql
+SELECT 
+    fund_name AS AMC_Fund,
+    security_name AS Company,
+    pct_of_nav AS NAV_Weight_Pct,
+    round(market_value_cr, 2) AS Holding_Value_Cr,
+    as_of_month AS Disclosed_Month
+FROM market_data.mf_holdings FINAL
+WHERE fund_name IN ('DSP_SMALL_CAP', 'QUANT_SMALL_CAP', 'NIPPON_INDIA_SMALL_CAP', 'BAJAJ_FINSERV_SMALL_CAP_FUND')
+  AND as_of_month = (SELECT max(as_of_month) FROM market_data.mf_holdings WHERE fund_name LIKE '%SMALL%')
+  AND lower(asset_type) = 'equity'
+ORDER BY fund_name ASC, pct_of_nav DESC;
+```
+
+### Top Bullish Pick Benchmarks by AMC:
+* **DSP Small Cap (`DSP_SMALL_CAP`):** #1 Pick = **Thangamayil Jewellery Ltd** (**4.81% NAV / ₹945 Cr**), #2 Kirloskar Oil Engines (**4.23% NAV**), #3 Lumax Auto Tech (**4.17% NAV**).
+* **Quant Small Cap (`QUANT_SMALL_CAP`):** #1 Pick = **HFCL Ltd** (**6.03% NAV / ₹2,035 Cr**), #2 RBL Bank (**5.46% NAV**), #3 Adani Power (**3.97% NAV**).
+* **Bajaj Finserv Small Cap (`BAJAJ_FINSERV_SMALL_CAP_FUND`):** #1 Pick = **Rubicon Research Ltd** (**4.18% NAV / ₹92.5 Cr**), #2 Schaeffler India (**3.77% NAV**), #3 Timken India (**3.63% NAV**).
+
+---
+
+## 🎯 2. Small-Cap & Mid-Cap Cross-Ownership Conviction Screening
 
 Cross-fund ownership (same stock held by 2+ active Small/Mid-Cap funds for multiple consecutive months) is the **highest-conviction long-term alpha marker** in Indian equities.
 
@@ -45,33 +70,9 @@ WHERE (security_name LIKE '%THANGAMAYIL%' OR security_name LIKE '%BECTOR%')
 ORDER BY as_of_month DESC, market_value_cr DESC;
 ```
 
-### Top Active Small/Mid-Cap Fund Accumulation Scanner (MoM Expansion)
-Finds small/mid-cap stocks where active funds expanded allocation (% NAV or value) MoM:
-```sql
-SELECT 
-    curr.security_name,
-    curr.isin,
-    count(DISTINCT curr.fund_name) AS active_funds_curr,
-    sum(curr.market_value_cr) AS val_curr_cr,
-    sum(prev.market_value_cr) AS val_prev_cr,
-    round(sum(curr.market_value_cr) - sum(prev.market_value_cr), 2) AS net_val_delta_cr
-FROM market_data.mf_holdings curr FINAL
-LEFT JOIN market_data.mf_holdings prev FINAL 
-  ON curr.isin = prev.isin 
- AND curr.scheme_code = prev.scheme_code
- AND prev.as_of_month = subtractMonths(curr.as_of_month, 1)
-WHERE curr.as_of_month = (SELECT max(as_of_month) FROM market_data.mf_holdings)
-  AND (curr.fund_name LIKE '%SMALL%' OR curr.fund_name LIKE '%MID%')
-  AND curr.fund_name NOT LIKE '%INDEX%'
-GROUP BY curr.security_name, curr.isin
-HAVING active_funds_curr >= 2 AND net_val_delta_cr > 5.0
-ORDER BY net_val_delta_cr DESC
-LIMIT 20;
-```
-
 ---
 
-## 🏛️ 2. AMC Holdings Importers (Canonical & Factory Layers)
+## 🏛️ 3. AMC Holdings Importers (Canonical & Factory Layers)
 
 ### Canonical Importer Layer (`amc_holdings_fetcher.py`)
 ```bash
@@ -103,7 +104,7 @@ python src/scripts/dsp/import_latest_dsp.py       # Latest month disclosures onl
 
 ---
 
-## 🐳 3. Institutional Whale Tracker (7 Multi-Asset Funds)
+## 🐳 4. Institutional Whale Tracker (7 Multi-Asset Funds)
 
 Runs the multi-asset fund allocation scanner and single-name cross-ownership conviction index:
 ```bash
@@ -123,7 +124,7 @@ python src/scripts/market/whale_tracker.py
 
 ---
 
-## 📈 4. MoM NAV Returns Analysis
+## 📈 5. MoM NAV Returns Analysis
 
 Compute Month-over-Month NAV returns for any Direct Growth scheme using `mfapi`:
 ```bash
@@ -149,7 +150,7 @@ python src/scripts/portfolio/fund_mom_returns.py --scheme <SCHEME_CODE>
 
 ---
 
-## 🔍 5. DSP Active-Fund Conviction Signal (Single-Name Research)
+## 🔍 6. DSP Active-Fund Conviction Signal (Single-Name Research)
 
 DSP active-fund holdings in `market_data.mf_holdings` are the primary institutional single-name conviction signal.
 
@@ -161,7 +162,7 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary institutio
 
 ---
 
-## ⚡ 6. Ultra-Fast Pre-Aggregated Queries (<100ms)
+## ⚡ 7. Ultra-Fast Pre-Aggregated Queries (<100ms)
 
 Use `market_data.mf_holding_summaries` Materialized View for instant aggregate stock counts and totals:
 ```sql
@@ -178,7 +179,7 @@ ORDER BY as_of_month DESC;
 
 ---
 
-## 📊 7. AMFI Category Flows & Sector AUM Tracking
+## 📊 8. AMFI Category Flows & Sector AUM Tracking
 
 `market_data.amfi_category_flows` contains monthly category-level gross purchases, redemptions, net flows, and closing AUM.
 

--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -344,6 +344,7 @@ AGENT_SYSTEM_PROMPT = (
     "numbers that were returned verbatim by a tool. If no tool has produced a "
     "number, state that the data is unavailable — do NOT approximate.\n\n"
     "MATERIALIZED VIEW RULE: For ultra-fast (<100ms) aggregate queries on mutual fund cross-ownership totals and fund count per stock/month, query the pre-aggregated Materialized View table `market_data.mf_holding_summaries FINAL` (`isin`, `security_name`, `as_of_month`, `active_funds_count`, `total_market_val_cr`). For full fund-by-fund breakdowns, query `market_data.mf_holdings FINAL`.\n\n"
+    "AMC BULLISH SMALL-CAP PICKS RULE: When asked for specific small-cap stocks an AMC is bullish on, query `market_data.mf_holdings FINAL` for the highest % NAV allocation (`pct_of_nav`) in active small-cap funds (e.g. `DSP_SMALL_CAP` -> Thangamayil Jewellery 4.81% NAV, `QUANT_SMALL_CAP` -> HFCL 6.03% NAV, `BAJAJ_FINSERV_SMALL_CAP_FUND` -> Rubicon Research 4.18% NAV).\n\n"
     "CLICKHOUSE SYNTAX RULE (mandatory — never violate): "
     "When writing ad-hoc SQL queries using `query_clickhouse_db`, every ReplacingMergeTree table MUST use the `FINAL` modifier. "
     "If you declare an alias for the table, the alias MUST be declared BEFORE the `FINAL` modifier. "

--- a/src/agents/sub_agents/mf.py
+++ b/src/agents/sub_agents/mf.py
@@ -44,6 +44,7 @@ class MFSubAgent(_SubAgent):
         "| Find funds by asset category exposure     | `search_mf_exposure`                        |\n"
         "| Ad-hoc holdings query                     | `query_clickhouse_db` on `mf_holdings FINAL`|\n"
         "| Fast multi-fund holding count/value totals| `query_clickhouse_db` on `mf_holding_summaries FINAL` (Materialized View <100ms)|\n"
+        "| AMC bullish small-cap stock picks (% NAV) | `query_clickhouse_db` on `mf_holdings FINAL` ordered by `pct_of_nav DESC` |\n"
         "| Import latest DSP holdings                | `run_dsp_multi_asset_importer`              |\n"
         "| Import latest Nippon holdings             | `run_nippon_importer`                       |\n"
         "| Import latest Quant holdings              | `run_quant_importer`                        |\n"


### PR DESCRIPTION
## Summary
- Add **AMC-Specific Bullish Small-Cap Stock Picks** section and benchmarks to .
- Add  to  system prompt.
- Add AMC bullish small-cap query pattern to  system prompt table.