### PR TITLE
feat(importer): add Shoonya intraday EOD fallback, single-symbol auto-import, and volume patterns

### DIFF
--- a/src/agents/sub_agents/equity_gatherer.py
+++ b/src/agents/sub_agents/equity_gatherer.py
@@ -71,6 +71,20 @@ def _gather_indian_equity_data(symbol: str, exchange: str, company_name: str, ll
             r1y = round((latest - prev1y) / prev1y * 100, 2) if prev1y else 0
             sig = "BULLISH" if r30 > 5 else "BEARISH" if r30 < -5 else "NEUTRAL"
             parts.append(f"**Price Momentum:** 30d {r30:+.2f}% │ 90d {r90:+.2f}% │ 1y (YoY) {r1y:+.2f}% │ Signal: **{sig}**")
+
+            # Volume pattern analysis
+            recent_vols = [r.get("volume", 0) for r in hist if r.get("volume")]
+            if len(recent_vols) >= 20:
+                avg_vol_20d = sum(recent_vols[-20:]) / 20.0
+                latest_vol = recent_vols[-1]
+                vol_ratio = (latest_vol / avg_vol_20d) if avg_vol_20d > 0 else 1.0
+                avg_vol_30d = sum(recent_vols[-30:]) / min(len(recent_vols), 30) if recent_vols else 0
+                vol_sig = "HIGH EXPANSION" if vol_ratio >= 1.8 else "ACCUMULATION/DISTRIBUTION" if vol_ratio >= 1.3 else "NORMAL"
+                parts.append(
+                    f"**Volume Pattern:** 30d ADV: {int(avg_vol_30d):,} shares │ "
+                    f"Latest Vol vs 20d MA: {vol_ratio:.2f}x │ Activity: **{vol_sig}**"
+                )
+
             try:
                 from src.tools.chart_tools import plot_price_chart
                 chart_str = plot_price_chart(symbol, days=365)

--- a/src/agents/sub_agents/india_equity.py
+++ b/src/agents/sub_agents/india_equity.py
@@ -190,6 +190,7 @@ class IndianEquityResearchSubAgent(_SubAgent):
         "(1b) Price Anomalies & Shock Events — summarise the dates, price shocks, and underlying news/macro causes retrieved from search_anomaly_events (explain the anomalies/red dots on the chart)  "
         "(1c) Event Correlation Analysis — include the full output of find_anomaly_correlations verbatim (attribution table, mapped anomalies timeline, FX validation block, and attribution summary). "
         "Write `[CHART:correlation_timeline]` then `[CHART:lead_lag_grid]` on their own lines immediately after the attribution table so the charts appear inline.  "
+        "(1d) Volume & Liquidity Pattern — summarise average daily volume (30d ADV), recent volume vs 20d MA expansion/contraction ratio, volume Z-scores, and institutional block volume probability (`p_institutional` from search_anomaly_events).  "
         "(2) Financials table  (3) Valuation vs sector  "
         "(4) Cash Flow quality  "
         "(5) Institutional Ownership — write `[CHART:shareholding]` on its own line where the shareholding bar should appear, then the "

--- a/src/db/anomaly_vector.py
+++ b/src/db/anomaly_vector.py
@@ -292,6 +292,7 @@ def retrieve_similar_anomalies(
     k: int = 5,
     category: str = "",
     same_asset_only: bool = False,
+    exclude_window_days: int = 0,
 ) -> list[dict]:
     """
     Find past anomaly events semantically similar to the given regime + context.
@@ -300,13 +301,14 @@ def retrieve_similar_anomalies(
     `market_anomalies` collection by vector similarity.
 
     Args:
-        symbol:          The asset symbol (e.g. "GOLDBEES").
-        regime:          The anomaly regime label (e.g. "⚡ Flash Crash / Black Swan (EXIT)").
-        trade_date:      The anomaly date — used to exclude future-leaking matches
-                         that are within 30 days of the query date.
-        k:               Number of similar events to return.
-        category:        Optional asset category for richer query context.
-        same_asset_only: If True, restrict results to the same symbol.
+        symbol:              The asset symbol (e.g. "GOLDBEES").
+        regime:              The anomaly regime label (e.g. "⚡ Flash Crash / Black Swan (EXIT)").
+        trade_date:          The query anomaly date.
+        k:                   Number of similar events to return.
+        category:            Optional asset category for richer query context.
+        same_asset_only:     If True, restrict results to the same symbol.
+        exclude_window_days: Optional calendar days window around query date to exclude.
+                             Defaults to 0 (do not exclude surrounding dates).
 
     Returns:
         List of dicts with keys: symbol, category, trade_date, regime,
@@ -324,11 +326,6 @@ def retrieve_similar_anomalies(
     if all(v == 0.0 for v in query_vec):
         return []
 
-    # Exclude a 30-day window around the query date to avoid trivial self-matches
-    ts = _to_ts(trade_date)
-    exclusion_lo = ts - 30 * 86400
-    exclusion_hi = ts + 30 * 86400
-
     try:
         must_conditions = []
         if same_asset_only:
@@ -336,12 +333,17 @@ def retrieve_similar_anomalies(
                 FieldCondition(key="symbol", match=MatchValue(value=symbol))
             )
 
-        # Two searches: before and after the exclusion window, then merge
+        ts = _to_ts(trade_date)
+        if exclude_window_days > 0:
+            exclusion_lo = ts - exclude_window_days * 86400
+            exclusion_hi = ts + exclude_window_days * 86400
+            ranges = [(0.0, exclusion_lo), (exclusion_hi, ts + 10 * 365 * 86400)]
+        else:
+            ranges = [(0.0, float(2e9))]
+
         results_all: list[dict] = []
-        for (lo, hi) in [
-            (0.0, exclusion_lo),
-            (exclusion_hi, ts + 10 * 365 * 86400),
-        ]:
+        query_date_str = str(trade_date)[:10]
+        for (lo, hi) in ranges:
             range_conds = list(must_conditions) + [
                 FieldCondition(key="trade_timestamp", range=Range(gte=lo, lte=hi))
             ]
@@ -349,11 +351,15 @@ def retrieve_similar_anomalies(
                 collection_name=_COLLECTION,
                 query=query_vec,
                 query_filter=Filter(must=range_conds),
-                limit=k,
+                limit=k * 2,
                 with_payload=True,
             )
             for hit in hits.points:
                 p = hit.payload or {}
+                p_date = str(p.get("trade_date", ""))[:10]
+                # Exclude only exact self-match date if querying same event
+                if p_date == query_date_str and p.get("symbol") == symbol:
+                    continue
                 results_all.append({
                     "symbol":       p.get("symbol", ""),
                     "category":     p.get("category", ""),

--- a/src/importer/fetchers/shoonya_fetcher.py
+++ b/src/importer/fetchers/shoonya_fetcher.py
@@ -313,11 +313,61 @@ def fetch_shoonya_ohlcv(
                 log.debug("Shoonya: bad bar for %s: %s — %s", nse_sym, bar, exc)
                 continue
 
+        # If the daily series is missing recent dates up to to_date/today, try intraday aggregation fallback
+        parsed_dates = {r["trade_date"] for r in rows if r["symbol"] == nse_sym}
+        check_date = from_date
+        max_check = min(to_date, date.today())
+        while check_date <= max_check:
+            if check_date.weekday() < 5 and check_date not in parsed_dates:
+                extra_bar = _fetch_shoonya_intraday_eod(api, nse_sym, category, check_date)
+                if extra_bar:
+                    rows.append(extra_bar)
+                    parsed_dates.add(check_date)
+            check_date += timedelta(days=1)
+
         # Be polite — Shoonya has no documented rate limit but avoid hammering
         time.sleep(0.1)
 
     log.info("Shoonya: fetched %d rows for %s (%s→%s)", len(rows), category, from_date, to_date)
     return rows
+
+
+def _fetch_shoonya_intraday_eod(api, nse_sym: str, category: str, target_date: date) -> dict[str, Any] | None:
+    """Aggregate 1-minute intraday bars from Shoonya into an EOD bar when get_daily_price_series lags."""
+    try:
+        from src.tools.shoonya_tools import _resolve_token
+        token_info = _resolve_token(api, nse_sym)
+        if not token_info:
+            return None
+        token, _tsym = token_info
+        exchange = "NSE"
+        start_ts = int(datetime.combine(target_date, datetime.min.time()).timestamp())
+        end_ts   = int(datetime.combine(target_date, datetime.max.time()).timestamp())
+        bars = api.get_time_price_series(exchange=exchange, token=token, starttime=start_ts, endtime=end_ts)
+        if not bars or not isinstance(bars, list):
+            return None
+        valid_bars = [b for b in bars if isinstance(b, dict) and b.get("ssboe") and b.get("into")]
+        if not valid_bars:
+            return None
+        valid_bars.sort(key=lambda x: int(x["ssboe"]))
+        open_p  = float(valid_bars[0]["into"])
+        high_p  = max(float(b["inth"]) for b in valid_bars)
+        low_p   = min(float(b["intl"]) for b in valid_bars)
+        close_p = float(valid_bars[-1]["intc"])
+        vol     = sum(float(b.get("intv", 0)) for b in valid_bars)
+        return {
+            "symbol":     nse_sym,
+            "category":   category,
+            "trade_date": target_date,
+            "open":       open_p,
+            "high":       high_p,
+            "low":        low_p,
+            "close":      close_p,
+            "volume":     vol,
+        }
+    except Exception as exc:
+        log.debug("Shoonya intraday fallback failed for %s on %s: %s", nse_sym, target_date, exc)
+        return None
 
 
 def _parse_shoonya_date(raw: str) -> date | None:

--- a/src/ml/anomaly/_qdrant.py
+++ b/src/ml/anomaly/_qdrant.py
@@ -19,6 +19,7 @@ def retrieve_similar_anomalies(
     k: int = 5,
     category: str = "",
     same_asset_only: bool = False,
+    exclude_window_days: int = 0,
 ) -> list[dict]:
     """Retrieve past anomaly events semantically similar to the given regime+context.
 
@@ -37,6 +38,7 @@ def retrieve_similar_anomalies(
             k=k,
             category=category,
             same_asset_only=same_asset_only,
+            exclude_window_days=exclude_window_days,
         )
     except (ImportError, ConnectionError, OSError) as e:
         # Qdrant unavailable — expected in offline or non-vectorised environments

--- a/src/tools/agent_tools.py
+++ b/src/tools/agent_tools.py
@@ -45,7 +45,7 @@ _SYMBOL_CATEGORY: dict[str, str] = {
 # ETFs trade weekdays only — Friday close shows 3 days old on Monday, 4 on Tuesday.
 # 7 days tolerates normal weekends + Indian market holidays without false-positive imports.
 _ETF_STALE_DAYS   = 7
-_STOCK_STALE_DAYS = 4
+_STOCK_STALE_DAYS = 0
 
 
 # ── Data availability + auto-import ───────────────────────────────────────────
@@ -59,7 +59,7 @@ def check_and_refresh_symbol_data(symbol: str, auto_import: bool = True) -> str:
 
     Staleness thresholds (weekday-only sources):
       ETFs   — 7 calendar days  (covers weekends + Indian market holidays)
-      Stocks — 4 calendar days
+      Stocks — 0 calendar days  (always refresh if not current date)
 
     Call this BEFORE running price-based analysis (momentum, correlations, GARCH)
     for any symbol the user explicitly named. Do NOT call it for every ETF in a
@@ -137,10 +137,10 @@ def check_and_refresh_symbol_data(symbol: str, auto_import: bool = True) -> str:
             f"Run: `import --category {category}` to refresh."
         )
 
-    # Trigger the importer
+    # Trigger the importer for the specific symbol only
     try:
-        from src.tools.skills_tools import run_data_engineering_importer
-        run_data_engineering_importer.invoke({"category": category, "full": False})
+        from src.tools.skills_tools import import_symbol_data_impl
+        import_symbol_data_impl(sym)
 
         # Verify: re-check last_date after import
         verify_df = query_df(


### PR DESCRIPTION
## Summary
- Added  fallback in  to aggregate 1-minute intraday bars into daily EOD candles when Shoonya batch EOD lags.
- Updated  in  to set  and auto-import only the target symbol ().
- Enhanced India Equity research note prompts and programmatic fallback (, ) to analyze and report Volume & Liquidity Patterns (30d ADV, volume expansion ratio, volume activity signals).
- Removed mandatory 30-day exclusion window in  (, ) so historical vector search queries the full timeline.