### PR TITLE
feat: add Shoonya WebSocket today-price fallback and progress indicators

### DIFF
--- a/src/importer/fetchers/nselib_fetcher.py
+++ b/src/importer/fetchers/nselib_fetcher.py
@@ -49,7 +49,8 @@ def fetch_nselib_ohlcv(
     rows: list[dict[str, Any]] = []
 
     for idx, (nse_sym, _yahoo_sym) in enumerate(symbols, 1):
-        print(f"    [{idx}/{len(symbols)}] Fetching {nse_sym} via nselib...", flush=True)
+        pct = (idx / len(symbols)) * 100
+        print(f"    [{idx}/{len(symbols)} - {pct:.1f}%] Fetching {nse_sym} via nselib...", flush=True)
         try:
             df = capital_market.price_volume_and_deliverable_position_data(
                 nse_sym,

--- a/src/importer/fetchers/shoonya_fetcher.py
+++ b/src/importer/fetchers/shoonya_fetcher.py
@@ -329,6 +329,20 @@ def fetch_shoonya_ohlcv(
         # Be polite — Shoonya has no documented rate limit but avoid hammering
         time.sleep(0.1)
 
+    # Batch WebSocket fallback for today's price if still missing
+    today = date.today()
+    if from_date <= today <= to_date:
+        missing_today_symbols = []
+        for nse_sym, yahoo_sym in symbols:
+            symbol_has_today = any(r["symbol"] == nse_sym and r["trade_date"] == today for r in rows)
+            if not symbol_has_today:
+                missing_today_symbols.append((nse_sym, yahoo_sym))
+        
+        if missing_today_symbols:
+            log.info("Shoonya: %d symbol(s) missing today's bar. Attempting WebSocket touchline fetch...", len(missing_today_symbols))
+            ws_rows = _fetch_shoonya_websocket_today_batch(api, missing_today_symbols, category, today)
+            rows.extend(ws_rows)
+
     log.info("Shoonya: fetched %d rows for %s (%s→%s)", len(rows), category, from_date, to_date)
     return rows
 
@@ -379,3 +393,99 @@ def _parse_shoonya_date(raw: str) -> date | None:
         except ValueError:
             continue
     return None
+
+
+def _fetch_shoonya_websocket_today_batch(
+    api,
+    symbols: list[tuple[str, str]],
+    category: str,
+    today_date: date,
+) -> list[dict[str, Any]]:
+    """
+    Connect to Shoonya WebSocket, subscribe to all symbols in parallel,
+    wait for touchline tick data, and format them as EOD bars for today.
+    """
+    import queue
+    import threading
+    from src.tools.shoonya_tools import _resolve_token
+
+    token_to_symbol = {}
+    tokens = []
+    for nse_sym, _yf_sym in symbols:
+        token_info = _resolve_token(api, nse_sym)
+        if token_info:
+            token, _tsym = token_info
+            token_to_symbol[token] = nse_sym
+            tokens.append(f"NSE|{token}")
+
+    if not tokens:
+        return []
+
+    ticks = {}
+    ticks_lock = threading.Lock()
+    all_done = threading.Event()
+
+    def on_feed(tick_data):
+        if not tick_data or tick_data.get("t") not in ("tk", "tf"):
+            return
+        token = tick_data.get("tk")
+        if not token or token not in token_to_symbol:
+            return
+
+        lp = tick_data.get("lp")
+        o = tick_data.get("o")
+        h = tick_data.get("h")
+        l = tick_data.get("l")
+        v = tick_data.get("v")
+
+        # We need touchline values (last traded price, open, high, low, volume)
+        if all(x is not None for x in (lp, o, h, l, v)):
+            with ticks_lock:
+                ticks[token] = tick_data
+                if len(ticks) == len(tokens):
+                    all_done.set()
+
+    try:
+        api.start_websocket(
+            order_update_callback=lambda x: None,
+            subscribe_callback=on_feed,
+            socket_open_callback=lambda: api.subscribe(tokens),
+        )
+        # Wait up to 3 seconds for all ticks to arrive
+        all_done.wait(timeout=3.0)
+    except Exception as exc:
+        log.warning("Shoonya: WebSocket batch fetch failed: %s", exc)
+    finally:
+        try:
+            api.close_websocket()
+        except Exception:
+            pass
+
+    # Construct EOD rows from cached ticks
+    ws_rows = []
+    with ticks_lock:
+        for token, tick in ticks.items():
+            symbol = token_to_symbol[token]
+            try:
+                close = float(tick["lp"])
+                if close <= 0:
+                    continue
+                ws_rows.append({
+                    "symbol":     symbol,
+                    "category":   category,
+                    "trade_date": today_date,
+                    "open":       float(tick.get("o") or close),
+                    "high":       float(tick.get("h") or close),
+                    "low":        float(tick.get("l") or close),
+                    "close":      close,
+                    "volume":     float(tick.get("v") or 0),
+                })
+            except (ValueError, TypeError, KeyError) as e:
+                log.debug("Shoonya: WebSocket parse failed for %s: %s", symbol, e)
+                continue
+
+    log.info(
+        "Shoonya: WebSocket touchline fetch completed. Retrieved %d rows out of %d requested.",
+        len(ws_rows), len(symbols)
+    )
+    return ws_rows

--- a/src/importer/fetchers/shoonya_fetcher.py
+++ b/src/importer/fetchers/shoonya_fetcher.py
@@ -261,7 +261,8 @@ def fetch_shoonya_ohlcv(
     rows: list[dict[str, Any]] = []
 
     for idx, (nse_sym, _yahoo_sym) in enumerate(symbols, 1):
-        print(f"    [{idx}/{len(symbols)}] Fetching {nse_sym} via Shoonya...", flush=True)
+        pct = (idx / len(symbols)) * 100
+        print(f"    [{idx}/{len(symbols)} - {pct:.1f}%] Fetching {nse_sym} via Shoonya...", flush=True)
         tradingsymbol = f"{nse_sym}-EQ"
         try:
             data = api.get_daily_price_series(

--- a/src/importer/fetchers/shoonya_fetcher.py
+++ b/src/importer/fetchers/shoonya_fetcher.py
@@ -457,7 +457,14 @@ def _fetch_shoonya_websocket_today_batch(
         log.warning("Shoonya: WebSocket batch fetch failed: %s", exc)
     finally:
         try:
-            api.close_websocket()
+            def _close():
+                try:
+                    api.close_websocket()
+                except Exception:
+                    pass
+            t = threading.Thread(target=_close, daemon=True)
+            t.start()
+            t.join(timeout=2.0)
         except Exception:
             pass
 


### PR DESCRIPTION
This PR introduces two features:
1. **Shoonya WebSocket Today-Price Fallback**: When the Shoonya REST historical database has not processed today's EOD daily bar yet (such as immediately after market close), the import process previously fell back to scraping NSE via nselib. This PR implements a batch WebSocket touchline fallback. It connects to the Shoonya WebSocket, subscribes to all missing tokens in parallel, fetches the touchline tick (which contains Open, High, Low, LTP, and Volume), compiles them as daily EOD bars, and inserts them into ClickHouse.
2. **Percentage Progress Indicators**: Updated `shoonya_fetcher` and `nselib_fetcher` print statements to show the percentage progress alongside the count index when downloading data.