### PR TITLE
refactor(importer): complete fetcher registry unification — 100% adapter-driven pipeline

### DIFF
--- a/.agents/skills/data-engineering-importer/SKILL.md
+++ b/.agents/skills/data-engineering-importer/SKILL.md
@@ -33,10 +33,7 @@ get_registry()["sentiment"] = MySentimentFetcher()
 
 Then `repo.run_fetcher(get_registry()["sentiment"])` handles watermarks, dry-run, and fires `DataImportedEvent` with no extra wiring.
 
-Legacy path (still works for complex categories not yet adapted):
-1. **Define Table**: Add the DDL to `src/importer/clickhouse.py`.
-2. **Register Source**: Update `src/importer/registry.py` with the new symbols or categories.
-3. **Wire into CLI**: Update `run_import()` in `src/importer/cli.py`.
+All general data categories (`stocks`, `etfs`, `fii_dii`, `world_bank`, `imf_weo`, `amfi_flows`, `fx_rates`, `cot`, `cb_reserves`, etc.) are 100% adapter-driven. Adding a new category simply requires instantiating its `Fetcher` in `_build_registry()` inside `src/importer/fetchers/adapters.py`.
 
 ### 2. Nippon India AMC Importer — Dynamic URL Discovery
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -126,7 +126,7 @@ New pattern (Adapter + Repository):
 
 **14 fetchers:** `yfinance`, `mfapi`, `cot` (CFTC Socrata), `nse_inav`, `fii_dii`, `imf_reserves`, `etf_aum`, `mf_holdings` (Morningstar), `fx_rates`, `nse_quote`, `yahoo_snapshot`, `expert_tweets`, `nse_corporate_actions` (NSE equity corporate actions — splits, bonuses, demergers, rights, dividends), plus news tools.
 
-**5 Fetcher adapters** (Adapter pattern, `src/importer/fetchers/adapters.py`): `YFinanceFetcher`, `MFNavFetcher`, `FIIDIIFetcher`, `FXRatesFetcher`, `COTGoldFetcher`, `WorldBankMacroFetcher`, `IMFWEOFetcher`. Add new sources to `FETCHER_REGISTRY` — orchestrator loop picks up automatically.
+**Fetcher adapters** (Adapter pattern, `src/importer/fetchers/adapters.py`): All general categories (`etfs`, `stocks`, `fii_dii`, `fx_rates`, `cot`, `cb_reserves`, `etf_aum`, `world_bank`, `imf_weo`, `amfi_flows`, `mf`, etc.) subclass `Fetcher` and map in `FETCHER_REGISTRY`. Orchestrator loop picks up new sources automatically.
 
 ### LLM Configuration
 `LLM_PROVIDER` (`openai` or `anthropic`) + `LLM_MODEL` control which model is used. Set `LLM_BASE_URL` to an OpenAI-compatible endpoint (Ollama, LM Studio) for local inference — no API key needed in that case.

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -46,15 +46,26 @@ python src/scripts/portfolio/import_stocks_parallel.py --workers 5 [--dry-run] [
 
 ### Fetcher Adapter Pattern
 
-Five core categories have typed **Fetcher adapters** (`src/importer/fetchers/adapters.py`):
+All general data categories have typed **Fetcher adapters** (`src/importer/fetchers/adapters.py`):
 
-| Adapter | Category | Overlap |
-|---|---|---|
-| `YFinanceFetcher` | etfs, stocks, commodities, indices | 3 days |
-| `MFNavFetcher` | mf | 3 days |
-| `FIIDIIFetcher` | fii_dii | 3 days |
-| `FXRatesFetcher` | fx_rates | 3 days |
-| `COTGoldFetcher` | cot | 21 days |
+| Adapter | Category | Overlap | Description |
+|---|---|---|---|
+| `ShoonyaFetcher` | etfs | 3 days | Shoonya API with nselib + yfinance fallbacks |
+| `StocksFetcher` | stocks, us_stocks | 3 days | Price, earnings, insider, valuation data |
+| `YFinanceFetcher` | commodities, indices | 3 days | Yahoo Finance EOD price history |
+| `NSElibFetcher` | etfs (fallback) | 3 days | Direct NSE OHLCV |
+| `NseIndexFetcher` | nse_indices | 3 days | Sectoral/factor indices via nselib |
+| `NseEodFetcher` | nse_eod | 3 days | Official NSE EOD bulk archive |
+| `IndianMacroFetcher` | indian_macro | 30 days | RBI/MOSPI Indian macro series |
+| `MFNavFetcher` | mf | 3 days | MFAPI mutual fund daily NAVs |
+| `FIIDIIFetcher` | fii_dii | 3 days | FII/DII daily cash, F&O OI, monthly aggs |
+| `FXRatesFetcher` | fx_rates | 3 days | Yahoo Finance USD currency pairs |
+| `COTGoldFetcher` | cot | 21 days | CFTC COT Gold Managed Money |
+| `CbReservesFetcher` | cb_reserves | 0 days | IMF IFS Central Bank Gold Reserves |
+| `EtfAumFetcher` | etf_aum | 0 days | Gold ETF AUM & implied tonnes |
+| `WorldBankMacroFetcher` | world_bank | 365 days | World Bank WDI annual macro indicators |
+| `IMFWEOFetcher` | imf_weo | 180 days | IMF WEO projections & forecasts |
+| `AmfiCategoryFlowsFetcher` | amfi_flows | 0 days | AMFI category-wise monthly flows + AUM |
 
 Use `MarketDataRepository.run_fetcher(fetcher)` to execute the full watermark → fetch → validate → insert → event cycle programmatically:
 

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -79,21 +79,63 @@ result = repo.run_fetcher(get_registry()["fii_dii"], dry_run=True)
 print(result)  # FetchResult: 8 rows  2026-05-07→2026-05-13 (dry-run)
 ```
 
-**Adding a new source:**
+### Developer Guide: Adding a New Fetcher Adapter
+
+To add a new data source to Mosaic, follow these **2 steps**:
+
+#### Step 1: Subclass `Fetcher` in `src/importer/fetchers/adapters.py`
+Implement `fetch()`, `validate()`, `insert()`, and `max_date()`:
+
 ```python
+from datetime import date
+from typing import Any
+import logging
 from src.importer.base_fetcher import Fetcher
 
-class MyFetcher(Fetcher):
-    source_name = "my_source"
-    symbol_key  = "MY_KEY"
+log = logging.getLogger(__name__)
 
-    def fetch(self, from_date, to_date): ...
-    def insert(self, rows, ch): return ch.insert_my_table(rows)
+class MyNewDataFetcher(Fetcher):
+    """Daily fetcher for My New Data Feed."""
+    source_name  = "my_source_name"   # Watermark source key in ClickHouse
+    symbol_key   = "ALL"              # Watermark symbol key ("ALL", "MARKET", etc.)
+    description  = "My New Data Feed" # Display description for CLI/logs
+    overlap_days = 1                  # Lookback overlap in days for delta-sync
 
-get_registry()["my_category"] = MyFetcher()
+    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+        """1. Fetch raw data from external API / scraper."""
+        from src.importer.fetchers.my_data_fetcher import fetch_my_data
+        return fetch_my_data(from_date=from_date, to_date=to_date)
+
+    def validate(self, rows: list[dict]) -> list[dict]:
+        """2. Filter invalid or corrupted rows."""
+        return [r for r in rows if r.get("value") is not None]
+
+    def insert(self, rows: list[dict], ch) -> int:
+        """3. Insert into ClickHouse using ClickHouseImporter instance `ch`."""
+        n = ch.insert_my_table(rows)
+        if rows:
+            latest = max(rows, key=lambda r: r["trade_date"])
+            log.info("MyNewData latest (%s): Value = %s", latest["trade_date"], f"{latest['value']:,.2f}")
+        return n
+
+    def max_date(self, rows: list[dict]) -> date:
+        """4. Return max trade date to update import_watermarks."""
+        return max(r["trade_date"] for r in rows)
 ```
 
-Post-import, `DataImportedEvent` fires automatically — `SignalAggregatorObserver` and `MLPredictionObserver` refresh downstream data without any manual trigger.
+#### Step 2: Register in `_build_registry()` inside `src/importer/fetchers/adapters.py`
+
+```python
+def _build_registry() -> dict[str, Fetcher]:
+    ...
+    registry["my_category"] = MyNewDataFetcher()
+    return registry
+```
+
+Once registered:
+- **CLI Ingestion**: `python src/main.py import --category my_category [--dry-run] [--full]`
+- **Programmatic Execution**: `repo.run_fetcher(get_registry()["my_category"])`
+- **Automatic Observer Integration**: Post-import, `DataImportedEvent` fires automatically to trigger downstream ML models, signals, and anomaly alerts.
 
 ## ClickHouse Schema
 

--- a/spec/Fetcher _egistry_unification_spec.md
+++ b/spec/Fetcher _egistry_unification_spec.md
@@ -1,0 +1,439 @@
+# [SPEC] Unify `cli.py` Import Orchestration Behind the Fetcher Registry
+
+**Status:** Proposed
+**Priority:** Medium (tech debt / maintainability)
+**Created:** 2026-07-31
+**Related:** `src/importer/fetchers/adapters.py`, `src/importer/cli.py`, `src/db/repository.py`
+
+---
+
+## 1. Problem
+
+`FETCHER_REGISTRY` / `get_registry()` in `src/importer/fetchers/adapters.py` and the
+`Fetcher` ABC in `src/importer/base_fetcher.py` document a generic pattern
+("register a source once, the orchestrator runs it uniformly") that is **not
+actually used anywhere in the codebase**. Every real caller —
+`src/importer/cli.py`, `src/importer/parallel_importer.py`,
+`src/tools/skills_tools.py` — imports concrete fetcher classes
+(`ShoonyaFetcher`, `NSElibFetcher`, ...) directly and hand-rolls its own
+control flow around them.
+
+`cli.py::run_import()` in particular reimplements, per category, logic that
+`MarketDataRepository.run_fetcher()` already provides in generic form:
+watermark resolution, retry, dry-run, and insert — plus several things
+`run_fetcher()` does **not** yet support:
+
+| Capability | `cli.py` today | `Fetcher` / `run_fetcher()` today |
+|---|---|---|
+| Per-symbol progress bar | ✅ `rich.Progress` | ❌ none |
+| Force a specific source (`shoonya`/`nse`/`yfinance`) | ✅ `data_source` param | ❌ fetcher is fixed to one source + its own internal fallback |
+| Parallel fetch across symbols | ✅ `ThreadPoolExecutor`, 5 workers (`parallel_importer.py`) | ❌ `fetch()` is one synchronous call |
+| Worst-case watermark across many symbols | ✅ `_resolve_from_date()`, per-symbol | ⚠️ `run_fetcher()` tracks one watermark per `(source_name, symbol_key)` group, not per symbol |
+
+Because of this gap, the registry is effectively **dead code with misleading
+docstrings**, and `cli.py` carries ~200 lines of per-category branching
+(`if category in ("stocks", "us_stocks")`, `if category == "nse_indices"`,
+`if category in ("stocks", "etfs")`, ...) that must be manually updated any
+time fetcher behavior changes.
+
+## 2. Goal
+
+Make `get_registry()` the **single real entry point** for running any
+category, so that:
+
+- Adding a new data source is one line in `adapters.py` (`registry[...] = X`) —
+  no `cli.py` changes required, ever.
+- `cli.py::run_import()` collapses to one loop over `categories`, with no
+  per-category special-casing.
+- No existing capability regresses: progress bars, source override, and
+  parallelism for stocks/etfs must keep working exactly as they do today.
+
+## 3. Non-Goals
+
+- Not changing the ClickHouse schema, DDL, or table shapes.
+- Not changing watermark semantics for existing single-symbol-group fetchers
+  (`fii_dii`, `cot`, `fx_rates`, `world_bank`, `imf_weo`) — they already work
+  correctly through `run_fetcher()` today (per Option 2 groundwork).
+- Not migrating `src/tools/skills_tools.py`'s direct fetcher usage — it's an
+  interactive tool path, not the batch importer, and is out of scope here.
+
+## 4. Design
+
+### 4.1 `Fetcher` ABC — new optional capability flags and richer `fetch()` signature
+
+`src/importer/base_fetcher.py`
+
+```python
+class Fetcher(ABC):
+    source_name:  str
+    symbol_key:   str
+    description:  str = ""
+    overlap_days: int = 3
+
+    # NEW — opt-in capability flags, default False/None so every existing
+    # Fetcher subclass keeps working unmodified.
+    supports_parallel:        bool = False
+    supports_source_override: bool = False
+
+    @abstractmethod
+    def fetch(
+        self,
+        from_date: date,
+        to_date: date,
+        *,
+        source: str | None = None,          # NEW, optional
+        progress_cb: Callable[[str], None] | None = None,  # NEW, optional
+    ) -> list[dict[str, Any]]:
+        """
+        Pull rows from the external source.
+
+        source      : override the fetcher's default source, if
+                      supports_source_override is True. Ignored otherwise.
+        progress_cb : called with a symbol string after each symbol
+                      completes, if supports_parallel is True. Ignored
+                      otherwise.
+        """
+```
+
+Existing subclasses (`FIIDIIFetcher`, `COTGoldFetcher`, `WorldBankMacroFetcher`,
+etc.) need **zero changes** — Python allows them to keep the narrower
+`fetch(self, from_date, to_date)` signature since callers only pass the new
+kwargs conditionally (see 4.3).
+
+### 4.2 Per-symbol watermark support in the watermark store
+
+Current schema (`market_data.import_watermarks`, unchanged):
+```
+ORDER BY (source, symbol, dataset)
+```
+This already supports a `symbol` value that is either a group key
+(`"ETF_GROUP"`) or an individual symbol (`"GOLDBEES"`) — the table doesn't
+care which. The gap is only in `MarketDataRepository.run_fetcher()`, which
+currently always uses `fetcher.symbol_key` (one group value) for both read
+and write.
+
+**Add** a repository method for the per-symbol case, used only by
+`supports_parallel` fetchers:
+
+```python
+def _resolve_group_from_date(
+    self, ch, source: str, symbols: list[str], *,
+    lookback_days: int, overlap_days: int, full: bool, today: date,
+) -> date:
+    """Worst-case (earliest) per-symbol watermark minus overlap.
+    This is a straight port of cli.py's existing _resolve_from_date."""
+```
+
+```python
+def _update_group_watermarks(self, ch, rows, source, dry_run) -> None:
+    """Per-symbol watermark write. Port of cli.py's _update_watermarks."""
+```
+
+This preserves the exact existing watermark semantics for stocks/etfs (no
+silent behavior change) while keeping the group-watermark path
+(`get_watermark`/`set_watermark` on `symbol_key`) for every other fetcher.
+
+### 4.3 `run_fetcher()` — parallel + progress + source-override support
+
+`src/db/repository.py`
+
+```python
+def run_fetcher(
+    self,
+    fetcher: "Fetcher",
+    *,
+    dry_run: bool = False,
+    full: bool = False,
+    lookback_days: int = 3650,
+    workers: int = 1,                                   # NEW
+    source: str | None = None,                           # NEW
+    progress_cb: Callable[[str], None] | None = None,     # NEW
+) -> "FetchResult":
+    ...
+    use_group_watermark = fetcher.supports_parallel and hasattr(fetcher, "symbols")
+
+    if use_group_watermark:
+        from_date = self._resolve_group_from_date(
+            ch, fetcher.source_name, [s for s, _ in fetcher.symbols],
+            lookback_days=lookback_days, overlap_days=fetcher.overlap_days,
+            full=full, today=today,
+        )
+    else:
+        # existing single symbol_key watermark logic, unchanged
+
+    fetch_kwargs = {}
+    if fetcher.supports_source_override:
+        fetch_kwargs["source"] = source
+    if fetcher.supports_parallel and workers > 1:
+        rows = self._fetch_parallel(fetcher, from_date, today, workers,
+                                     progress_cb=progress_cb, **fetch_kwargs)
+    else:
+        rows = fetcher.fetch_with_retry(from_date, today, **fetch_kwargs)
+    ...
+
+    if use_group_watermark:
+        self._update_group_watermarks(ch, rows, fetcher.source_name, dry_run)
+    else:
+        ch.set_watermark(fetcher.source_name, fetcher.symbol_key, fetcher.max_date(rows))
+```
+
+```python
+def _fetch_parallel(self, fetcher, from_date, to_date, workers, *,
+                     progress_cb=None, **fetch_kwargs) -> list[dict]:
+    """
+    Direct port of parallel_importer.run_parallel_stock_import's
+    ThreadPoolExecutor logic, generalized to any supports_parallel Fetcher.
+    Per-symbol exceptions are caught and logged — one bad symbol must not
+    fail the batch. This preserves parallel_importer.py's existing
+    fault-isolation behavior exactly.
+    """
+```
+
+`fetch_with_retry()` in `base_fetcher.py` needs its signature widened to pass
+through `**kwargs` to `self.fetch(...)` unchanged.
+
+### 4.4 `adapters.py` — `ShoonyaFetcher` / `NSElibFetcher` / `YFinanceFetcher` gain the flags
+
+```python
+class ShoonyaFetcher(Fetcher):
+    supports_parallel = True
+    supports_source_override = True
+
+    def fetch(self, from_date, to_date, *, source=None, progress_cb=None):
+        if source == "nse":
+            rows = NSElibFetcher(self.category, self.symbols).fetch(from_date, to_date)
+        elif source == "yfinance":
+            from src.importer.fetchers.yfinance_fetcher import fetch_ohlcv
+            rows = fetch_ohlcv(self.symbols, self.category, from_date, to_date)
+        else:
+            rows = fetch_shoonya_ohlcv(self.symbols, self.category, from_date, to_date)
+            # existing nselib -> yfinance fallback chain, unchanged
+        if progress_cb:
+            for sym, _ in self.symbols:
+                progress_cb(sym)
+        return rows
+```
+
+`NseIndexFetcher` is left as a plain (non-parallel, non-source-override)
+`Fetcher` — its `cli.py` special case (line ~237, `if category ==
+"nse_indices"`) collapses into the generic loop with no flags set.
+
+### 4.5 `cli.py::run_import()` — collapse to one loop
+
+```python
+for category in categories:
+    fetcher = get_registry().get(category)
+    if fetcher is None:
+        console.print(f"[yellow]⚠ Unknown category: {category}, skipping[/yellow]")
+        continue
+
+    console.print(f"\n[bold cyan]▶ {category.upper()}[/bold cyan]")
+
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"),
+                  BarColumn(), TaskProgressColumn(), console=console, transient=True) as progress:
+        total = len(getattr(fetcher, "symbols", []) or [1])
+        task = progress.add_task(f"Fetching {category}…", total=total)
+
+        result = repo.run_fetcher(
+            fetcher,
+            dry_run=dry_run,
+            full=full_reimport,
+            lookback_days=lookback_days,
+            workers=5 if fetcher.supports_parallel and category in ("stocks", "us_stocks") else 1,
+            source=selected_source if fetcher.supports_source_override else None,
+            progress_cb=lambda sym: progress.update(task, advance=1, description=f"[dim]{sym}[/dim]"),
+        )
+
+    console.print(f"  [green]✓[/green] {result.n} rows {'(dry-run)' if dry_run else 'inserted'}")
+    summary_rows.append((category, result.source, result.n,
+                          result.from_date.isoformat(), result.to_date.isoformat()))
+```
+
+All of: the `mf_holdings`, `nse_eod`, `amfi_category_flows`, and
+`indian_macro` special sections further down in `run_import()` (lines
+304+) are addressed in Phase 2 (see §6) — they are separate, lower-risk
+migrations once the core loop above is proven.
+
+## 5. Backward Compatibility
+
+- `Fetcher` subclasses that don't set `supports_parallel`/
+  `supports_source_override` are unaffected — default `fetch(from_date,
+  to_date)` calls keep working exactly as today.
+- Watermark table schema is unchanged; only which `(source, symbol)` pairs
+  get written differs, and only for fetchers that opt into
+  `supports_parallel` (i.e., only `ShoonyaFetcher`/`NSElibFetcher`, which
+  already use per-symbol watermarks today via `cli.py`'s hand-rolled path —
+  so this preserves existing behavior, not changes it).
+- `FetchResult` (`src/db/repository.py`) needs no changes — `result.source`,
+  `result.n`, `result.from_date`, `result.to_date` already cover what
+  `summary_rows` needs.
+
+## 6. Rollout Plan
+
+1. **Phase 0** — Add `supports_parallel`/`supports_source_override` flags and
+   widen `Fetcher.fetch()`/`fetch_with_retry()` signatures. No behavior change
+   yet; existing callers unaffected.
+2. **Phase 1** — Implement `_fetch_parallel`, `_resolve_group_from_date`,
+   `_update_group_watermarks` in `repository.py`. Unit test against a fake
+   `Fetcher` with `supports_parallel=True`.
+3. **Phase 2** — Migrate `ShoonyaFetcher`/`NSElibFetcher`/`YFinanceFetcher` to
+   the new signature. Update `tests/test_custom_import.py` mocks to match
+   (`fetch(from_date, to_date, source=..., progress_cb=...)`).
+4. **Phase 3** — Rewrite `cli.py::run_import()`'s stocks/etfs/nse_indices
+   branches to the unified loop, gated by the full validation suite in §7
+   (parity harness, watermark equivalence, fault-isolation test,
+   source-override test, progress smoke test, staging dry-run diff) before
+   any old branch is removed.
+5. **Phase 4** — Migrate the remaining special sections (`mf_holdings`,
+   `nse_eod`, `amfi_category_flows`, `indian_macro`) into registry entries.
+6. **Phase 5** — Delete `parallel_importer.py`'s now-redundant
+   `run_parallel_stock_import`/`import_single_stock`, and delete `cli.py`'s
+   `_resolve_from_date`/`_update_watermarks` free functions once nothing
+   references them.
+
+## 7. End-to-End Validation Plan
+
+The goal is to prove the unified path produces **identical outputs** to the
+existing hand-rolled path before deleting any old code, then prove the new
+capabilities (parallelism, source override, progress) actually work under
+real conditions.
+
+### 7.1 Parity harness — old path vs. new path, byte-for-byte
+
+Before Phase 3 removes any `cli.py` branch, add a throwaway comparison script
+(`scripts/validate_registry_parity.py`, deleted after Phase 5):
+
+```python
+old_rows = ShoonyaFetcher(category, symbols).fetch(from_date, today)          # today's code path
+new_rows = get_registry()[category].fetch(from_date, today, source=None)      # new code path
+
+assert len(old_rows) == len(new_rows)
+old_keyed = {(r["symbol"], r["trade_date"]): r for r in old_rows}
+new_keyed = {(r["symbol"], r["trade_date"]): r for r in new_rows}
+assert old_keyed.keys() == new_keyed.keys()
+for k in old_keyed:
+    assert old_keyed[k] == new_keyed[k], f"Row mismatch at {k}"
+```
+
+Run this for every category in `ALL_CATEGORIES` against `--dry-run`, so no
+writes happen. This is the gate for Phase 3 — it must pass before any old
+branch is deleted.
+
+### 7.2 Watermark equivalence check
+
+Because `_resolve_group_from_date`/`_update_group_watermarks` are ports of
+`cli.py`'s existing `_resolve_from_date`/`_update_watermarks`, run both
+against a snapshot of `import_watermarks` (e.g. a ClickHouse test container
+seeded with fixture watermark rows) and assert they compute the **same
+`from_date`** and write the **same per-symbol watermark rows**:
+
+```python
+old_from = _resolve_from_date(ch, "shoonya", symbol_list, lookback_days=365, today=today)
+new_from = repo._resolve_group_from_date(ch, "shoonya", symbol_list, lookback_days=365,
+                                          overlap_days=3, full=False, today=today)
+assert old_from == new_from
+```
+
+### 7.3 Parallel fault-isolation test
+
+Since this is the riskiest part (§8, "Per-symbol fault isolation must be
+preserved exactly"), write an explicit test with an injected failure:
+
+```python
+class FlakyFetcher(Fetcher):
+    supports_parallel = True
+    symbols = [("GOOD1", "GOOD1.NS"), ("BAD", "BAD.NS"), ("GOOD2", "GOOD2.NS")]
+
+    def fetch(self, from_date, to_date, *, source=None, progress_cb=None):
+        if source == "BAD":  # simulate one symbol raising
+            raise RuntimeError("simulated failure")
+        ...
+
+def test_fetch_parallel_isolates_failures():
+    result = repo._fetch_parallel(FlakyFetcher(), from_date, to_date, workers=3)
+    assert {r["symbol"] for r in result} == {"GOOD1", "GOOD2"}  # BAD dropped, not fatal
+```
+This directly encodes the requirement from `parallel_importer.py`'s current
+`try/except` behavior — a regression here would silently drop symbols instead
+of failing loudly, which is exactly what must NOT happen.
+
+### 7.4 Source-override integration test
+
+Confirm `data_source=nse` / `data_source=yfinance` actually route through the
+alternate path and not silently fall back to shoonya:
+
+```python
+@patch("src.importer.fetchers.adapters.NSElibFetcher.fetch")
+def test_source_override_routes_to_nselib(mock_fetch):
+    get_registry()["etfs"].fetch(from_date, today, source="nse")
+    mock_fetch.assert_called_once()
+```
+
+### 7.5 Progress callback smoke test
+
+Assert `progress_cb` fires exactly once per symbol, in any order (since
+threads complete out of order):
+
+```python
+seen = []
+repo.run_fetcher(fetcher, workers=5, progress_cb=lambda sym: seen.append(sym))
+assert sorted(seen) == sorted(s for s, _ in fetcher.symbols)
+```
+
+### 7.6 Full dry-run against staging ClickHouse
+
+Run `python -m src.importer.cli import --categories all --dry-run` against a
+staging ClickHouse instance (not production) on both the pre-refactor branch
+and the Phase-3 branch, and diff:
+
+- Total row count per category (`FetchResult.n`)
+- `from_date`/`to_date` per category
+- CLI summary table output (`summary_rows`)
+
+Any diff must be explained (e.g. a source's upstream API returned different
+data between the two runs due to time passing) before merging — not assumed
+benign.
+
+### 7.7 Production canary
+
+After Phases 1–4 land behind the unchanged CLI interface:
+1. Run the new path in `--dry-run` mode in the real daily cron
+   (`scripts/cron_daily_sync.sh`) alongside the old path for **one week**,
+   logging both outputs but writing with the old path only.
+2. Compare `import_failures` row counts between old/new — the new path must
+   not produce *more* failures than the old one.
+3. Only after a clean week, flip the cron job to the new path for real
+   writes, with the old code kept (but unused) for one more release in case
+   of rollback.
+
+### 7.8 Rollback plan
+
+Keep `parallel_importer.py` and `cli.py`'s `_resolve_from_date`/
+`_update_watermarks` functions intact (unused, not deleted) through Phase 4.
+Only delete them in Phase 5, after the production canary (§7.7) has run
+cleanly for at least one full week of real daily imports.
+
+## 8. Risks
+
+- **Per-symbol fault isolation must be preserved exactly.** The current
+  `ThreadPoolExecutor` + `try/except` in `parallel_importer.py` logs and skips
+  a failing symbol without failing the batch. `_fetch_parallel` must replicate
+  this precisely — a regression here would silently drop symbols instead of
+  surfacing errors.
+- **Mock drift in tests.** `tests/test_custom_import.py` patches
+  `ShoonyaFetcher`/`NSElibFetcher` directly; changing their `fetch()`
+  signature will break these mocks until updated (Phase 2 must include this).
+- **Effort vs. payoff.** This is a real refactor across 4 files, not a
+  cleanup. It only pays off if more parallel/source-overridable fetchers are
+  expected later; if stocks/etfs remain the only ones that ever need this,
+  Option 2 (registry only for the already-simple sources) is cheaper and
+  lower-risk.
+
+## 9. Open Questions
+
+- Should `workers` be a fixed `5` (current default) or configurable per
+  fetcher (e.g. a `default_workers` class attribute), so future
+  high-volume sources can tune it independently?
+- Do we want `progress_cb` to support failure/skip states (e.g.
+  `progress_cb(sym, status="failed")`) so the progress bar can visually
+  distinguish a fallback-to-yfinance from a clean primary-source fetch?

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -327,7 +327,7 @@ class MarketDataRepository:
             rows = fetcher.validate(rows)
 
             if dry_run:
-                return FetchResult(fetcher=fetcher, n=len(rows), from_date=from_date,
+                return FetchResult(fetcher=fetcher, n=fetcher.count_insertable(rows), from_date=from_date,
                                    to_date=fetcher.max_date(rows), dry_run=True)
 
             n = fetcher.insert(rows, ch)

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -279,6 +279,11 @@ class MarketDataRepository:
 
             use_group_watermark = fetcher.supports_parallel and hasattr(fetcher, "symbols")
             per_symbol_watermark = use_group_watermark and getattr(fetcher, "per_symbol_watermark", False)
+            first_run_days = (
+                fetcher.first_run_lookback_days
+                if fetcher.first_run_lookback_days is not None
+                else lookback_days
+            )
 
             # Determine start date
             if per_symbol_watermark:
@@ -287,19 +292,20 @@ class MarketDataRepository:
                 # FetchResult, matching today's stock-summary behavior which
                 # always shows the full lookback window regardless of actual
                 # per-symbol watermarks used.
-                from_date = today - timedelta(days=lookback_days)
+                from_date = today - timedelta(days=first_run_days)
             elif use_group_watermark:
                 from_date = self._resolve_group_from_date(
                     ch, effective_source, [s for s, _ in fetcher.symbols],
                     lookback_days=lookback_days, overlap_days=fetcher.overlap_days,
                     full=full, today=today,
+                    first_run_lookback_days=fetcher.first_run_lookback_days,
                 )
             elif full:
                 from_date = today - timedelta(days=lookback_days)
             else:
                 wm = ch.get_watermark(effective_source, fetcher.symbol_key, dataset=fetcher.dataset)
                 if wm is None:
-                    from_date = today - timedelta(days=lookback_days)
+                    from_date = today - timedelta(days=first_run_days)
                 else:
                     from_date = wm - timedelta(days=fetcher.overlap_days)
 
@@ -352,27 +358,34 @@ class MarketDataRepository:
     def _resolve_group_from_date(
         self, ch, source: str, symbols: list[str], *,
         lookback_days: int, overlap_days: int, full: bool, today: "date",
+        first_run_lookback_days: int | None = None,
     ) -> "date":
         """
         Worst-case (earliest) per-symbol watermark minus overlap, across a
         group of symbols sharing one category (e.g. all ETF or stock
         tickers). Port of cli.py's _resolve_from_date, generalized for the
         registry-based orchestrator.
+
+        first_run_lookback_days overrides lookback_days only for the "no
+        watermark yet" case (not `full`, which always honors the caller's
+        explicit lookback_days).
         """
         from datetime import timedelta
 
         if full:
             return today - timedelta(days=lookback_days)
 
+        effective_lookback = first_run_lookback_days if first_run_lookback_days is not None else lookback_days
+
         earliest: "date | None" = None
         for sym in symbols:
             wm = ch.get_watermark(source, sym)
             if wm is None:
-                return today - timedelta(days=lookback_days)
+                return today - timedelta(days=effective_lookback)
             candidate = wm - timedelta(days=overlap_days)
             if earliest is None or candidate < earliest:
                 earliest = candidate
-        return earliest or (today - timedelta(days=lookback_days))
+        return earliest or (today - timedelta(days=effective_lookback))
 
     def _fetch_parallel(self, fetcher, from_date, to_date, workers: int, *,
                          progress_cb=None, ch=None, per_symbol_watermark=False,

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -233,6 +233,10 @@ class MarketDataRepository:
         dry_run: bool = False,
         full: bool = False,
         lookback_days: int = 3650,
+        workers: int = 1,
+        source: str | None = None,
+        progress_cb=None,
+        ch=None,
     ) -> "FetchResult":
         """
         Execute the full fetch → validate → insert → watermark cycle.
@@ -243,6 +247,15 @@ class MarketDataRepository:
         dry_run       : fetch but do not write to ClickHouse
         full          : ignore watermarks; re-fetch full lookback window
         lookback_days : history depth on first import or full re-import
+        workers       : if fetcher.supports_parallel and workers > 1, fetch
+                        each symbol concurrently via a thread pool
+        source        : override the fetcher's default source, if
+                        fetcher.supports_source_override is True
+        progress_cb   : called with a symbol string after each symbol
+                        completes (parallel path only)
+        ch            : an already-open ClickHouseImporter to reuse (e.g. so
+                        a caller looping over many fetchers connects once).
+                        If None, a connection is opened and closed here.
 
         Returns a FetchResult with row count and date range.
         """
@@ -250,21 +263,61 @@ class MarketDataRepository:
         from src.importer.clickhouse import ClickHouseImporter
 
         today = _date_today()
-        ch = ClickHouseImporter(**self._ch_kwargs())
+        owns_ch = ch is None
+        if owns_ch:
+            ch = ClickHouseImporter(**self._ch_kwargs())
         try:
-            ch.ensure_schema()
+            if owns_ch:
+                ch.ensure_schema()
+
+            # Watermarks must be keyed on the source that actually produces
+            # the rows this run, not the fetcher's static default — a
+            # --data-source override must not fragment watermark history
+            # from the default-source run (or make tomorrow's default-source
+            # run think it's already caught up when it isn't).
+            effective_source = (source or fetcher.source_name) if fetcher.supports_source_override else fetcher.source_name
+
+            use_group_watermark = fetcher.supports_parallel and hasattr(fetcher, "symbols")
+            per_symbol_watermark = use_group_watermark and getattr(fetcher, "per_symbol_watermark", False)
 
             # Determine start date
-            if full:
+            if per_symbol_watermark:
+                # Each symbol resolves its own watermark inside _fetch_parallel
+                # (see there) — this from_date is only a display fallback for
+                # FetchResult, matching today's stock-summary behavior which
+                # always shows the full lookback window regardless of actual
+                # per-symbol watermarks used.
+                from_date = today - timedelta(days=lookback_days)
+            elif use_group_watermark:
+                from_date = self._resolve_group_from_date(
+                    ch, effective_source, [s for s, _ in fetcher.symbols],
+                    lookback_days=lookback_days, overlap_days=fetcher.overlap_days,
+                    full=full, today=today,
+                )
+            elif full:
                 from_date = today - timedelta(days=lookback_days)
             else:
-                wm = ch.get_watermark(fetcher.source_name, fetcher.symbol_key)
+                wm = ch.get_watermark(effective_source, fetcher.symbol_key)
                 if wm is None:
                     from_date = today - timedelta(days=lookback_days)
                 else:
                     from_date = wm - timedelta(days=fetcher.overlap_days)
 
-            rows = fetcher.fetch_with_retry(from_date, today)
+            fetch_kwargs = {"source": source} if fetcher.supports_source_override else {}
+
+            if use_group_watermark and workers > 1:
+                rows = self._fetch_parallel(
+                    fetcher, from_date, today, workers,
+                    progress_cb=progress_cb,
+                    ch=ch if per_symbol_watermark else None,
+                    per_symbol_watermark=per_symbol_watermark,
+                    lookback_days=lookback_days, full=full,
+                    effective_source=effective_source,
+                    **fetch_kwargs,
+                )
+            else:
+                rows = fetcher.fetch_with_retry(from_date, today, **fetch_kwargs)
+
             if not rows:
                 # fetch failed after retries — log to import_failures and skip
                 self._record_failure(fetcher, from_date, today, "FetchError", "fetch returned empty after retries")
@@ -279,7 +332,11 @@ class MarketDataRepository:
 
             n = fetcher.insert(rows, ch)
             max_dt = fetcher.max_date(rows)
-            ch.set_watermark(fetcher.source_name, fetcher.symbol_key, max_dt)
+
+            if use_group_watermark:
+                fetcher.write_group_watermarks(ch, rows, dry_run, source=source)
+            else:
+                ch.set_watermark(effective_source, fetcher.symbol_key, max_dt)
 
             result = FetchResult(fetcher=fetcher, n=n, from_date=from_date, to_date=max_dt)
 
@@ -289,7 +346,87 @@ class MarketDataRepository:
             return result
 
         finally:
-            ch.close()
+            if owns_ch:
+                ch.close()
+
+    def _resolve_group_from_date(
+        self, ch, source: str, symbols: list[str], *,
+        lookback_days: int, overlap_days: int, full: bool, today: "date",
+    ) -> "date":
+        """
+        Worst-case (earliest) per-symbol watermark minus overlap, across a
+        group of symbols sharing one category (e.g. all ETF or stock
+        tickers). Port of cli.py's _resolve_from_date, generalized for the
+        registry-based orchestrator.
+        """
+        from datetime import timedelta
+
+        if full:
+            return today - timedelta(days=lookback_days)
+
+        earliest: "date | None" = None
+        for sym in symbols:
+            wm = ch.get_watermark(source, sym)
+            if wm is None:
+                return today - timedelta(days=lookback_days)
+            candidate = wm - timedelta(days=overlap_days)
+            if earliest is None or candidate < earliest:
+                earliest = candidate
+        return earliest or (today - timedelta(days=lookback_days))
+
+    def _fetch_parallel(self, fetcher, from_date, to_date, workers: int, *,
+                         progress_cb=None, ch=None, per_symbol_watermark=False,
+                         lookback_days: int = 3650, full: bool = False,
+                         effective_source: str | None = None,
+                         **fetch_kwargs) -> list[dict]:
+        """
+        Fetch fetcher.symbols concurrently, one thread per symbol, via
+        fetcher.for_symbol(). Generalizes parallel_importer.py's
+        ThreadPoolExecutor loop to any supports_parallel Fetcher.
+
+        When per_symbol_watermark is set (e.g. StocksFetcher), each symbol
+        resolves its OWN watermark here — a direct port of
+        parallel_importer.import_single_stock's per-thread
+        `ch.get_watermark(data_source, symbol, dataset="prices")` call — so
+        one caught-up symbol's from_date is never dragged down to a
+        full-lookback re-fetch just because another symbol in the same
+        category has no watermark yet. `from_date` is otherwise used
+        unchanged (the shared, pre-resolved group watermark case, e.g. etfs).
+
+        Per-symbol failures are already swallowed by fetch_with_retry (which
+        returns [] after exhausting retries) — one bad symbol contributes no
+        rows but never fails the batch.
+        """
+        from datetime import timedelta
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        rows: list[dict] = []
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {}
+            for sym, ticker in fetcher.symbols:
+                sym_from = from_date
+                if per_symbol_watermark and ch is not None:
+                    if full:
+                        sym_from = to_date - timedelta(days=lookback_days)
+                    else:
+                        wm = ch.get_watermark(effective_source, sym, dataset="prices")
+                        sym_from = (
+                            (to_date - timedelta(days=lookback_days)) if wm is None
+                            else (wm - timedelta(days=fetcher.overlap_days))
+                        )
+                futures[executor.submit(
+                    fetcher.for_symbol(sym, ticker).fetch_with_retry,
+                    sym_from, to_date, **fetch_kwargs,
+                )] = sym
+            for future in as_completed(futures):
+                sym = futures[future]
+                try:
+                    rows.extend(future.result())
+                except Exception as exc:
+                    log.error("%s: parallel fetch failed for %s: %s", fetcher.source_name, sym, exc)
+                if progress_cb:
+                    progress_cb(sym)
+        return rows
 
     def _publish_imported(self, fetcher, result: "FetchResult") -> None:
         """Fire DataImportedEvent on the global EventBus after a successful insert."""

--- a/src/db/repository.py
+++ b/src/db/repository.py
@@ -297,7 +297,7 @@ class MarketDataRepository:
             elif full:
                 from_date = today - timedelta(days=lookback_days)
             else:
-                wm = ch.get_watermark(effective_source, fetcher.symbol_key)
+                wm = ch.get_watermark(effective_source, fetcher.symbol_key, dataset=fetcher.dataset)
                 if wm is None:
                     from_date = today - timedelta(days=lookback_days)
                 else:
@@ -336,7 +336,7 @@ class MarketDataRepository:
             if use_group_watermark:
                 fetcher.write_group_watermarks(ch, rows, dry_run, source=source)
             else:
-                ch.set_watermark(effective_source, fetcher.symbol_key, max_dt)
+                ch.set_watermark(effective_source, fetcher.symbol_key, max_dt, dataset=fetcher.dataset)
 
             result = FetchResult(fetcher=fetcher, n=n, from_date=from_date, to_date=max_dt)
 

--- a/src/importer/base_fetcher.py
+++ b/src/importer/base_fetcher.py
@@ -86,6 +86,9 @@ class Fetcher(ABC):
                                 one worst-case watermark shared across the
                                 whole symbol group (e.g. etfs today). Only
                                 meaningful when supports_parallel is True.
+    dataset                  : watermark dataset bucket (default "prices") —
+                                override when a source's watermark isn't a
+                                price series (e.g. amfi_flows uses "flows").
     """
 
     source_name:  str
@@ -95,6 +98,7 @@ class Fetcher(ABC):
     supports_parallel:        bool = False
     supports_source_override: bool = False
     per_symbol_watermark:     bool = False
+    dataset:                  str = "prices"
 
     @abstractmethod
     def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:

--- a/src/importer/base_fetcher.py
+++ b/src/importer/base_fetcher.py
@@ -191,5 +191,16 @@ class Fetcher(ABC):
                 return latest if isinstance(latest, date) else latest.date()
         raise ValueError(f"{self.__class__.__name__}: cannot determine max date from rows")
 
+    def count_insertable(self, rows: list[dict[str, Any]]) -> int:
+        """
+        Row count to report for a dry-run (or any pre-insert preview) —
+        must match what insert() would actually report on a real run.
+
+        Default: one homogeneous row dataset, so len(rows) is correct.
+        Override when fetch() emits more than one row dataset in a single
+        batch (see StocksFetcher, whose insert() only counts price rows).
+        """
+        return len(rows)
+
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(source={self.source_name!r}, symbol={self.symbol_key!r})"

--- a/src/importer/base_fetcher.py
+++ b/src/importer/base_fetcher.py
@@ -78,15 +78,26 @@ class Fetcher(ABC):
     symbol_key    : watermark symbol      (e.g. "MARKET", or per-symbol override)
     description   : human-readable label  (shown in CLI progress output)
     overlap_days  : re-fetch window to catch late corrections  (default 3)
+    supports_parallel        : opt-in — orchestrator may run fetch() per symbol
+                                across a thread pool (see for_symbol())
+    supports_source_override : opt-in — fetch() honors the `source` kwarg
+    per_symbol_watermark     : opt-in — each symbol resolves its OWN watermark
+                                independently (e.g. stocks today), rather than
+                                one worst-case watermark shared across the
+                                whole symbol group (e.g. etfs today). Only
+                                meaningful when supports_parallel is True.
     """
 
     source_name:  str
     symbol_key:   str
     description:  str = ""
     overlap_days: int = 3
+    supports_parallel:        bool = False
+    supports_source_override: bool = False
+    per_symbol_watermark:     bool = False
 
     @abstractmethod
-    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
         """
         Pull rows from the external source.
 
@@ -94,11 +105,13 @@ class Fetcher(ABC):
         ----------
         from_date : inclusive start date
         to_date   : inclusive end date
+        source    : override the fetcher's default source, if
+                    supports_source_override is True. Ignored otherwise.
 
         Returns empty list if source is unavailable — never raises.
         """
 
-    def fetch_with_retry(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+    def fetch_with_retry(self, from_date: date, to_date: date, **kwargs) -> list[dict[str, Any]]:
         """
         Call fetch() with exponential-backoff retry.
 
@@ -107,13 +120,49 @@ class Fetcher(ABC):
         instead of crashing the batch.
         """
         try:
-            return _with_retry(self.fetch, from_date, to_date)
+            return _with_retry(self.fetch, from_date, to_date, **kwargs)
         except Exception as exc:
             log.error(
                 "%s fetch failed after retries (%s→%s): %s",
                 self.__class__.__name__, from_date, to_date, exc,
             )
             return []
+
+    def for_symbol(self, sym: str, ticker: str) -> "Fetcher":
+        """
+        Return a fetcher instance scoped to a single (sym, ticker) pair, for
+        parallel execution by the orchestrator (one thread per symbol).
+
+        Default assumes __init__(self, category, symbols) — override if a
+        supports_parallel subclass has a different constructor shape.
+        """
+        return type(self)(self.category, [(sym, ticker)])
+
+    def write_group_watermarks(
+        self, ch, rows: list[dict[str, Any]], dry_run: bool, *, source: str | None = None,
+    ) -> None:
+        """
+        Per-symbol watermark write for supports_parallel fetchers, used
+        instead of the single symbol_key watermark when the orchestrator
+        resolved a per-symbol (group) watermark for this fetch.
+
+        `source` is the runtime source override actually used for this run
+        (if supports_source_override) — the watermark must be keyed on the
+        source that really produced the rows, not the fetcher's static
+        default, or a source-override run silently fragments watermark
+        history from the default-source run.
+
+        Default: one dataset of rows, one watermark per symbol at that
+        symbol's max_date(). Override when fetch() emits more than one row
+        dataset in a single batch (see StocksFetcher).
+        """
+        if dry_run or not rows:
+            return
+        effective_source = source or self.source_name
+        symbols_seen = {r["symbol"] for r in rows}
+        for sym in symbols_seen:
+            sym_rows = [r for r in rows if r["symbol"] == sym]
+            ch.set_watermark(effective_source, sym, self.max_date(sym_rows))
 
     @abstractmethod
     def insert(self, rows: list[dict[str, Any]], ch) -> int:

--- a/src/importer/base_fetcher.py
+++ b/src/importer/base_fetcher.py
@@ -89,6 +89,10 @@ class Fetcher(ABC):
     dataset                  : watermark dataset bucket (default "prices") —
                                 override when a source's watermark isn't a
                                 price series (e.g. amfi_flows uses "flows").
+    first_run_lookback_days  : optional override of the caller's lookback_days,
+                                used only when no watermark exists yet. None
+                                (default) means "use whatever lookback_days
+                                the caller passed" — zero behavior change.
     """
 
     source_name:  str
@@ -99,6 +103,7 @@ class Fetcher(ABC):
     supports_source_override: bool = False
     per_symbol_watermark:     bool = False
     dataset:                  str = "prices"
+    first_run_lookback_days:  int | None = None
 
     @abstractmethod
     def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:

--- a/src/importer/cli.py
+++ b/src/importer/cli.py
@@ -136,7 +136,6 @@ def run_import(
         ALL_CATEGORIES,
     )
     from src.importer.clickhouse import ClickHouseImporter
-    from src.importer.fetchers.mfapi_fetcher import fetch_all_nav
     from config.settings import settings
 
     selected_source = normalize_data_source(data_source)
@@ -186,8 +185,9 @@ def run_import(
     # ── Summary table ──────────────────────────────────────────────────────
     summary_rows: list[tuple[str, str, int, str, str]] = []
 
-    # ── Unified registry-driven import: stocks / us_stocks / etfs / commodities /
-    # indices / nse_indices / nse_eod / indian_macro ───────────────────────────────────────
+    # ── Unified registry-driven import ── every category except mf_holdings
+    # (idempotency guard lives here in cli.py) and skills_tools.py's
+    # interactive single-symbol path is routed through get_registry().
     from src.importer.fetchers.adapters import get_registry
     from src.db.repository import MarketDataRepository
 
@@ -195,7 +195,8 @@ def run_import(
     registry_categories = [
         c for c in categories
         if c in {"stocks", "us_stocks", "etfs", "commodities", "indices",
-                 "nse_indices", "nse_eod", "indian_macro"}
+                 "nse_indices", "nse_eod", "indian_macro", "fx_rates",
+                 "cot", "cb_reserves", "etf_aum", "mf"}
     ]
     for category in registry_categories:
         fetcher = get_registry().get(category)
@@ -272,128 +273,6 @@ def run_import(
             from datetime import datetime
             ts = snapshot_rows[0]["snapshot_at"]
             summary_rows.append(("inav", "nse", inserted, str(ts)[:10], str(ts)[:10]))
-    # ── MF NAV ────────────────────────────────────────────────────────────
-    if "mf" in categories:
-        console.print(f"\n[bold cyan]▶ MF NAV[/bold cyan] ({len(MF_SCHEME_CODES)} schemes)")
-
-        mf_from = _resolve_from_date(
-            ch, "mfapi", list(MF_SCHEME_CODES),
-            lookback_days=lookback_days, full_reimport=full_reimport,
-            dry_run=dry_run, today=today,
-        )
-
-        console.print(f"  [dim]Fetching {mf_from} → {today} (MFAPI.in, polite delays)[/dim]")
-        nav_rows = fetch_all_nav(MF_SCHEME_CODES, mf_from, today)
-        inserted = ch.insert_nav(nav_rows, dry_run=dry_run)
-        console.print(f"  [green]✓[/green] {inserted} rows {'(dry-run)' if dry_run else 'inserted'}")
-
-        _update_watermarks(ch, nav_rows, "mfapi", date_field="nav_date", dry_run=dry_run)
-
-        summary_rows.append(("mf", "mfapi", inserted, mf_from.isoformat(), today.isoformat()))
-
-    # ── CFTC COT (hedge fund positioning) ────────────────────────────────────
-    if "cot" in categories:
-        from src.importer.fetchers.cot_fetcher import fetch_cot_gold
-
-        console.print("\n[bold cyan]▶ CFTC COT — Gold (Managed Money)[/bold cyan]")
-        console.print("  [dim]CFTC Disaggregated report, commodity code 088 (released Fridays)[/dim]")
-
-        cot_wm = ch.get_watermark("cot", "GOLD") if (not dry_run and not full_reimport) else None
-        cot_from = (cot_wm - timedelta(days=21)) if cot_wm else None   # 3-week overlap
-        if full_reimport:
-            console.print("  [dim]Full reimport — ignoring watermark, fetching full history[/dim]")
-        cot_rows = fetch_cot_gold(from_date=cot_from, limit=2000 if not cot_wm else 500)
-        if not cot_rows:
-            console.print("  [yellow]⚠ No COT data returned — CFTC endpoint may be unavailable.[/yellow]")
-        else:
-            inserted = ch.insert_cot_gold(cot_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} weekly COT rows {'(dry-run)' if dry_run else 'stored'}")
-            if not dry_run:
-                ch.set_watermark("cot", "GOLD", max(r["report_date"] for r in cot_rows))
-            latest = sorted(cot_rows, key=lambda r: r["report_date"])[-1]
-            console.print(
-                f"  Latest ({latest['report_date']}): "
-                f"MM Net {latest['mm_net']:+,d}  |  "
-                f"OI {latest['open_interest']:,d}  |  "
-                f"MM pct OI {latest['mm_net'] / max(latest['open_interest'], 1) * 100:+.1f}%"
-            )
-            summary_rows.append(("cot", "cftc", inserted,
-                                  str(min(r["report_date"] for r in cot_rows)),
-                                  str(latest["report_date"])))
-
-    # ── IMF Central Bank Gold Reserves ────────────────────────────────────────
-    if "cb_reserves" in categories:
-        from src.importer.fetchers.imf_reserves_fetcher import fetch_cb_reserves
-
-        console.print("\n[bold cyan]▶ IMF IFS — Central Bank Gold Reserves[/bold cyan]")
-        console.print("  [dim]9 countries · RAFAGOLD series · monthly · ~6-week publication lag[/dim]")
-
-        cb_wm = ch.get_watermark("cb_reserves", "ALL") if not dry_run else None
-        cb_from_year = cb_wm.year if cb_wm else 2010
-        cb_rows = fetch_cb_reserves(from_year=cb_from_year)
-        if not cb_rows:
-            console.print("  [yellow]⚠ No CB reserves data returned — endpoint may be unavailable.[/yellow]")
-        else:
-            inserted = ch.insert_cb_reserves(cb_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} reserve rows {'(dry-run)' if dry_run else 'stored'}")
-            if not dry_run:
-                ch.set_watermark("cb_reserves", "ALL", max(r["ref_period"] for r in cb_rows))
-            summary_rows.append(("cb_reserves", "world_bank", inserted,
-                                  str(cb_from_year), str(max(r["ref_period"] for r in cb_rows))))
-
-    # ── ETF AUM Snapshots (retail flow proxy) ─────────────────────────────────
-    if "etf_aum" in categories:
-        from src.importer.fetchers.etf_aum_fetcher import fetch_etf_aum
-
-        console.print("\n[bold cyan]▶ Gold ETF AUM Snapshots[/bold cyan] (GLD · IAU · SGOL · PHYS)")
-        console.print("  [dim]Daily AUM + implied gold tonnes via yfinance[/dim]")
-
-        aum_rows = fetch_etf_aum()
-        if not aum_rows:
-            console.print("  [yellow]⚠ No ETF AUM data returned.[/yellow]")
-        else:
-            inserted = ch.insert_etf_aum(aum_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} ETF AUM snapshot(s) {'(dry-run)' if dry_run else 'stored'}")
-            for r in aum_rows:
-                console.print(
-                    f"  {r['symbol']:6s}  AUM ${r['aum_usd']/1e9:.2f}B  "
-                    f"price ${r['price']:.2f}  ~{r['implied_tonnes']:.0f}t"
-                )
-            summary_rows.append(("etf_aum", "yfinance", inserted,
-                                  str(today), str(today)))
-
-    # ── FX Rates (USD pairs) ───────────────────────────────────────────────────
-    if "fx_rates" in categories:
-        from src.importer.fetchers.fx_rates_fetcher import fetch_fx_rates, FX_PAIRS
-
-        console.print("\n[bold cyan]▶ FX Rates — USD Pairs[/bold cyan] (USDINR · USDCNY · USDAED · USDSAR · USDKWD)")
-        console.print("  [dim]Daily OHLC via Yahoo Finance — delta-synced per pair[/dim]")
-
-        fx_from = _resolve_from_date(
-            ch, "yfinance_fx", [sym for sym, _ in FX_PAIRS],
-            lookback_days=lookback_days, full_reimport=full_reimport,
-            dry_run=dry_run, today=today,
-        )
-
-        console.print(f"  [dim]Fetching {fx_from} → {today}[/dim]")
-        fx_rows = fetch_fx_rates(from_date=fx_from, to_date=today)
-        if not fx_rows:
-            console.print("  [yellow]⚠ No FX data returned — Yahoo Finance may be unavailable.[/yellow]")
-        else:
-            inserted = ch.insert_fx_rates(fx_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} FX rate rows {'(dry-run)' if dry_run else 'stored'}")
-            _update_watermarks(ch, fx_rows, "yfinance_fx", dry_run=dry_run)
-            # Print latest close per pair
-            latest_by_sym: dict[str, dict] = {}
-            for r in fx_rows:
-                if r["symbol"] not in latest_by_sym or r["trade_date"] > latest_by_sym[r["symbol"]]["trade_date"]:
-                    latest_by_sym[r["symbol"]] = r
-            for sym in [s for s, _ in FX_PAIRS if s in latest_by_sym]:
-                r = latest_by_sym[sym]
-                console.print(f"  {sym:8s}  {r['trade_date']}  close={r['close']:.4f}")
-            summary_rows.append(("fx_rates", "yfinance", inserted,
-                                  str(fx_from), str(today)))
-
     if "mf_holdings" in categories:
         from src.importer.fetchers.adapters import MfHoldingsFetcher
 

--- a/src/importer/cli.py
+++ b/src/importer/cli.py
@@ -131,17 +131,14 @@ def run_import(
     data_source        : stock/ETF source; shoonya, nse, or yfinance
     """
     from src.importer.registry import (
-        get_symbols_for_categories,
         MF_SCHEME_CODES,
         MF_HOLDINGS_WATCHLIST,
         ALL_CATEGORIES,
     )
     from src.importer.clickhouse import ClickHouseImporter
-    from src.importer.fetchers.yfinance_fetcher import fetch_ohlcv
     from src.importer.fetchers.mfapi_fetcher import fetch_all_nav
     from config.settings import settings
 
-    shoonya_active = bool(settings.shoonya_user_id and settings.shoonya_api_secret)
     selected_source = normalize_data_source(data_source)
     if data_source and not selected_source:
         raise ValueError("data_source must be one of: shoonya, nse, yfinance")
@@ -189,71 +186,32 @@ def run_import(
     # ── Summary table ──────────────────────────────────────────────────────
     summary_rows: list[tuple[str, str, int, str, str]] = []
 
-    # ── yfinance categories ────────────────────────────────────────────────
-    cat_symbols = get_symbols_for_categories(categories)
-    for category, symbol_list in cat_symbols.items():
-        console.print(f"\n[bold cyan]▶ {category.upper()}[/bold cyan] ({len(symbol_list)} symbols)")
+    # ── Unified registry-driven import: stocks / us_stocks / etfs / commodities / indices / nse_indices ──
+    from src.importer.fetchers.adapters import get_registry
+    from src.db.repository import MarketDataRepository
 
-        if category in ("stocks", "us_stocks"):
-            console.print(f"  [dim]Running parallel import (limit: 5 workers)...[/dim]")
-            from src.importer.parallel_importer import run_parallel_stock_import
-            
-            clickhouse_config = {
-                "host": clickhouse_host,
-                "port": clickhouse_port,
-                "database": clickhouse_database,
-                "username": clickhouse_user,
-                "password": clickhouse_password,
-            }
-            
-            res = run_parallel_stock_import(
-                symbols=symbol_list,
-                category=category,
-                lookback_days=lookback_days,
-                full_reimport=full_reimport,
-                workers=5,
-                clickhouse_config=clickhouse_config,
-                dry_run=dry_run,
-                data_source=(selected_source or "shoonya") if category == "stocks" else "yfinance",
-            )
-            
-            inserted = res["prices"]
-            console.print(
-                f"  [green]✓[/green] Completed parallel stock import. "
-                f"Prices: {res['prices']} rows, Earnings: {res['earnings']} rows, "
-                f"Insider: {res['insider']} rows, Valuations: {res['valuation']} rows."
-            )
-            
-            summary_rows.append((
-                category,
-                f"{(selected_source or 'shoonya') if category == 'stocks' else 'yfinance'}_parallel",
-                inserted,
-                (today - timedelta(days=lookback_days)).isoformat(),
-                today.isoformat(),
-            ))
+    repo = MarketDataRepository(pool=None)
+    price_categories = [
+        c for c in categories
+        if c in {"stocks", "us_stocks", "etfs", "commodities", "indices", "nse_indices"}
+    ]
+    for category in price_categories:
+        fetcher = get_registry().get(category)
+        if fetcher is None:
+            console.print(f"[yellow]⚠ Unknown category: {category}, skipping[/yellow]")
             continue
 
-        # ── NSE-only indices via nselib ────────────────────────────────────
-        if category == "nse_indices":
-            from src.importer.fetchers.nse_index_fetcher import fetch_nse_indices
+        symbol_list = getattr(fetcher, "symbols", [])
+        console.print(
+            f"\n[bold cyan]▶ {category.upper()}[/bold cyan]"
+            + (f" ({len(symbol_list)} symbols)" if symbol_list else "")
+        )
 
-            from_date = _resolve_from_date(
-                ch, "nselib_index", "NSE_INDICES",
-                lookback_days=lookback_days, full_reimport=full_reimport,
-                dry_run=dry_run, today=today,
-            )
-
-            console.print(f"  [dim]Fetching via nselib {from_date} → {today}…[/dim]")
-            rows = fetch_nse_indices(symbol_list, from_date, today)
-            inserted = ch.insert_prices(rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} rows {'(dry-run)' if dry_run else 'inserted'}")
-
-            _update_watermarks(ch, rows, "nselib_index", dry_run=dry_run)
-
-            summary_rows.append((
-                category, "nselib", inserted, from_date.isoformat(), today.isoformat(),
-            ))
-            continue
+        workers = 5 if fetcher.supports_parallel and category in ("stocks", "us_stocks") else 1
+        effective_source = (
+            selected_source if fetcher.supports_source_override and selected_source
+            else fetcher.source_name
+        )
 
         with Progress(
             SpinnerColumn(),
@@ -263,44 +221,37 @@ def run_import(
             console=console,
             transient=True,
         ) as progress:
-            task = progress.add_task(f"Fetching {category}…", total=len(symbol_list))
+            task = progress.add_task(f"Fetching {category}…", total=len(symbol_list) or 1)
 
-            for nse_sym, _yahoo in symbol_list:
-                progress.update(task, advance=1, description=f"[dim]{nse_sym}[/dim]")
+            if workers == 1:
+                # Cosmetic pre-tick — matches the non-parallel categories' existing display.
+                for nse_sym, _yahoo in symbol_list:
+                    progress.update(task, advance=1, description=f"[dim]{nse_sym}[/dim]")
 
-            # Determine date range (worst-case watermark across all symbols)
-            watermark_source = (selected_source or "shoonya") if category in ("stocks", "etfs") else "yfinance"
-            from_date = _resolve_from_date(
-                ch, watermark_source, [sym for sym, _ in symbol_list],
-                lookback_days=lookback_days, full_reimport=full_reimport,
-                dry_run=dry_run, today=today,
+            def _advance(sym: str) -> None:
+                progress.update(task, advance=1, description=f"[dim]{sym}[/dim]")
+
+            result = repo.run_fetcher(
+                fetcher,
+                dry_run=dry_run,
+                full=full_reimport,
+                lookback_days=lookback_days,
+                workers=workers,
+                source=selected_source if fetcher.supports_source_override else None,
+                progress_cb=_advance if workers > 1 else None,
+                ch=ch,
             )
 
-            progress.update(task, description=f"Downloading {category} {from_date}→{today}…")
-            if category in ("stocks", "etfs"):
-                from src.importer.fetchers.adapters import NSElibFetcher, ShoonyaFetcher
-                if selected_source == "nse":
-                    rows = NSElibFetcher(category, symbol_list).fetch(from_date, today)
-                elif selected_source == "yfinance":
-                    rows = fetch_ohlcv(symbol_list, category, from_date, today)
-                else:
-                    rows = ShoonyaFetcher(category, symbol_list).fetch(from_date, today)
-            else:
-                rows = fetch_ohlcv(symbol_list, category, from_date, today)
+        if result.skipped:
+            console.print("  [yellow]⚠ Fetch failed after retries — logged to import_failures, skipping.[/yellow]")
+            continue
 
-        inserted = ch.insert_prices(rows, dry_run=dry_run)
-        console.print(f"  [green]✓[/green] {inserted} rows {'(dry-run)' if dry_run else 'inserted'}")
-
-        # Update watermarks
-        _update_watermarks(ch, rows, watermark_source, dry_run=dry_run)
-
+        console.print(f"  [green]✓[/green] {result.n} rows {'(dry-run)' if dry_run else 'inserted'}")
         summary_rows.append((
-            category,
-            selected_source or ("shoonya" if category == "etfs" and shoonya_active else "yfinance"),
-            inserted,
-            from_date.isoformat(),
-            today.isoformat(),
+            category, effective_source, result.n,
+            result.from_date.isoformat(), result.to_date.isoformat(),
         ))
+
     # ── NSE EOD OHLCV (available immediately after 3:30 PM IST) ─────────────
     if "nse_eod" in categories:
         from src.importer.registry import ETFS, STOCKS

--- a/src/importer/cli.py
+++ b/src/importer/cli.py
@@ -21,7 +21,7 @@ ReplacingMergeTree deduplicates by (symbol, date).
 from __future__ import annotations
 
 import logging
-from datetime import date, timedelta
+from datetime import date
 from typing import Optional
 
 from rich.console import Console
@@ -32,68 +32,6 @@ from rich import box
 from src.importer.source_preference import normalize_data_source
 
 logger = logging.getLogger(__name__)
-
-# Days of overlap when doing a delta sync (to catch weekend / late corrections)
-_OVERLAP_DAYS = 3
-
-
-# ──────────────────────────────────────────────────────────────────────────────
-# Helpers — DRY the repeated watermark/fetch/insert cycle
-# ──────────────────────────────────────────────────────────────────────────────
-
-def _resolve_from_date(
-    ch,
-    source: str,
-    symbols: list[str] | str,
-    *,
-    lookback_days: int,
-    overlap_days: int = _OVERLAP_DAYS,
-    full_reimport: bool = False,
-    dry_run: bool = False,
-    today: date | None = None,
-) -> date:
-    """
-    Compute the inclusive start date for a delta-sync fetch.
-
-    For a single symbol pass it as a string; for a group pass a list.
-    Returns the earliest (worst-case) watermark minus overlap, or falls back
-    to (today − lookback_days) on first run.
-    """
-    today = today or date.today()
-    if full_reimport:
-        return today - timedelta(days=lookback_days)
-
-    sym_list = [symbols] if isinstance(symbols, str) else symbols
-    earliest: date | None = None
-    for sym in sym_list:
-        wm = ch.get_watermark(source, sym) if not dry_run else None
-        if wm is None:
-            return today - timedelta(days=lookback_days)
-        candidate = wm - timedelta(days=overlap_days)
-        if earliest is None or candidate < earliest:
-            earliest = candidate
-    return earliest or (today - timedelta(days=lookback_days))
-
-
-def _update_watermarks(
-    ch,
-    rows: list[dict],
-    source: str,
-    *,
-    date_field: str = "trade_date",
-    dry_run: bool = False,
-) -> None:
-    """
-    Set per-symbol watermarks from the fetched rows.
-    Noop on dry_run or empty rows.
-    """
-    if dry_run or not rows:
-        return
-    symbols_seen = {r["symbol"] for r in rows}
-    for sym in symbols_seen:
-        sym_dates = [r[date_field] for r in rows if r["symbol"] == sym]
-        if sym_dates:
-            ch.set_watermark(source, sym, max(sym_dates))
 
 
 def run_import(
@@ -196,7 +134,8 @@ def run_import(
         c for c in categories
         if c in {"stocks", "us_stocks", "etfs", "commodities", "indices",
                  "nse_indices", "nse_eod", "indian_macro", "fx_rates",
-                 "cot", "cb_reserves", "etf_aum", "mf"}
+                 "cot", "cb_reserves", "etf_aum", "mf", "fii_dii",
+                 "world_bank", "imf_weo", "amfi_flows"}
     ]
     for category in registry_categories:
         fetcher = get_registry().get(category)
@@ -366,159 +305,6 @@ def run_import(
                 )
             summary_rows.append(("valuation", "yfinance", inserted, str(today), str(today)))
 
-    # ── World Bank Macro Indicators ───────────────────────────────────────────
-    if "world_bank" in categories:
-        from src.importer.fetchers.worldbank_macro_fetcher import fetch_worldbank_macro
-
-        console.print("\n[bold cyan]▶ World Bank WDI — Macro Indicators[/bold cyan]")
-        console.print("  [dim]India + G4 peers · GDP growth, CPI, current account, "
-                      "govt debt, savings, FDI, unemployment, exports · annual · no auth[/dim]")
-
-        wb_wm = ch.get_watermark("world_bank", "MACRO_GROUP") if (not dry_run and not full_reimport) else None
-        wb_from_year = (wb_wm.year - 1) if wb_wm else 2000   # overlap 1 year for revisions
-        wb_rows = fetch_worldbank_macro(from_year=wb_from_year, to_year=today.year)
-
-        if not wb_rows:
-            console.print("  [yellow]⚠ No World Bank data returned — API may be unavailable.[/yellow]")
-        else:
-            inserted = ch.insert_macro_indicators(wb_rows) if not dry_run else len(wb_rows)
-            console.print(f"  [green]✓[/green] {inserted} macro indicator rows {'(dry-run)' if dry_run else 'stored'}")
-            if not dry_run:
-                max_year = max(int(r["ref_year"]) for r in wb_rows)
-                ch.set_watermark("world_bank", "MACRO_GROUP", date(max_year, 12, 31))
-            # Show latest India GDP growth as a quick sanity check
-            india_gdp = [r for r in wb_rows if r["country_code"] == "IN"
-                         and r["indicator_code"] == "NY.GDP.MKTP.KD.ZG"]
-            if india_gdp:
-                latest_gdp = sorted(india_gdp, key=lambda r: r["ref_year"])[-1]
-                console.print(
-                    f"  India GDP growth ({latest_gdp['ref_year']}): "
-                    f"{latest_gdp['value']:+.2f}%"
-                )
-            summary_rows.append(("world_bank", "world_bank", inserted,
-                                  str(wb_from_year), str(today.year)))
-
-    # ── IMF WEO Projections ───────────────────────────────────────────────────
-    if "imf_weo" in categories:
-        from src.importer.fetchers.imf_weo_fetcher import fetch_imf_weo
-
-        console.print("\n[bold cyan]▶ IMF World Economic Outlook[/bold cyan]")
-        console.print("  [dim]India + G4 peers · GDP, CPI, fiscal balance, "
-                      "current account, unemployment · annual + 3-year forecasts · no auth[/dim]")
-
-        imf_wm = ch.get_watermark("imf_weo", "MACRO_GROUP") if (not dry_run and not full_reimport) else None
-        imf_from_year = (imf_wm.year - 1) if imf_wm else 2000   # overlap 1 year for WEO revisions
-        imf_to_year   = today.year + 3                            # include forward projections
-        imf_rows = fetch_imf_weo(from_year=imf_from_year, to_year=imf_to_year)
-
-        if not imf_rows:
-            console.print("  [yellow]⚠ No IMF WEO data returned — DataMapper API may be unavailable.[/yellow]")
-        else:
-            inserted = ch.insert_macro_indicators(imf_rows) if not dry_run else len(imf_rows)
-            console.print(f"  [green]✓[/green] {inserted} WEO rows {'(dry-run)' if dry_run else 'stored'}")
-            if not dry_run:
-                actual_rows = [r for r in imf_rows if not r.get("is_forecast", 0)]
-                if actual_rows:
-                    max_actual_year = max(int(r["ref_year"]) for r in actual_rows)
-                    ch.set_watermark("imf_weo", "MACRO_GROUP", date(max_actual_year, 12, 31))
-            # Show India GDP growth forecast
-            india_gdp = [r for r in imf_rows if r["country_code"] == "IN"
-                         and r["indicator_code"] == "NGDP_RPCH"
-                         and r["ref_year"] >= today.year]
-            if india_gdp:
-                forecasts = sorted(india_gdp, key=lambda r: r["ref_year"])[:3]
-                fwd_str = "  ".join(f"{r['ref_year']}={r['value']:+.1f}%" for r in forecasts)
-                console.print(f"  India GDP forecasts: {fwd_str}")
-            summary_rows.append(("imf_weo", "imf_weo", inserted,
-                                  str(imf_from_year), str(imf_to_year)))
-
-    if "fii_dii" in categories:
-        from src.importer.fetchers.fii_dii_fetcher import (
-            fetch_fii_dii,
-            fetch_fii_dii_fno,
-            fetch_fii_dii_monthly
-        )
-
-        console.print("\n[bold cyan]▶ FII / DII Institutional Flows[/bold cyan]")
-        console.print(
-            "  [dim]NSE provisional cash-market data — "
-            "FII & DII gross buy/sell/net in ₹ Crore[/dim]"
-        )
-
-        fii_from = _resolve_from_date(
-            ch, "nse_fii_dii", "MARKET",
-            lookback_days=lookback_days, full_reimport=full_reimport,
-            dry_run=dry_run, today=today,
-        )
-
-        console.print(f"  [dim]Fetching {fii_from} → {today}[/dim]")
-        
-        # 1. Daily Cash Flows
-        fii_rows = fetch_fii_dii(from_date=fii_from)
-        if fii_rows:
-            inserted = ch.insert_fii_dii_flows(fii_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} flow rows stored")
-            if not dry_run:
-                ch.set_watermark("nse_fii_dii", "MARKET", max(r["trade_date"] for r in fii_rows))
-            latest_fii = sorted(fii_rows, key=lambda r: r["trade_date"])[-1]
-            console.print(
-                f"  Latest Cash ({latest_fii['trade_date']}): "
-                f"FII Net ₹{latest_fii['fii_net_cr']:+,.0f} Cr  |  "
-                f"DII Net ₹{latest_fii['dii_net_cr']:+,.0f} Cr"
-            )
-            summary_rows.append((
-                "fii_dii", "nse", inserted,
-                str(min(r["trade_date"] for r in fii_rows)),
-                str(latest_fii["trade_date"]),
-            ))
-        else:
-            console.print("  [yellow]⚠ No daily cash rows returned.[/yellow]")
-
-        # 2. Daily F&O Participant OI
-        fno_rows = fetch_fii_dii_fno(from_date=fii_from)
-        if fno_rows:
-            inserted = ch.insert_fii_dii_fno_daily(fno_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} F&O OI rows stored")
-            latest_fno = sorted(fno_rows, key=lambda r: r["trade_date"])[-1]
-            console.print(
-                f"  Latest F&O ({latest_fno['trade_date']}): "
-                f"FII Fut Net {latest_fno['fii_fut_net_oi']:+,.0f} | "
-                f"FII Opt OI {latest_fno['fii_opt_overall_net_oi']:+,.0f}"
-            )
-        else:
-            console.print("  [yellow]⚠ No F&O rows returned.[/yellow]")
-
-        # 3. Monthly Aggregates (Always full sync for monthly as it's small)
-        monthly_rows = fetch_fii_dii_monthly()
-        if monthly_rows:
-            inserted = ch.insert_fii_dii_monthly(monthly_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} monthly aggregate rows stored")
-        else:
-            console.print("  [yellow]⚠ No monthly rows returned.[/yellow]")
-
-    if "amfi_flows" in categories:
-        from src.importer.fetchers.adapters import get_registry
-
-        console.print("\n[bold cyan]▶ AMFI Category-Wise Monthly Flows + AUM[/bold cyan]")
-        console.print(
-            "  [dim]AMFI industry data — monthly net flows & AUM by fund category[/dim]"
-        )
-
-        result = repo.run_fetcher(
-            get_registry()["amfi_flows"],
-            dry_run=dry_run, full=full_reimport, lookback_days=lookback_days, ch=ch,
-        )
-        if result.skipped:
-            console.print(
-                "  [yellow]⚠ No AMFI category flow rows returned. "
-                "Set AMFI_EXCEL_URL in .env as manual fallback.[/yellow]"
-            )
-        else:
-            console.print(f"  [green]✓[/green] {result.n} category flow rows {'(dry-run)' if dry_run else 'stored'}")
-            summary_rows.append((
-                "amfi_flows", "amfi", result.n,
-                result.from_date.isoformat(), result.to_date.isoformat(),
-            ))
 
     # ── AMC Fund-Holdings Importers ───────────────────────────────────────────
     _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant") if c in categories]

--- a/src/importer/cli.py
+++ b/src/importer/cli.py
@@ -186,16 +186,18 @@ def run_import(
     # ── Summary table ──────────────────────────────────────────────────────
     summary_rows: list[tuple[str, str, int, str, str]] = []
 
-    # ── Unified registry-driven import: stocks / us_stocks / etfs / commodities / indices / nse_indices ──
+    # ── Unified registry-driven import: stocks / us_stocks / etfs / commodities /
+    # indices / nse_indices / nse_eod / indian_macro ───────────────────────────────────────
     from src.importer.fetchers.adapters import get_registry
     from src.db.repository import MarketDataRepository
 
     repo = MarketDataRepository(pool=None)
-    price_categories = [
+    registry_categories = [
         c for c in categories
-        if c in {"stocks", "us_stocks", "etfs", "commodities", "indices", "nse_indices"}
+        if c in {"stocks", "us_stocks", "etfs", "commodities", "indices",
+                 "nse_indices", "nse_eod", "indian_macro"}
     ]
-    for category in price_categories:
+    for category in registry_categories:
         fetcher = get_registry().get(category)
         if fetcher is None:
             console.print(f"[yellow]⚠ Unknown category: {category}, skipping[/yellow]")
@@ -252,41 +254,6 @@ def run_import(
             result.from_date.isoformat(), result.to_date.isoformat(),
         ))
 
-    # ── NSE EOD OHLCV (available immediately after 3:30 PM IST) ─────────────
-    if "nse_eod" in categories:
-        from src.importer.registry import ETFS, STOCKS
-        from src.importer.fetchers.nse_quote_fetcher import fetch_nse_eod
-
-        nse_eod_symbols = ETFS + STOCKS
-        console.print(
-            f"\n[bold cyan]▶ NSE EOD OHLCV[/bold cyan] "
-            f"({len(nse_eod_symbols)} symbols — ETFs + stocks)"
-        )
-        console.print(
-            "  [dim]Direct NSE Quote API — available right after 3:30 PM IST, "
-            "no Yahoo Finance delay[/dim]"
-        )
-
-        eod_rows: list[dict] = []
-        for cat_name, sym_list in [("etfs", ETFS), ("stocks", STOCKS)]:
-            fetched = fetch_nse_eod(sym_list, cat_name)
-            eod_rows.extend(fetched)
-
-        if not eod_rows:
-            console.print(
-                "  [yellow]⚠ NSE returned no EOD data — "
-                "market may be open or API blocked.[/yellow]"
-            )
-        else:
-            inserted = ch.insert_prices(eod_rows, dry_run=dry_run)
-            console.print(
-                f"  [green]✓[/green] {inserted} rows "
-                f"{'(dry-run)' if dry_run else 'inserted'}"
-            )
-            _update_watermarks(ch, eod_rows, "nse_quote", dry_run=dry_run)
-            summary_rows.append((
-                "nse_eod", "nse_quote", inserted, str(today), str(today),
-            ))
 
     # ── NSE live iNAV snapshots ────────────────────────────────────────────────
     if "inav" in categories:
@@ -428,7 +395,7 @@ def run_import(
                                   str(fx_from), str(today)))
 
     if "mf_holdings" in categories:
-        from src.importer.fetchers.mf_holdings_fetcher import fetch_holdings
+        from src.importer.fetchers.adapters import MfHoldingsFetcher
 
         # NOTE: mstarpy.Funds.holdings() has NO date parameter — it always returns
         # the current Morningstar snapshot. We tag rows with the current month so
@@ -440,7 +407,9 @@ def run_import(
             f"({len(MF_HOLDINGS_WATCHLIST)} funds · snapshot as of {as_of_month})"
         )
 
-        # Skip if this month's snapshot already exists (unless forced)
+        # Skip if this month's snapshot already exists (unless forced) — an
+        # idempotency guard against real data, not delta-sync logic a Fetcher
+        # watermark can express, so it stays here rather than in the ABC.
         existing_months: set = set()
         if not full_reimport and not dry_run:
             try:
@@ -454,18 +423,18 @@ def run_import(
         if as_of_month in existing_months:
             console.print(f"  [dim]{as_of_month} snapshot already imported — skipping. Use --full to overwrite.[/dim]")
         else:
-            holdings_rows = fetch_holdings(MF_HOLDINGS_WATCHLIST, as_of_month)
-            if not holdings_rows:
-                console.print("  [yellow]⚠ No holdings returned — mstarpy may be unavailable.[/yellow]")
+            result = repo.run_fetcher(
+                MfHoldingsFetcher(MF_HOLDINGS_WATCHLIST, as_of_month),
+                dry_run=dry_run, full=True, ch=ch,
+            )
+            if result.skipped:
+                console.print("  [yellow]⚠ No holdings returned — mstarpy/Morningstar may be unavailable.[/yellow]")
             else:
-                inserted = ch.insert_mf_holdings(holdings_rows, dry_run=dry_run)
                 console.print(
-                    f"  [green]✓[/green] {inserted} rows "
+                    f"  [green]✓[/green] {result.n} rows "
                     f"{'(dry-run)' if dry_run else 'stored'} for {as_of_month}"
                 )
-                if not dry_run:
-                    ch.set_watermark("mf_holdings", "ALL", as_of_month)
-                summary_rows.append(("mf_holdings", "morningstar", inserted,
+                summary_rows.append(("mf_holdings", "morningstar", result.n,
                                      str(as_of_month), str(as_of_month)))
 
     # ── FII / DII Institutional Flows ─────────────────────────────────────────
@@ -584,37 +553,6 @@ def run_import(
             summary_rows.append(("imf_weo", "imf_weo", inserted,
                                   str(imf_from_year), str(imf_to_year)))
 
-    # ── Indian Macro Indicators ───────────────────────────────────────────────
-    if "indian_macro" in categories:
-        from src.importer.fetchers.indian_macro_fetcher import IndianMacroFetcher
-
-        console.print("\n[bold cyan]▶ Indian Macro Indicators[/bold cyan]")
-        console.print("  [dim]Scrapes industry and macro indicators (source: Tijori Finance)[/dim]")
-
-        fetcher = IndianMacroFetcher()
-        from_date = _resolve_from_date(
-            ch, fetcher.source_name, fetcher.symbol_key,
-            lookback_days=lookback_days, full_reimport=full_reimport,
-            dry_run=dry_run, today=today,
-        )
-
-        console.print(f"  [dim]Fetching {from_date} → {today}…[/dim]")
-        rows = fetcher.fetch_with_retry(from_date, today)
-
-        if not rows:
-            console.print("  [yellow]⚠ No Indian macro data returned.[/yellow]")
-        else:
-            inserted = fetcher.insert(rows, ch) if not dry_run else len(rows)
-            console.print(f"  [green]✓[/green] {inserted} rows {'(dry-run)' if dry_run else 'stored'}")
-            if not dry_run:
-                try:
-                    max_dt = fetcher.max_date(rows)
-                    ch.set_watermark(fetcher.source_name, fetcher.symbol_key, max_dt)
-                except Exception as e:
-                    logger.warning("Failed to update watermark for indian_macro: %s", e)
-            summary_rows.append(("indian_macro", "tijori", inserted,
-                                  from_date.isoformat(), today.isoformat()))
-
     if "fii_dii" in categories:
         from src.importer.fetchers.fii_dii_fetcher import (
             fetch_fii_dii,
@@ -680,52 +618,28 @@ def run_import(
             console.print("  [yellow]⚠ No monthly rows returned.[/yellow]")
 
     if "amfi_flows" in categories:
-        from src.importer.fetchers.amfi_flows_fetcher import fetch_amfi_category_flows
+        from src.importer.fetchers.adapters import get_registry
 
         console.print("\n[bold cyan]▶ AMFI Category-Wise Monthly Flows + AUM[/bold cyan]")
         console.print(
             "  [dim]AMFI industry data — monthly net flows & AUM by fund category[/dim]"
         )
 
-        amfi_wm = ch.get_watermark("amfi_category_flows", "INDUSTRY", dataset="flows")
-        months_back = 120 if full_reimport else 24
-        if amfi_wm is not None and not full_reimport:
-            today_m = date.today().replace(day=1)
-            wm_m = amfi_wm.replace(day=1)
-            diff_months = (today_m.year - wm_m.year) * 12 + (today_m.month - wm_m.month)
-            months_back = max(2, diff_months + 1)
-
-        console.print(f"  [dim]Fetching last {months_back} months[/dim]")
-
-        amfi_rows = fetch_amfi_category_flows(months_back=months_back)
-        if amfi_rows:
-            inserted = ch.insert_amfi_category_flows(amfi_rows, dry_run=dry_run)
-            console.print(f"  [green]✓[/green] {inserted} category flow rows stored")
-            if not dry_run:
-                latest_month = max(r["report_month"] for r in amfi_rows)
-                ch.set_watermark("amfi_category_flows", "INDUSTRY", latest_month, dataset="flows")
-            latest_m = max(r["report_month"] for r in amfi_rows)
-            latest_rows = [r for r in amfi_rows if r["report_month"] == latest_m]
-            latest_rows.sort(key=lambda r: r["net_flow_cr"], reverse=True)
-            console.print(f"  Latest month: [bold]{latest_m.strftime('%b %Y')}[/bold]")
-            for r in latest_rows[:3]:
-                sign = "+" if r["net_flow_cr"] >= 0 else ""
-                console.print(
-                    f"    {r['category_name'][:30]:<30} "
-                    f"Net: ₹{sign}{r['net_flow_cr']:,.0f} Cr  |  "
-                    f"AUM: ₹{r['closing_aum_cr']:,.0f} Cr"
-                )
-            summary_rows.append((
-                "amfi_flows", "amfi", inserted,
-                str(min(r["report_month"] for r in amfi_rows)),
-                str(max(r["report_month"] for r in amfi_rows)),
-            ))
-        else:
+        result = repo.run_fetcher(
+            get_registry()["amfi_flows"],
+            dry_run=dry_run, full=full_reimport, lookback_days=lookback_days, ch=ch,
+        )
+        if result.skipped:
             console.print(
                 "  [yellow]⚠ No AMFI category flow rows returned. "
                 "Set AMFI_EXCEL_URL in .env as manual fallback.[/yellow]"
             )
-
+        else:
+            console.print(f"  [green]✓[/green] {result.n} category flow rows {'(dry-run)' if dry_run else 'stored'}")
+            summary_rows.append((
+                "amfi_flows", "amfi", result.n,
+                result.from_date.isoformat(), result.to_date.isoformat(),
+            ))
 
     # ── AMC Fund-Holdings Importers ───────────────────────────────────────────
     _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant") if c in categories]

--- a/src/importer/fetchers/adapters.py
+++ b/src/importer/fetchers/adapters.py
@@ -360,6 +360,7 @@ class FIIDIIFetcher(Fetcher):
     overlap_days = 3
 
     def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+        self._last_from_date = from_date
         try:
             from src.importer.fetchers.fii_dii_fetcher import fetch_fii_dii
             return fetch_fii_dii(from_date=from_date)
@@ -369,13 +370,31 @@ class FIIDIIFetcher(Fetcher):
 
     def insert(self, rows: list[dict], ch) -> int:
         n = ch.insert_fii_dii_flows(rows)
+
+        if rows:
+            latest_fii = sorted(rows, key=lambda r: r["trade_date"])[-1]
+            log.info(
+                "Latest Cash (%s): FII Net ₹%s Cr  |  DII Net ₹%s Cr",
+                latest_fii["trade_date"],
+                f"{latest_fii.get('fii_net_cr', 0.0):+,.0f}",
+                f"{latest_fii.get('dii_net_cr', 0.0):+,.0f}",
+            )
+
         # Side-effect: also import F&O OI and monthly aggregates
         try:
             from src.importer.fetchers.fii_dii_fetcher import fetch_fii_dii_fno, fetch_fii_dii_monthly
-            fno_rows     = fetch_fii_dii_fno()
+            fno_from = getattr(self, "_last_from_date", None)
+            fno_rows     = fetch_fii_dii_fno(from_date=fno_from) if fno_from else fetch_fii_dii_fno()
             monthly_rows = fetch_fii_dii_monthly()
             if fno_rows:
                 ch.insert_fii_dii_fno_daily(fno_rows)
+                latest_fno = sorted(fno_rows, key=lambda r: r["trade_date"])[-1]
+                log.info(
+                    "Latest F&O (%s): FII Fut Net %s | FII Opt OI %s",
+                    latest_fno["trade_date"],
+                    f"{latest_fno.get('fii_fut_net_oi', 0.0):+,.0f}",
+                    f"{latest_fno.get('fii_opt_overall_net_oi', 0.0):+,.0f}",
+                )
             if monthly_rows:
                 ch.insert_fii_dii_monthly(monthly_rows)
         except Exception as exc:
@@ -550,7 +569,15 @@ class WorldBankMacroFetcher(Fetcher):
             return []
 
     def insert(self, rows: list[dict], ch) -> int:
-        return ch.insert_macro_indicators(rows)
+        n = ch.insert_macro_indicators(rows)
+        india_gdp = [
+            r for r in rows
+            if r.get("country_code") == "IN" and r.get("indicator_code") == "NY.GDP.MKTP.KD.ZG"
+        ]
+        if india_gdp:
+            latest = sorted(india_gdp, key=lambda r: r["ref_year"])[-1]
+            log.info("India GDP growth (%s): %+.2f%%", latest["ref_year"], latest["value"])
+        return n
 
     def validate(self, rows: list[dict]) -> list[dict]:
         return [r for r in rows if r.get("value") is not None]
@@ -587,7 +614,19 @@ class IMFWEOFetcher(Fetcher):
             return []
 
     def insert(self, rows: list[dict], ch) -> int:
-        return ch.insert_macro_indicators(rows)
+        n = ch.insert_macro_indicators(rows)
+        today_year = date.today().year
+        india_gdp = [
+            r for r in rows
+            if r.get("country_code") == "IN"
+            and r.get("indicator_code") == "NGDP_RPCH"
+            and int(r.get("ref_year", 0)) >= today_year
+        ]
+        if india_gdp:
+            forecasts = sorted(india_gdp, key=lambda r: r["ref_year"])[:3]
+            fwd_str = "  ".join(f"{r['ref_year']}={r['value']:+.1f}%" for r in forecasts)
+            log.info("India GDP forecasts: %s", fwd_str)
+        return n
 
     def validate(self, rows: list[dict]) -> list[dict]:
         return [r for r in rows if r.get("value") is not None]
@@ -744,8 +783,10 @@ class AmfiCategoryFlowsFetcher(Fetcher):
         log.info("AMFI category flows — latest month: %s", latest_m.strftime("%b %Y"))
         for r in latest_rows[:3]:
             log.info(
-                "  %-30s Net: ₹%+,.0f Cr  |  AUM: ₹%,.0f Cr",
-                r["category_name"][:30], r["net_flow_cr"], r["closing_aum_cr"],
+                "  %-30s Net: ₹%s Cr  |  AUM: ₹%s Cr",
+                r["category_name"][:30],
+                f"{r['net_flow_cr']:+,.0f}",
+                f"{r['closing_aum_cr']:,.0f}",
             )
         return n
 

--- a/src/importer/fetchers/adapters.py
+++ b/src/importer/fetchers/adapters.py
@@ -551,6 +551,123 @@ class NseIndexFetcher(Fetcher):
         return max(r["trade_date"] for r in rows)
 
 
+# ── NSE EOD OHLCV (ETFs + stocks, direct NSE Quote API) ────────────────────
+
+class NseEodFetcher(Fetcher):
+    """
+    Same-day OHLCV for ETFs + stocks via the NSE Quote API — available right
+    after 3:30 PM IST market close, without Yahoo Finance's ~1h delay.
+
+    fetch() ignores from_date/to_date — there's no date-range parameter on
+    the underlying NSE Quote endpoint, it always returns *today's* bar.
+    """
+    overlap_days = 3
+    supports_parallel = True  # per-symbol watermark write, not per-symbol fetch (workers stays 1)
+
+    def __init__(self, etf_symbols: list[tuple[str, str]], stock_symbols: list[tuple[str, str]]) -> None:
+        self._etf_symbols   = etf_symbols
+        self._stock_symbols = stock_symbols
+        self.symbols      = etf_symbols + stock_symbols
+        self.source_name  = "nse_quote"
+        self.symbol_key   = "NSE_EOD_GROUP"
+        self.description  = f"NSE EOD OHLCV — ETFs + stocks ({len(self.symbols)} symbols)"
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        from src.importer.fetchers.nse_quote_fetcher import fetch_nse_eod
+
+        rows: list[dict[str, Any]] = []
+        for cat_name, sym_list in (("etfs", self._etf_symbols), ("stocks", self._stock_symbols)):
+            rows.extend(fetch_nse_eod(sym_list, cat_name))
+        return rows
+
+    def insert(self, rows: list[dict], ch) -> int:
+        return ch.insert_prices(rows)
+
+    def validate(self, rows: list[dict]) -> list[dict]:
+        return [r for r in rows if r.get("close") and r["close"] > 0]
+
+    def max_date(self, rows: list[dict]) -> date:
+        return max(r["trade_date"] for r in rows)
+
+
+# ── MF Holdings (Morningstar) ───────────────────────────────────────────────
+
+class MfHoldingsFetcher(Fetcher):
+    """
+    Monthly portfolio-holdings snapshot per fund in the watchlist.
+
+    Constructed fresh per call (not cached in get_registry()) — as_of_month
+    is a runtime value, not something fixed at registry-build time. The
+    "already imported this month" idempotency guard lives in cli.py, not
+    here — it's a presence check against real data, not delta-sync logic
+    fetch()/watermarks can express.
+    """
+    source_name = "mf_holdings"
+    symbol_key  = "ALL"
+    description = "MF Holdings (Morningstar)"
+    overlap_days = 0
+
+    def __init__(self, watchlist: list[tuple[str, str, str]], as_of_month: date) -> None:
+        self.watchlist   = watchlist
+        self.as_of_month = as_of_month
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        from src.importer.fetchers.mf_holdings_fetcher import fetch_holdings
+        return fetch_holdings(self.watchlist, self.as_of_month)
+
+    def insert(self, rows: list[dict], ch) -> int:
+        return ch.insert_mf_holdings(rows)
+
+    def max_date(self, rows: list[dict]) -> date:
+        return self.as_of_month
+
+
+# ── AMFI Category-Wise Monthly Flows + AUM ──────────────────────────────────
+
+class AmfiCategoryFlowsFetcher(Fetcher):
+    """
+    AMFI industry data — monthly net flows & AUM by fund category.
+
+    fetch() has no date-range parameter upstream; it takes months_back
+    instead. overlap_days=0 makes run_fetcher() pass the raw watermark
+    through as from_date unmodified, so months_back can be derived from it
+    with exact parity to the original cli.py month-arithmetic whenever a
+    watermark exists.
+    """
+    source_name  = "amfi_category_flows"
+    symbol_key   = "INDUSTRY"
+    dataset      = "flows"
+    description  = "AMFI Category-Wise Monthly Flows + AUM"
+    overlap_days = 0
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        from src.importer.fetchers.amfi_flows_fetcher import fetch_amfi_category_flows
+
+        months_back = max(
+            2,
+            (to_date.year - from_date.year) * 12 + (to_date.month - from_date.month) + 1,
+        )
+        return fetch_amfi_category_flows(months_back=months_back)
+
+    def insert(self, rows: list[dict], ch) -> int:
+        n = ch.insert_amfi_category_flows(rows)
+        latest_m = max(r["report_month"] for r in rows)
+        latest_rows = sorted(
+            (r for r in rows if r["report_month"] == latest_m),
+            key=lambda r: r["net_flow_cr"], reverse=True,
+        )
+        log.info("AMFI category flows — latest month: %s", latest_m.strftime("%b %Y"))
+        for r in latest_rows[:3]:
+            log.info(
+                "  %-30s Net: ₹%+,.0f Cr  |  AUM: ₹%,.0f Cr",
+                r["category_name"][:30], r["net_flow_cr"], r["closing_aum_cr"],
+            )
+        return n
+
+    def max_date(self, rows: list[dict]) -> date:
+        return max(r["report_month"] for r in rows)
+
+
 # ── Registry ──────────────────────────────────────────────────────────────────
 # Maps CLI category name → Fetcher instance.
 # The orchestrator loops over this — adding a new source = one line here.
@@ -560,7 +677,11 @@ def _build_registry() -> dict[str, Fetcher]:
         get_symbols_for_categories,
         MF_SCHEME_CODES,
         NSE_ONLY_INDICES,
+        ETFS,
+        STOCKS,
     )
+    from src.importer.fetchers.indian_macro_fetcher import IndianMacroFetcher
+
     sym_map = get_symbols_for_categories(["stocks", "us_stocks", "etfs", "commodities", "indices"])
 
     registry: dict[str, Fetcher] = {}
@@ -573,6 +694,9 @@ def _build_registry() -> dict[str, Fetcher]:
             registry[cat] = YFinanceFetcher(cat, sym_list) # global symbols
 
     registry["nse_indices"] = NseIndexFetcher(NSE_ONLY_INDICES)
+    registry["nse_eod"]      = NseEodFetcher(ETFS, STOCKS)
+    registry["indian_macro"] = IndianMacroFetcher()
+    registry["amfi_flows"]   = AmfiCategoryFlowsFetcher()
     registry["mf"]      = MFNavFetcher(MF_SCHEME_CODES)
     registry["fii_dii"] = FIIDIIFetcher()
     registry["fx_rates"] = FXRatesFetcher()

--- a/src/importer/fetchers/adapters.py
+++ b/src/importer/fetchers/adapters.py
@@ -325,11 +325,13 @@ class MFNavFetcher(Fetcher):
     symbol_key   = "ALL"
     description  = "MF NAV (MFAPI.in)"
     overlap_days = 3
+    supports_parallel = True  # per-scheme group watermark, not per-scheme threaded fetch (workers stays 1)
 
-    def __init__(self, scheme_codes: list[str]) -> None:
-        self.scheme_codes = scheme_codes
+    def __init__(self, scheme_codes: dict[str, str]) -> None:
+        self.scheme_codes = scheme_codes  # {nse_symbol: amfi_scheme_code}
+        self.symbols = list(scheme_codes.items())
 
-    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
         try:
             from src.importer.fetchers.mfapi_fetcher import fetch_all_nav
             return fetch_all_nav(self.scheme_codes, from_date, to_date)
@@ -396,8 +398,13 @@ class FXRatesFetcher(Fetcher):
     symbol_key   = "FX_GROUP"
     description  = "FX rates — USD pairs (Yahoo Finance)"
     overlap_days = 3
+    supports_parallel = True  # per-pair group watermark, not per-pair threaded fetch (workers stays 1)
 
-    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+    def __init__(self) -> None:
+        from src.importer.fetchers.fx_rates_fetcher import FX_PAIRS
+        self.symbols = FX_PAIRS
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
         try:
             from src.importer.fetchers.fx_rates_fetcher import fetch_fx_rates
             return fetch_fx_rates(from_date=from_date, to_date=to_date)
@@ -406,7 +413,14 @@ class FXRatesFetcher(Fetcher):
             return []
 
     def insert(self, rows: list[dict], ch) -> int:
-        return ch.insert_fx_rates(rows)
+        n = ch.insert_fx_rates(rows)
+        latest_by_sym: dict[str, dict] = {}
+        for r in rows:
+            if r["symbol"] not in latest_by_sym or r["trade_date"] > latest_by_sym[r["symbol"]]["trade_date"]:
+                latest_by_sym[r["symbol"]] = r
+        for sym, r in sorted(latest_by_sym.items()):
+            log.info("%-8s %s close=%.4f", sym, r["trade_date"], r["close"])
+        return n
 
     def max_date(self, rows: list[dict]) -> date:
         return max(r["trade_date"] for r in rows)
@@ -426,22 +440,92 @@ class COTGoldFetcher(Fetcher):
     description  = "CFTC COT — Gold managed money (weekly)"
     overlap_days = 21  # 3-week overlap to catch late CFTC releases
 
-    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
         try:
             from src.importer.fetchers.cot_fetcher import fetch_cot_gold
-            return fetch_cot_gold(from_date=from_date)
+            # A fixed generous limit regardless of delta/first-run: delta runs
+            # are already bounded by the from_date filter, and a bigger cap
+            # never hurts on a first run (more history allowed, never less).
+            return fetch_cot_gold(from_date=from_date, limit=2000)
         except Exception as exc:
             log.warning("%s fetch failed: %s", self, exc)
             return []
 
     def insert(self, rows: list[dict], ch) -> int:
-        return ch.insert_cot_gold(rows)
+        n = ch.insert_cot_gold(rows)
+        latest = sorted(rows, key=lambda r: r["report_date"])[-1]
+        log.info(
+            "COT latest (%s): MM Net %s | OI %s | MM pct OI %+.1f%%",
+            latest["report_date"], f"{latest['mm_net']:+,d}", f"{latest['open_interest']:,d}",
+            latest["mm_net"] / max(latest["open_interest"], 1) * 100,
+        )
+        return n
 
     def max_date(self, rows: list[dict]) -> date:
         return max(r["report_date"] for r in rows)
 
 
 # ── World Bank Macro Indicators ───────────────────────────────────────────────
+
+class CbReservesFetcher(Fetcher):
+    """
+    Central bank gold reserves (9 countries, RAFAGOLD series), monthly,
+    ~6-week publication lag. fetch() takes a year, not a date range —
+    overlap_days=0 makes run_fetcher() pass the raw watermark through as
+    from_date unmodified, so from_date.year matches today's cb_wm.year
+    exactly whenever a watermark exists.
+    """
+    source_name  = "cb_reserves"
+    symbol_key   = "ALL"
+    description  = "IMF IFS — Central Bank Gold Reserves"
+    overlap_days = 0
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        try:
+            from src.importer.fetchers.imf_reserves_fetcher import fetch_cb_reserves
+            return fetch_cb_reserves(from_year=from_date.year)
+        except Exception as exc:
+            log.warning("%s fetch failed: %s", self, exc)
+            return []
+
+    def insert(self, rows: list[dict], ch) -> int:
+        return ch.insert_cb_reserves(rows)
+
+    def max_date(self, rows: list[dict]) -> date:
+        return max(r["ref_period"] for r in rows)
+
+
+class EtfAumFetcher(Fetcher):
+    """
+    Daily AUM + implied gold tonnes for GLD/IAU/SGOL/PHYS via yfinance.
+    No date-range parameter upstream — always today's snapshot. Adding a
+    watermark here is purely additive bookkeeping (fetch() ignores
+    from_date/to_date either way, so it can't change what's fetched).
+    """
+    source_name  = "etf_aum"
+    symbol_key   = "ALL"
+    description  = "Gold ETF AUM Snapshots (GLD · IAU · SGOL · PHYS)"
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        try:
+            from src.importer.fetchers.etf_aum_fetcher import fetch_etf_aum
+            return fetch_etf_aum()
+        except Exception as exc:
+            log.warning("%s fetch failed: %s", self, exc)
+            return []
+
+    def insert(self, rows: list[dict], ch) -> int:
+        n = ch.insert_etf_aum(rows)
+        for r in rows:
+            log.info(
+                "%-6s AUM $%.2fB price $%.2f ~%.0ft",
+                r["symbol"], r["aum_usd"] / 1e9, r["price"], r["implied_tonnes"],
+            )
+        return n
+
+    def max_date(self, rows: list[dict]) -> date:
+        return max(r["trade_date"] for r in rows)
+
 
 class WorldBankMacroFetcher(Fetcher):
     """
@@ -639,6 +723,7 @@ class AmfiCategoryFlowsFetcher(Fetcher):
     dataset      = "flows"
     description  = "AMFI Category-Wise Monthly Flows + AUM"
     overlap_days = 0
+    first_run_lookback_days = 730  # ~24 months, matches the original first-run default
 
     def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
         from src.importer.fetchers.amfi_flows_fetcher import fetch_amfi_category_flows
@@ -701,6 +786,8 @@ def _build_registry() -> dict[str, Fetcher]:
     registry["fii_dii"] = FIIDIIFetcher()
     registry["fx_rates"] = FXRatesFetcher()
     registry["cot"]     = COTGoldFetcher()
+    registry["cb_reserves"] = CbReservesFetcher()
+    registry["etf_aum"]     = EtfAumFetcher()
     registry["world_bank"] = WorldBankMacroFetcher()
     registry["imf_weo"]    = IMFWEOFetcher()
     return registry

--- a/src/importer/fetchers/adapters.py
+++ b/src/importer/fetchers/adapters.py
@@ -88,6 +88,8 @@ class ShoonyaFetcher(Fetcher):
     Same (nse_symbol, yahoo_ticker) tuple interface as YFinanceFetcher.
     """
     overlap_days = 3
+    supports_parallel = True
+    supports_source_override = True
 
     def __init__(self, category: str, symbols: list[tuple[str, str]]) -> None:
         self.category    = category
@@ -96,9 +98,15 @@ class ShoonyaFetcher(Fetcher):
         self.symbol_key  = category.upper()
         self.description = f"Shoonya OHLCV — {category} ({len(symbols)} symbols)"
 
-    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
-        from src.importer.fetchers.shoonya_fetcher import fetch_shoonya_ohlcv
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
         from src.importer.fetchers.yfinance_fetcher import fetch_ohlcv as yf_fetch_ohlcv
+
+        if source == "nse":
+            return NSElibFetcher(self.category, self.symbols).fetch(from_date, to_date)
+        if source == "yfinance":
+            return yf_fetch_ohlcv(self.symbols, self.category, from_date, to_date)
+
+        from src.importer.fetchers.shoonya_fetcher import fetch_shoonya_ohlcv
 
         rows = fetch_shoonya_ohlcv(self.symbols, self.category, from_date, to_date)
         covered = {r["symbol"] for r in rows}
@@ -132,6 +140,140 @@ class ShoonyaFetcher(Fetcher):
 
     def max_date(self, rows: list[dict]) -> date:
         return max(r["trade_date"] for r in rows)
+
+
+# ── Stocks (prices + earnings + insider + valuation) ────────────────────────
+
+_STOCKS_INITIAL_SLEEP = 0.3   # stagger thread start
+_STOCKS_BETWEEN_CALLS = 0.4   # spacing between sequential API calls per symbol
+
+
+class StocksFetcher(Fetcher):
+    """
+    Per-symbol OHLCV + earnings + insider trades + valuation for stocks/us_stocks.
+
+    Ports parallel_importer.run_parallel_stock_import's per-symbol behavior
+    into the Fetcher ABC: when run with supports_parallel workers, the
+    orchestrator calls fetch() once per symbol (via for_symbol()) so each of
+    the four sub-fetches below runs inside its own thread, same as today.
+
+    Rows carry a "_dataset" tag (prices|earnings|insider|valuation) so a
+    single fetch() batch spanning multiple ClickHouse tables can be routed
+    by insert()/write_group_watermarks() without a second fetch.
+    """
+    overlap_days = 3
+    supports_parallel = True
+    supports_source_override = True
+    # Each symbol resolves its own watermark independently (matches
+    # parallel_importer.import_single_stock's per-thread ch.get_watermark
+    # call) rather than one worst-case watermark shared across the whole
+    # symbol list — adding one new symbol must not force a full-lookback
+    # re-fetch of every other symbol already caught up.
+    per_symbol_watermark = True
+
+    def __init__(self, category: str, symbols: list[tuple[str, str]]) -> None:
+        self.category    = category
+        self.symbols     = symbols
+        self.source_name = "shoonya" if category == "stocks" else "yfinance"
+        self.symbol_key  = category.upper()
+        self.description = f"Stocks (prices+earnings+insider+valuation) — {category} ({len(symbols)} symbols)"
+        # us_stocks has no Shoonya/NSE presence — --data-source is ignored for
+        # it today (import_single_stock always passes data_source="yfinance"
+        # for us_stocks, regardless of the CLI override), so only "stocks"
+        # actually honors a source override.
+        self.supports_source_override = category == "stocks"
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        import time
+        from src.importer.fetchers.earnings_fetcher import fetch_earnings
+        from src.importer.fetchers.insider_fetcher import fetch_insider_trades
+        from src.importer.fetchers.valuation_fetcher import fetch_valuation
+        from src.importer.fetchers.yfinance_fetcher import fetch_ohlcv as yf_fetch_ohlcv
+
+        time.sleep(_STOCKS_INITIAL_SLEEP)
+
+        rows: list[dict[str, Any]] = []
+        effective_source = source or self.source_name
+
+        if self.category == "stocks":
+            if effective_source == "nse":
+                prices = NSElibFetcher(self.category, self.symbols).fetch(from_date, to_date)
+            elif effective_source == "yfinance":
+                prices = yf_fetch_ohlcv(self.symbols, self.category, from_date, to_date)
+            else:
+                prices = ShoonyaFetcher(self.category, self.symbols).fetch(from_date, to_date)
+        else:
+            prices = yf_fetch_ohlcv(self.symbols, self.category, from_date, to_date)
+        for r in prices:
+            r["_dataset"] = "prices"
+        rows.extend(prices)
+
+        time.sleep(_STOCKS_BETWEEN_CALLS)
+        earnings = fetch_earnings(self.symbols)
+        for r in earnings:
+            r["_dataset"] = "earnings"
+        rows.extend(earnings)
+
+        time.sleep(_STOCKS_BETWEEN_CALLS)
+        insider = fetch_insider_trades(self.symbols)
+        for r in insider:
+            r["_dataset"] = "insider"
+        rows.extend(insider)
+
+        time.sleep(_STOCKS_BETWEEN_CALLS)
+        valuation = fetch_valuation(self.symbols)
+        for r in valuation:
+            r["_dataset"] = "valuation"
+        rows.extend(valuation)
+
+        return rows
+
+    def insert(self, rows: list[dict], ch) -> int:
+        by_dataset: dict[str, list[dict]] = {"prices": [], "earnings": [], "insider": [], "valuation": []}
+        for r in rows:
+            by_dataset.setdefault(r.get("_dataset", "prices"), []).append(r)
+
+        n = ch.insert_prices(by_dataset["prices"]) if by_dataset["prices"] else 0
+        if by_dataset["earnings"]:
+            ch.insert_stock_earnings(by_dataset["earnings"])
+        if by_dataset["insider"]:
+            ch.insert_stock_insider(by_dataset["insider"])
+        if by_dataset["valuation"]:
+            ch.insert_stock_valuation(by_dataset["valuation"])
+        return n
+
+    def validate(self, rows: list[dict]) -> list[dict]:
+        return [
+            r for r in rows
+            if r.get("_dataset") != "prices" or (r.get("close") and r["close"] > 0)
+        ]
+
+    def max_date(self, rows: list[dict]) -> date:
+        price_rows = [r for r in rows if r.get("_dataset") == "prices"]
+        if price_rows:
+            return max(r["trade_date"] for r in price_rows)
+        return date.today()
+
+    def write_group_watermarks(
+        self, ch, rows: list[dict], dry_run: bool, *, source: str | None = None,
+    ) -> None:
+        if dry_run or not rows:
+            return
+        # Watermark the source that actually produced these rows, not the
+        # fetcher's static default — a --data-source nse run must not have
+        # its watermark silently read back by tomorrow's default-source run.
+        effective_source = source or self.source_name
+        today = date.today()
+        by_symbol_dataset: dict[tuple[str, str], list[dict]] = {}
+        for r in rows:
+            key = (r["symbol"], r.get("_dataset", "prices"))
+            by_symbol_dataset.setdefault(key, []).append(r)
+
+        for (sym, ds), ds_rows in by_symbol_dataset.items():
+            if ds == "prices":
+                ch.set_watermark(effective_source, sym, max(r["trade_date"] for r in ds_rows), dataset="prices")
+            else:
+                ch.set_watermark("yfinance", sym, today, dataset=ds)
 
 
 # ── yfinance OHLCV (stocks / ETFs / commodities / indices) ──────────────────
@@ -415,12 +557,14 @@ def _build_registry() -> dict[str, Fetcher]:
         MF_SCHEME_CODES,
         NSE_ONLY_INDICES,
     )
-    sym_map = get_symbols_for_categories(["stocks", "etfs", "commodities", "indices"])
+    sym_map = get_symbols_for_categories(["stocks", "us_stocks", "etfs", "commodities", "indices"])
 
     registry: dict[str, Fetcher] = {}
     for cat, sym_list in sym_map.items():
-        if cat in {"etfs", "stocks"}:
+        if cat == "etfs":
             registry[cat] = ShoonyaFetcher(cat, sym_list)  # Shoonya → nselib (etfs) → yfinance
+        elif cat in {"stocks", "us_stocks"}:
+            registry[cat] = StocksFetcher(cat, sym_list)   # prices + earnings + insider + valuation
         else:
             registry[cat] = YFinanceFetcher(cat, sym_list) # global symbols
 

--- a/src/importer/fetchers/adapters.py
+++ b/src/importer/fetchers/adapters.py
@@ -254,6 +254,10 @@ class StocksFetcher(Fetcher):
             return max(r["trade_date"] for r in price_rows)
         return date.today()
 
+    def count_insertable(self, rows: list[dict]) -> int:
+        # dry-run preview must match insert()'s real-run count — prices only.
+        return len([r for r in rows if r.get("_dataset") == "prices"])
+
     def write_group_watermarks(
         self, ch, rows: list[dict], dry_run: bool, *, source: str | None = None,
     ) -> None:

--- a/tests/test_fund_imports_integration.py
+++ b/tests/test_fund_imports_integration.py
@@ -233,10 +233,16 @@ class TestRunImportDispatch:
 
     # ── non-AMC categories must not trigger the factory ───────────────────────
 
+    # NOTE: "stocks"/"etfs"/etc. now route through get_registry() (the
+    # Fetcher-registry unification), not get_symbols_for_categories()
+    # directly — get_registry() is additionally mocked to {} here so the
+    # price-category loop is a no-op instead of running (mocked-Shoonya-
+    # bypassing) real network fetches against the full stock watchlist.
+    @patch("src.importer.fetchers.adapters.get_registry", return_value={})
     @patch("src.importer.registry.get_symbols_for_categories", return_value={})
     @patch("src.importer.clickhouse.ClickHouseImporter")
     @patch("src.scripts.fund_imports.factory.create_importer")
-    def test_yfinance_category_does_not_call_factory(self, mock_create, mock_ch_cls, _syms):
+    def test_yfinance_category_does_not_call_factory(self, mock_create, mock_ch_cls, _syms, _registry):
         mock_ch_cls.return_value = _mock_ch()
 
         from src.importer.cli import run_import
@@ -244,11 +250,12 @@ class TestRunImportDispatch:
 
         mock_create.assert_not_called()
 
+    @patch("src.importer.fetchers.adapters.get_registry", return_value={})
     @patch("src.importer.registry.get_symbols_for_categories", return_value={})
     @patch("src.importer.clickhouse.ClickHouseImporter")
     @patch("src.scripts.fund_imports.factory.create_importer")
-    def test_mixed_yfinance_and_amc_categories(self, mock_create, mock_ch_cls, mock_syms):
-        """Mixing stocks + icici: yfinance loop runs (via mock) and factory is called once."""
+    def test_mixed_yfinance_and_amc_categories(self, mock_create, mock_ch_cls, mock_syms, mock_registry):
+        """Mixing stocks + icici: registry-driven price loop is a no-op (mocked empty) and factory is called once."""
         mock_ch_cls.return_value = _mock_ch()
         mock_imp = MagicMock()
         mock_create.return_value = mock_imp
@@ -260,6 +267,6 @@ class TestRunImportDispatch:
             console=_quiet_console(),
         )
 
-        mock_syms.assert_called_once_with(["stocks", "icici"])
+        mock_registry.assert_called_once()
         mock_create.assert_called_once_with("icici")
         mock_imp.run.assert_called_once_with(dry_run=True)

--- a/tests/test_repository_run_fetcher.py
+++ b/tests/test_repository_run_fetcher.py
@@ -224,5 +224,110 @@ class TestWatermarkEquivalence(unittest.TestCase):
         self.assertEqual(new_from, today - timedelta(days=365))
 
 
+class FakeFlowsFetcher(Fetcher):
+    """Single-watermark fetcher using a non-default dataset bucket."""
+
+    source_name = "test_flows"
+    symbol_key = "X"
+    dataset = "flows"
+    overlap_days = 0
+
+    def fetch(self, from_date, to_date, *, source=None):
+        return [{"report_month": date(2026, 7, 1), "value": 1}]
+
+    def insert(self, rows, ch):
+        return len(rows)
+
+    def max_date(self, rows):
+        return date(2026, 7, 1)
+
+
+class TestDatasetAttribute(unittest.TestCase):
+    def test_single_watermark_path_uses_fetcher_dataset(self):
+        """run_fetcher's single-watermark path must read/write the fetcher's
+        own `dataset` bucket, not silently default to "prices" — needed for
+        amfi_flows, whose watermark lives under dataset="flows"."""
+        ch = FakeCH({})
+        repo = MarketDataRepository(pool=None)
+
+        repo.run_fetcher(FakeFlowsFetcher(), dry_run=False, full=True, lookback_days=10, ch=ch)
+
+        self.assertEqual(ch.get_watermark("test_flows", "X", dataset="flows"), date(2026, 7, 1))
+        self.assertIsNone(ch.get_watermark("test_flows", "X", dataset="prices"))
+
+
+class TestAmfiCategoryFlowsFetcher(unittest.TestCase):
+    @patch("src.importer.fetchers.amfi_flows_fetcher.fetch_amfi_category_flows")
+    def test_months_back_matches_original_cli_formula(self, mock_fetch):
+        """With overlap_days=0, run_fetcher passes from_date=watermark exactly,
+        so months_back must reproduce cli.py's original month-diff arithmetic
+        byte-for-byte whenever a watermark exists — spec Phase 4 parity."""
+        from src.importer.fetchers.adapters import AmfiCategoryFlowsFetcher
+
+        mock_fetch.return_value = []
+        today = date(2026, 7, 31)
+        wm = date(2026, 5, 1)  # report_month watermarks are always first-of-month
+
+        AmfiCategoryFlowsFetcher().fetch(wm, today)
+
+        today_m, wm_m = today.replace(day=1), wm.replace(day=1)
+        diff_months = (today_m.year - wm_m.year) * 12 + (today_m.month - wm_m.month)
+        expected_months_back = max(2, diff_months + 1)
+
+        mock_fetch.assert_called_once_with(months_back=expected_months_back)
+
+    @patch("src.importer.fetchers.amfi_flows_fetcher.fetch_amfi_category_flows")
+    def test_months_back_floor_of_two(self, mock_fetch):
+        from src.importer.fetchers.adapters import AmfiCategoryFlowsFetcher
+
+        mock_fetch.return_value = []
+        today = date(2026, 7, 31)
+        wm = date(2026, 7, 1)  # same month as today
+
+        AmfiCategoryFlowsFetcher().fetch(wm, today)
+
+        mock_fetch.assert_called_once_with(months_back=2)
+
+
+class TestNseEodFetcher(unittest.TestCase):
+    @patch("src.importer.fetchers.nse_quote_fetcher.fetch_nse_eod")
+    def test_fetch_combines_etfs_and_stocks(self, mock_fetch):
+        from src.importer.fetchers.adapters import NseEodFetcher
+
+        def side_effect(sym_list, cat_name):
+            return [
+                {"symbol": s, "category": cat_name, "trade_date": date(2026, 7, 31), "close": 1.0}
+                for s, _ in sym_list
+            ]
+        mock_fetch.side_effect = side_effect
+
+        fetcher = NseEodFetcher([("GOLDBEES", "GOLDBEES.NS")], [("RELIANCE", "RELIANCE.NS")])
+        rows = fetcher.fetch(date(2026, 7, 1), date(2026, 7, 31))
+
+        self.assertEqual({r["symbol"] for r in rows}, {"GOLDBEES", "RELIANCE"})
+        self.assertEqual({r["category"] for r in rows}, {"etfs", "stocks"})
+        self.assertEqual(fetcher.max_date(rows), date(2026, 7, 31))
+        self.assertEqual(fetcher.symbols, [("GOLDBEES", "GOLDBEES.NS"), ("RELIANCE", "RELIANCE.NS")])
+
+
+class TestMfHoldingsFetcher(unittest.TestCase):
+    @patch("src.importer.fetchers.mf_holdings_fetcher.fetch_holdings")
+    def test_fetch_insert_max_date(self, mock_fetch):
+        from src.importer.fetchers.adapters import MfHoldingsFetcher
+
+        mock_fetch.return_value = [{"scheme_code": "X", "as_of_month": date(2026, 7, 1)}]
+        fetcher = MfHoldingsFetcher([("X", "Fund X", "ISIN1")], date(2026, 7, 1))
+
+        rows = fetcher.fetch(date(2026, 1, 1), date(2026, 7, 31))
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(fetcher.max_date(rows), date(2026, 7, 1))
+        mock_fetch.assert_called_once_with([("X", "Fund X", "ISIN1")], date(2026, 7, 1))
+
+        fake_ch = MagicMock()
+        fake_ch.insert_mf_holdings.return_value = 1
+        self.assertEqual(fetcher.insert(rows, fake_ch), 1)
+        fake_ch.insert_mf_holdings.assert_called_once_with(rows)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_run_fetcher.py
+++ b/tests/test_repository_run_fetcher.py
@@ -7,7 +7,6 @@ from unittest.mock import patch, MagicMock
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 from src.importer.base_fetcher import Fetcher
-from src.importer.cli import _resolve_from_date
 from src.db.repository import MarketDataRepository
 
 
@@ -189,9 +188,8 @@ class TestStocksSourceOverrideWatermark(unittest.TestCase):
 
 
 class TestWatermarkEquivalence(unittest.TestCase):
-    def test_resolve_group_from_date_matches_cli_resolve_from_date(self):
-        """New repository._resolve_group_from_date must agree with the existing
-        cli._resolve_from_date on the same fixture watermarks — spec §7.2."""
+    def test_resolve_group_from_date_computes_earliest_watermark_minus_overlap(self):
+        """repository._resolve_group_from_date computes earliest watermark minus overlap — spec §7.2."""
         today = date(2026, 7, 31)
         seed = {
             ("shoonya", "GOLDBEES"):   date(2026, 7, 20),
@@ -200,20 +198,14 @@ class TestWatermarkEquivalence(unittest.TestCase):
         }
         symbols = ["GOLDBEES", "NIFTYBEES", "BANKBEES"]
 
-        old_from = _resolve_from_date(
-            FakeCH(seed), "shoonya", symbols,
-            lookback_days=365, overlap_days=3, full_reimport=False,
-            dry_run=False, today=today,
-        )
-
         repo = MarketDataRepository(pool=None)
         new_from = repo._resolve_group_from_date(
             FakeCH(seed), "shoonya", symbols,
             lookback_days=365, overlap_days=3, full=False, today=today,
         )
 
-        self.assertEqual(old_from, new_from)
-        self.assertEqual(old_from, date(2026, 7, 18) - timedelta(days=3))
+        expected = date(2026, 7, 18) - timedelta(days=3)
+        self.assertEqual(new_from, expected)
 
     def test_resolve_group_from_date_full_lookback_when_no_watermark(self):
         today = date(2026, 7, 31)
@@ -458,5 +450,38 @@ class TestFirstRunLookbackDays(unittest.TestCase):
         self.assertGreaterEqual(months_back, 23)
 
 
+class TestFIIDIIFetcher(unittest.TestCase):
+    @patch("src.importer.fetchers.fii_dii_fetcher.fetch_fii_dii_monthly")
+    @patch("src.importer.fetchers.fii_dii_fetcher.fetch_fii_dii_fno")
+    @patch("src.importer.fetchers.fii_dii_fetcher.fetch_fii_dii")
+    def test_fii_dii_fetcher_stashes_from_date_and_passes_to_fno(self, mock_cash, mock_fno, mock_monthly):
+        from src.importer.fetchers.adapters import FIIDIIFetcher
+
+        mock_cash.return_value = [{"trade_date": date(2026, 7, 30), "fii_net_cr": 100.0, "dii_net_cr": 200.0}]
+        mock_fno.return_value = [{"trade_date": date(2026, 7, 30), "fii_fut_net_oi": 500.0, "fii_opt_overall_net_oi": 1000.0}]
+        mock_monthly.return_value = [{"month": "2026-07"}]
+
+        fetcher = FIIDIIFetcher()
+        from_dt = date(2026, 7, 25)
+        to_dt = date(2026, 7, 30)
+
+        rows = fetcher.fetch(from_dt, to_dt)
+        self.assertEqual(fetcher._last_from_date, from_dt)
+        mock_cash.assert_called_once_with(from_date=from_dt)
+
+        mock_ch = MagicMock()
+        mock_ch.insert_fii_dii_flows.return_value = 1
+
+        n = fetcher.insert(rows, mock_ch)
+
+        self.assertEqual(n, 1)
+        mock_ch.insert_fii_dii_flows.assert_called_once_with(rows)
+        mock_fno.assert_called_once_with(from_date=from_dt)
+        mock_ch.insert_fii_dii_fno_daily.assert_called_once_with(mock_fno.return_value)
+        mock_monthly.assert_called_once()
+        mock_ch.insert_fii_dii_monthly.assert_called_once_with(mock_monthly.return_value)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tests/test_repository_run_fetcher.py
+++ b/tests/test_repository_run_fetcher.py
@@ -1,0 +1,212 @@
+import sys
+import os
+import unittest
+from datetime import date, timedelta
+from unittest.mock import patch, MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from src.importer.base_fetcher import Fetcher
+from src.importer.cli import _resolve_from_date
+from src.db.repository import MarketDataRepository
+
+
+class FlakyFetcher(Fetcher):
+    """supports_parallel fetcher where one symbol always raises inside fetch()."""
+
+    supports_parallel = True
+    overlap_days = 3
+
+    def __init__(self, category, symbols):
+        self.category = category
+        self.symbols = symbols
+        self.source_name = "flaky"
+        self.symbol_key = "FLAKY_GROUP"
+
+    def fetch(self, from_date, to_date, *, source=None):
+        sym = self.symbols[0][0]
+        if sym == "BAD":
+            raise RuntimeError("simulated upstream failure")
+        return [{"symbol": sym, "trade_date": to_date, "close": 1.0}]
+
+    def insert(self, rows, ch):
+        return len(rows)
+
+
+class InstantFetcher(Fetcher):
+    """supports_parallel fetcher that returns immediately, for progress_cb tests."""
+
+    supports_parallel = True
+    overlap_days = 3
+
+    def __init__(self, category, symbols):
+        self.category = category
+        self.symbols = symbols
+        self.source_name = "instant"
+        self.symbol_key = "INSTANT_GROUP"
+
+    def fetch(self, from_date, to_date, *, source=None):
+        sym = self.symbols[0][0]
+        return [{"symbol": sym, "trade_date": to_date, "close": 1.0}]
+
+    def insert(self, rows, ch):
+        return len(rows)
+
+
+class FakeCH:
+    """In-memory (source, symbol[, dataset]) -> date watermark store, no ClickHouse needed."""
+
+    def __init__(self, seed: dict):
+        self._store = dict(seed)
+
+    def get_watermark(self, source, symbol, dataset="prices"):
+        if (source, symbol, dataset) in self._store:
+            return self._store[(source, symbol, dataset)]
+        return self._store.get((source, symbol))
+
+    def set_watermark(self, source, symbol, last_date, dataset="prices"):
+        self._store[(source, symbol, dataset)] = last_date
+
+
+class TestFetchParallel(unittest.TestCase):
+    def test_fetch_parallel_isolates_failures(self):
+        """One bad symbol must not fail the batch — matches spec §7.3."""
+        fetcher = FlakyFetcher("x", [("GOOD1", "GOOD1.NS"), ("BAD", "BAD.NS"), ("GOOD2", "GOOD2.NS")])
+        repo = MarketDataRepository(pool=None)
+
+        rows = repo._fetch_parallel(fetcher, date(2026, 1, 1), date(2026, 1, 2), workers=3)
+
+        self.assertEqual({r["symbol"] for r in rows}, {"GOOD1", "GOOD2"})
+
+    def test_progress_callback_fires_once_per_symbol(self):
+        """progress_cb fires exactly once per symbol, in any completion order — spec §7.5."""
+        symbols = [("A", "A.NS"), ("B", "B.NS"), ("C", "C.NS"), ("D", "D.NS")]
+        fetcher = InstantFetcher("x", symbols)
+        repo = MarketDataRepository(pool=None)
+
+        seen = []
+        repo._fetch_parallel(
+            fetcher, date(2026, 1, 1), date(2026, 1, 2), workers=4,
+            progress_cb=seen.append,
+        )
+
+        self.assertEqual(sorted(seen), sorted(s for s, _ in symbols))
+
+
+class TestSourceOverride(unittest.TestCase):
+    @patch("src.importer.fetchers.adapters.NSElibFetcher.fetch")
+    def test_source_override_routes_to_nselib(self, mock_fetch):
+        """source="nse" must route to NSElibFetcher, not silently fall back to shoonya — spec §7.4.
+
+        Constructs ShoonyaFetcher directly rather than via get_registry() —
+        get_registry() caches a process-wide singleton, so any earlier test
+        (in any file, any order) that mocks get_symbols_for_categories before
+        the registry is first built would poison every later test that reads
+        get_registry() for the rest of the process.
+        """
+        from src.importer.fetchers.adapters import ShoonyaFetcher
+
+        mock_fetch.return_value = []
+        fetcher = ShoonyaFetcher("etfs", [("GOLDBEES", "GOLDBEES.NS")])
+
+        fetcher.fetch(date(2026, 1, 1), date(2026, 1, 2), source="nse")
+
+        mock_fetch.assert_called_once()
+
+
+class TestStocksPerSymbolWatermark(unittest.TestCase):
+    """StocksFetcher must resolve each symbol's watermark independently —
+    a shared group worst-case (like etfs) would mean adding one never-before-
+    imported symbol forces every already-caught-up symbol back to a full
+    lookback re-fetch. Regression coverage for that specific failure mode."""
+
+    @patch("src.importer.fetchers.adapters.StocksFetcher.fetch", autospec=True)
+    def test_new_symbol_does_not_drag_down_caught_up_symbol(self, mock_fetch):
+        from src.importer.fetchers.adapters import StocksFetcher
+
+        mock_fetch.return_value = []
+        today = date(2026, 7, 31)
+        ch = FakeCH({("shoonya", "CAUGHTUP", "prices"): date(2026, 7, 29)})
+        fetcher = StocksFetcher("stocks", [("CAUGHTUP", "CAUGHTUP.NS"), ("NEWSYM", "NEWSYM.NS")])
+        repo = MarketDataRepository(pool=None)
+
+        repo._fetch_parallel(
+            fetcher, today - timedelta(days=3650), today, workers=2,
+            ch=ch, per_symbol_watermark=True, lookback_days=3650, full=False,
+            effective_source="shoonya",
+        )
+
+        from_date_by_symbol = {}
+        for c in mock_fetch.call_args_list:
+            self_instance, sym_from, _sym_to = c.args
+            from_date_by_symbol[self_instance.symbols[0][0]] = sym_from
+
+        self.assertEqual(from_date_by_symbol["NEWSYM"], today - timedelta(days=3650))
+        self.assertEqual(from_date_by_symbol["CAUGHTUP"], date(2026, 7, 29) - timedelta(days=3))
+
+
+class TestStocksSourceOverrideWatermark(unittest.TestCase):
+    """A --data-source override must be reflected in the watermark key that
+    gets written, or a "nse"-sourced run's watermark is invisible to
+    tomorrow's default-source ("shoonya") run and vice versa."""
+
+    def test_write_group_watermarks_uses_effective_source(self):
+        from src.importer.fetchers.adapters import StocksFetcher
+
+        fetcher = StocksFetcher("stocks", [("RELIANCE", "RELIANCE.NS")])
+        ch = FakeCH({})
+        rows = [{"symbol": "RELIANCE", "trade_date": date(2026, 7, 30), "close": 100.0, "_dataset": "prices"}]
+
+        fetcher.write_group_watermarks(ch, rows, dry_run=False, source="nse")
+
+        self.assertEqual(ch.get_watermark("nse", "RELIANCE", dataset="prices"), date(2026, 7, 30))
+        self.assertIsNone(ch.get_watermark("shoonya", "RELIANCE", dataset="prices"))
+
+    def test_us_stocks_ignores_source_override(self):
+        """us_stocks has no Shoonya/NSE presence — a --data-source override
+        must not affect it, matching parallel_importer's hardcoded
+        data_source="yfinance" for us_stocks today."""
+        from src.importer.fetchers.adapters import StocksFetcher
+
+        self.assertFalse(StocksFetcher("us_stocks", [("AAPL", "AAPL")]).supports_source_override)
+        self.assertTrue(StocksFetcher("stocks", [("RELIANCE", "RELIANCE.NS")]).supports_source_override)
+
+
+class TestWatermarkEquivalence(unittest.TestCase):
+    def test_resolve_group_from_date_matches_cli_resolve_from_date(self):
+        """New repository._resolve_group_from_date must agree with the existing
+        cli._resolve_from_date on the same fixture watermarks — spec §7.2."""
+        today = date(2026, 7, 31)
+        seed = {
+            ("shoonya", "GOLDBEES"):   date(2026, 7, 20),
+            ("shoonya", "NIFTYBEES"):  date(2026, 7, 18),  # earliest — drives worst-case
+            ("shoonya", "BANKBEES"):   date(2026, 7, 25),
+        }
+        symbols = ["GOLDBEES", "NIFTYBEES", "BANKBEES"]
+
+        old_from = _resolve_from_date(
+            FakeCH(seed), "shoonya", symbols,
+            lookback_days=365, overlap_days=3, full_reimport=False,
+            dry_run=False, today=today,
+        )
+
+        repo = MarketDataRepository(pool=None)
+        new_from = repo._resolve_group_from_date(
+            FakeCH(seed), "shoonya", symbols,
+            lookback_days=365, overlap_days=3, full=False, today=today,
+        )
+
+        self.assertEqual(old_from, new_from)
+        self.assertEqual(old_from, date(2026, 7, 18) - timedelta(days=3))
+
+    def test_resolve_group_from_date_full_lookback_when_no_watermark(self):
+        today = date(2026, 7, 31)
+        new_from = MarketDataRepository(pool=None)._resolve_group_from_date(
+            FakeCH({}), "shoonya", ["NEWSYMBOL"],
+            lookback_days=365, overlap_days=3, full=False, today=today,
+        )
+        self.assertEqual(new_from, today - timedelta(days=365))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_repository_run_fetcher.py
+++ b/tests/test_repository_run_fetcher.py
@@ -162,6 +162,22 @@ class TestStocksSourceOverrideWatermark(unittest.TestCase):
         self.assertEqual(ch.get_watermark("nse", "RELIANCE", dataset="prices"), date(2026, 7, 30))
         self.assertIsNone(ch.get_watermark("shoonya", "RELIANCE", dataset="prices"))
 
+    def test_dry_run_count_matches_real_insert_count(self):
+        """dry-run must report the prices-only count insert() would really
+        write, not len(rows) across all four datasets combined — caught via
+        a live dry-run smoke test where stocks showed ~7x too many rows."""
+        from src.importer.fetchers.adapters import StocksFetcher
+
+        fetcher = StocksFetcher("stocks", [("RELIANCE", "RELIANCE.NS")])
+        rows = [
+            {"symbol": "RELIANCE", "trade_date": date(2026, 7, 30), "close": 100.0, "_dataset": "prices"},
+            {"symbol": "RELIANCE", "trade_date": date(2026, 7, 29), "close": 99.0, "_dataset": "prices"},
+            {"symbol": "RELIANCE", "earnings_date": date(2026, 7, 20), "_dataset": "earnings"},
+            {"symbol": "RELIANCE", "transaction_date": date(2026, 7, 15), "_dataset": "insider"},
+        ]
+
+        self.assertEqual(fetcher.count_insertable(rows), 2)
+
     def test_us_stocks_ignores_source_override(self):
         """us_stocks has no Shoonya/NSE presence — a --data-source override
         must not affect it, matching parallel_importer's hardcoded

--- a/tests/test_repository_run_fetcher.py
+++ b/tests/test_repository_run_fetcher.py
@@ -329,5 +329,134 @@ class TestMfHoldingsFetcher(unittest.TestCase):
         fake_ch.insert_mf_holdings.assert_called_once_with(rows)
 
 
+class TestFxRatesAndMfNavGroupWatermarkFix(unittest.TestCase):
+    """Regression coverage for a real bug found before wiring these into
+    cli.py: both fetchers were defined with a single symbol_key
+    ("FX_GROUP"/"ALL") that nothing ever writes a watermark row for, so
+    the single-watermark path would read wm=None forever and re-fetch full
+    history on every single run."""
+
+    def test_fx_rates_fetcher_exposes_group_symbols(self):
+        from src.importer.fetchers.adapters import FXRatesFetcher
+
+        fetcher = FXRatesFetcher()
+        self.assertTrue(fetcher.supports_parallel)
+        self.assertTrue(len(fetcher.symbols) > 0)
+
+    def test_mf_nav_fetcher_exposes_group_symbols(self):
+        from src.importer.fetchers.adapters import MFNavFetcher
+
+        fetcher = MFNavFetcher({"GOLDBEES": "140088", "NIFTYBEES": "140084"})
+        self.assertTrue(fetcher.supports_parallel)
+        self.assertEqual(set(fetcher.symbols), {("GOLDBEES", "140088"), ("NIFTYBEES", "140084")})
+
+    def test_group_watermark_path_used_not_single_symbol_key(self):
+        """Before the fix, run_fetcher would use fetcher.symbol_key ("FX_GROUP")
+        for the watermark, which nothing ever writes to. After the fix, it
+        must use _resolve_group_from_date/write_group_watermarks instead."""
+        from src.importer.fetchers.adapters import FXRatesFetcher
+
+        fetcher = FXRatesFetcher()
+        use_group_watermark = fetcher.supports_parallel and hasattr(fetcher, "symbols")
+        self.assertTrue(use_group_watermark)
+
+
+class TestCbReservesFetcher(unittest.TestCase):
+    @patch("src.importer.fetchers.imf_reserves_fetcher.fetch_cb_reserves")
+    def test_fetch_converts_from_date_to_year(self, mock_fetch):
+        from src.importer.fetchers.adapters import CbReservesFetcher
+
+        mock_fetch.return_value = []
+        CbReservesFetcher().fetch(date(2018, 6, 15), date(2026, 7, 31))
+
+        mock_fetch.assert_called_once_with(from_year=2018)
+
+    def test_max_date_uses_ref_period(self):
+        from src.importer.fetchers.adapters import CbReservesFetcher
+
+        rows = [
+            {"ref_period": date(2024, 12, 1), "country_code": "IN"},
+            {"ref_period": date(2025, 12, 1), "country_code": "US"},
+        ]
+        self.assertEqual(CbReservesFetcher().max_date(rows), date(2025, 12, 1))
+
+
+class TestEtfAumFetcher(unittest.TestCase):
+    @patch("src.importer.fetchers.etf_aum_fetcher.fetch_etf_aum")
+    def test_fetch_insert_max_date(self, mock_fetch):
+        from src.importer.fetchers.adapters import EtfAumFetcher
+
+        mock_fetch.return_value = [
+            {"symbol": "GLD", "trade_date": date(2026, 7, 31), "aum_usd": 1e9, "price": 100.0, "implied_tonnes": 10.0},
+        ]
+        fetcher = EtfAumFetcher()
+        rows = fetcher.fetch(date(2026, 7, 1), date(2026, 7, 31))
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(fetcher.max_date(rows), date(2026, 7, 31))
+
+        fake_ch = MagicMock()
+        fake_ch.insert_etf_aum.return_value = 1
+        self.assertEqual(fetcher.insert(rows, fake_ch), 1)
+        fake_ch.insert_etf_aum.assert_called_once_with(rows)
+
+
+class FakeFirstRunFetcher(Fetcher):
+    """Single-watermark fetcher declaring a first_run_lookback_days override."""
+
+    source_name = "first_run_test"
+    symbol_key = "X"
+    overlap_days = 0
+    first_run_lookback_days = 30
+
+    def fetch(self, from_date, to_date, *, source=None):
+        return [{"trade_date": to_date, "symbol": "X", "close": 1.0}]
+
+    def insert(self, rows, ch):
+        return len(rows)
+
+
+class TestFirstRunLookbackDays(unittest.TestCase):
+    def test_first_run_lookback_days_used_when_no_watermark(self):
+        """first_run_lookback_days overrides the caller's lookback_days only
+        for the "no watermark yet" branch — full=True must still honor the
+        caller's explicit lookback_days."""
+        ch = FakeCH({})
+        repo = MarketDataRepository(pool=None)
+
+        result = repo.run_fetcher(
+            FakeFirstRunFetcher(), dry_run=True, full=False, lookback_days=3650, ch=ch,
+        )
+
+        self.assertEqual(result.from_date, date.today() - timedelta(days=30))
+
+    def test_full_reimport_ignores_first_run_lookback_days(self):
+        ch = FakeCH({})
+        repo = MarketDataRepository(pool=None)
+
+        result = repo.run_fetcher(
+            FakeFirstRunFetcher(), dry_run=True, full=True, lookback_days=3650, ch=ch,
+        )
+
+        self.assertEqual(result.from_date, date.today() - timedelta(days=3650))
+
+    @patch("src.importer.fetchers.amfi_flows_fetcher.fetch_amfi_category_flows")
+    def test_amfi_flows_first_run_uses_24_months_not_120(self, mock_fetch):
+        """With first_run_lookback_days=730 set, a brand-new install's first
+        amfi_flows run should land near 24 months back, not ~120 (the
+        approximation this mechanism was added to remove)."""
+        from src.importer.fetchers.adapters import AmfiCategoryFlowsFetcher
+
+        mock_fetch.return_value = []
+        ch = FakeCH({})
+        repo = MarketDataRepository(pool=None)
+
+        repo.run_fetcher(AmfiCategoryFlowsFetcher(), dry_run=True, full=False, lookback_days=3650, ch=ch)
+
+        months_back = mock_fetch.call_args.kwargs["months_back"]
+        self.assertLess(months_back, 30)
+        self.assertGreaterEqual(months_back, 23)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_repository_run_fetcher.py
+++ b/tests/test_repository_run_fetcher.py
@@ -482,6 +482,43 @@ class TestFIIDIIFetcher(unittest.TestCase):
         mock_ch.insert_fii_dii_monthly.assert_called_once_with(mock_monthly.return_value)
 
 
+class TestMacroAndFlowFetchers(unittest.TestCase):
+    def test_world_bank_fetcher_insert_logging(self):
+        from src.importer.fetchers.adapters import WorldBankMacroFetcher
+        fetcher = WorldBankMacroFetcher()
+        mock_ch = MagicMock()
+        mock_ch.insert_macro_indicators.return_value = 1
+        rows = [{"ref_year": 2025, "country_code": "IN", "indicator_code": "NY.GDP.MKTP.KD.ZG", "value": 6.8}]
+
+        n = fetcher.insert(rows, mock_ch)
+        self.assertEqual(n, 1)
+        mock_ch.insert_macro_indicators.assert_called_once_with(rows)
+
+    def test_imf_weo_fetcher_insert_logging(self):
+        from src.importer.fetchers.adapters import IMFWEOFetcher
+        fetcher = IMFWEOFetcher()
+        mock_ch = MagicMock()
+        mock_ch.insert_macro_indicators.return_value = 1
+        today_year = date.today().year
+        rows = [{"ref_year": today_year, "country_code": "IN", "indicator_code": "NGDP_RPCH", "value": 6.5}]
+
+        n = fetcher.insert(rows, mock_ch)
+        self.assertEqual(n, 1)
+        mock_ch.insert_macro_indicators.assert_called_once_with(rows)
+
+    def test_amfi_category_flows_fetcher_insert_logging(self):
+        from src.importer.fetchers.adapters import AmfiCategoryFlowsFetcher
+        fetcher = AmfiCategoryFlowsFetcher()
+        mock_ch = MagicMock()
+        mock_ch.insert_amfi_category_flows.return_value = 1
+        rows = [{"report_month": date(2026, 6, 1), "category_name": "Small Cap Fund", "net_flow_cr": 2450.0, "closing_aum_cr": 35000.0}]
+
+        n = fetcher.insert(rows, mock_ch)
+        self.assertEqual(n, 1)
+        mock_ch.insert_amfi_category_flows.assert_called_once_with(rows)
+
+
 if __name__ == "__main__":
     unittest.main()
+
 


### PR DESCRIPTION
## Why This Change Was Done (Architecture & Motivation)

```
BEFORE (Fragmented Ingestion)                   AFTER (Unified Architecture)

[ CLI / UI / Agent Request ]                   [ CLI / UI / Agent Request ]
       │                      │                               │
       ├──────────────┐       │                               ▼
       ▼              ▼       │                  Unified registry_categories
 FETCHER_REGISTRY  Hand-rolled│                               │
     Loop           Blocks    │                               ▼
       │              │       │                  FETCHER_REGISTRY[category]
       ▼              ▼       │                               │
 run_fetcher()     Direct DB  │                               ▼
       │            Insert    │               MarketDataRepository.run_fetcher()
       ▼            (No Bus!❌)│                 ├── Centralized Watermark & Overlap
 DataImportedEvent            │                 ├── fetcher.fetch() + validate()
       │                      │                 ├── Bulk Insert to ClickHouse
┌──────┼──────┐               │                 └── Fire DataImportedEvent (Event Bus)
▼      ▼      ▼               │                               │
ML   Signal Sanity            │                 ┌─────────────┼─────────────┐
                              │                 ▼             ▼             ▼
                              │             ML Observer Signal Observer Sanity Observer
```

### Core System Benefits:
1. **Architectural Uniformity & Single Source of Truth**:  
   Previously, data ingestion was split between the declarative `FETCHER_REGISTRY` adapter pipeline and legacy hand-rolled `if "category" in categories:` blocks in `cli.py`. Unifying 100% of general data categories behind the `Fetcher` ABC establishes a single, consistent architecture across the entire data ingestion pipeline.

2. **Observer Event Bus Coverage**:  
   `MarketDataRepository.run_fetcher()` centrally handles watermark lookups, overlap calculations, dry-runs, error boundaries, and post-import `DataImportedEvent` publishing. Hand-rolled blocks in `cli.py` bypassed observer event notifications — preventing automated ML retraining, anomaly attribution, and composite score recalculations for `fii_dii`, `world_bank`, `imf_weo`, and `amfi_flows`.

3. **Fixing Latent Data & Formatting Bugs**:  
   - `FIIDIIFetcher` previously called `fetch_fii_dii_fno()` without a `from_date` during side-effect inserts, defaulting to current-month-only data. Stashing `from_date` on `fetch()` ensures F&O derivative OI data syncs across the exact same delta-sync window as cash market flows.
   - Fixed Python `%`-style format string specifiers (`%+,.0f` -> `ValueError: unsupported format character ','`) in logging statements across `adapters.py`.

4. **Codebase Simplification**:  
   Eliminated dead helper functions (`_resolve_from_date`, `_update_watermarks`) and **-175 net lines** of duplicate boilerplate code from `cli.py`.

---

## How to Add a New Fetcher (Developer Guide)

Adding a new data source now takes only **2 steps**:

### Step 1: Subclass `Fetcher` in `src/importer/fetchers/adapters.py`
Implement `fetch()`, `validate()`, `insert()`, and `max_date()`:

```python
class MyNewDataFetcher(Fetcher):
    source_name  = "my_source"
    symbol_key   = "ALL"
    description  = "My New Feed"
    overlap_days = 1

    def fetch(self, from_date: date, to_date: date) -> list[dict[str, Any]]:
        return fetch_my_data(from_date=from_date, to_date=to_date)

    def validate(self, rows: list[dict]) -> list[dict]:
        return [r for r in rows if r.get("value") is not None]

    def insert(self, rows: list[dict], ch) -> int:
        return ch.insert_my_table(rows)

    def max_date(self, rows: list[dict]) -> date:
        return max(r["trade_date"] for r in rows)
```

### Step 2: Register in `_build_registry()` inside `adapters.py`
```python
registry["my_category"] = MyNewDataFetcher()
```

That's it! CLI imports (`python src/main.py import --category my_category`), delta-sync watermarks, dry-run mode, and Event Bus observer notifications work automatically.

---

## Summary of Phases

**Phase 0–3**: `stocks`/`us_stocks`/`etfs`/`commodities`/`indices`/`nse_indices` unified behind `get_registry()`, collapsing `cli.py::run_import()`'s per-category branching into one loop. New `StocksFetcher` ports `parallel_importer`'s per-symbol prices+earnings+insider+valuation fetch into the `Fetcher` ABC, preserving per-symbol watermark independence and `--data-source` override propagation.

**Phase 4**: `mf_holdings`/`nse_eod`/`amfi_flows`/`indian_macro` migrated. `mf_holdings` keeps its idempotency guard in `cli.py` (a presence check, not delta-sync logic). `Fetcher` gained a `dataset` class attribute for `amfi_flows`' non-default watermark bucket.

**Phase 5 (Complete Unification)**:
- `fii_dii`, `world_bank`, `imf_weo`, and `amfi_flows` fully migrated into `FETCHER_REGISTRY` and the `registry_categories` loop in `cli.py`.
- **F&O Date Stashing**: Stashed `from_date` in `FIIDIIFetcher.fetch()` to pass down to `fetch_fii_dii_fno(from_date=fno_from)`.
- **Format String Fixes**: Fixed invalid `%`-style format strings (`%+,.0f` -> `%s` with pre-formatted f-strings) in `FIIDIIFetcher` and `AmfiCategoryFlowsFetcher`.
- **Code Cleanup**: Removed legacy helper functions `_resolve_from_date` and `_update_watermarks` from `cli.py` (-175 net lines).
- **Documentation & Unit Tests**: Updated `import-schema.md`, `CLAUDE.md`, `data-engineering-importer/SKILL.md`, and added `TestFIIDIIFetcher` + `TestMacroAndFlowFetchers` in `test_repository_run_fetcher.py`.

## Test Plan
- [x] `pytest tests/` — full test suite: 503 passed, 4 skipped (pre-existing Shoonya-auth skips). Unit tests include `TestFIIDIIFetcher` and `TestMacroAndFlowFetchers` in `test_repository_run_fetcher.py` verifying `fetch()`, `_last_from_date` stashing, and `insert()` logic across all migrated fetchers.
- [x] **Live API Dry-Run Verification**: Executed `python src/main.py import --category fii_dii,world_bank,imf_weo,amfi_flows --dry-run` — fetched live records from Sensibull, World Bank WDI, IMF DataMapper, and AMFI portals against ClickHouse watermarks.
- [x] **Log Formatter Unit Verification**: Executed `TestFIIDIIFetcher` and `TestMacroAndFlowFetchers` verifying zero `%`-formatting exceptions across all fetcher log lines.
