### PR TITLE
fix(ui): guard empty-result columns in MF Holdings tab

### DIFF
--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -2860,8 +2860,12 @@ with tab_holdings:
         ORDER BY fund_name, pct_of_nav DESC
         """
     )
-    _hold_df.columns = ["scheme_code", "fund_name", "isin", "security_name",
-                        "asset_type", "market_value_cr", "pct_of_nav"]
+    _HOLD_COLS = ["scheme_code", "fund_name", "isin", "security_name",
+                  "asset_type", "market_value_cr", "pct_of_nav"]
+    if _hold_df.empty:
+        _hold_df = pd.DataFrame(columns=_HOLD_COLS)
+    else:
+        _hold_df.columns = _HOLD_COLS
 
     # ── Fallback: for funds with no data in selected month, load their latest ─
     _sel_month_label = selected_month.strftime("%b %Y") if hasattr(selected_month, "strftime") else str(selected_month)[:7]


### PR DESCRIPTION
## Summary
- Fixes a crash in the 📦 MF Holdings tab: `ValueError: Length mismatch: Expected axis has 0 elements, new values have 7 elements`
- The default month selector picks the most recent month across the whole `mf_holdings` table, which can belong to funds unrelated to this tab (e.g. `BAJAJ_FINSERV_*`). When none of the tab's 5 funds have data for that month, the query returns 0 rows, and `clickhouse_connect` returns a 0-column DataFrame — the unconditional `.columns = [...]` assignment then failed (0 ≠ 7).
- Reported as "UI giving DB error" — ClickHouse itself was healthy the whole time; this was a pure application-side bug on the empty-result path.
- Fix guards the assignment so an empty result gets a DataFrame with the correct named (but empty) columns, matching the pattern already used everywhere else in this file, and letting the existing "load latest available month per fund" fallback logic run as intended.

## Test plan
- [x] Verified against the live container: reproduced the exact 0-row query via `clickhouse_connect`, confirmed it returns `(0, 0)` shape before the fix and `(0, 7)` with `fund_name` accessible after
- [x] Restarted `ofin-agent-ui-1` (src is bind-mounted) and confirmed no `ValueError`/traceback in logs post-restart
- [ ] Manually reload the MF Holdings tab in browser and confirm it shows the fallback-month notice instead of a crash
- [ ] Spot-check a month/fund combo with data still renders holdings table, pie charts, and drift sections correctly