### PR TITLE
fix(whale-scanner): fix AMC grouping, month alignment, and debt leakage

### DIFF
--- a/src/scripts/portfolio/whale_accumulation_scanner.py
+++ b/src/scripts/portfolio/whale_accumulation_scanner.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -47,14 +48,35 @@ def _is_passive(fund_name: str) -> bool:
     return any(kw in fu for kw in _PASSIVE_KEYWORDS)
 
 
+# ── Debt-instrument name patterns ──────────────────────────────────────────────
+# mf_holdings.asset_type is stamped per-fund at import time (the fund's own
+# category), not per-holding — so equity-oriented funds that also carry a small
+# G-Sec/NCD sleeve have those debt lines mislabeled asset_type='equity'. Filter
+# them out by name pattern since the asset_type column can't be trusted here.
+_DEBT_NAME_RE = re.compile(
+    r"^[0-9]+\.[0-9]+%\s|Govt Stock|T-Bill|\(\d{2}/\d{2}/\d{4}\)"
+)
+
+
+def _is_debt_instrument(security_name: str) -> bool:
+    return bool(_DEBT_NAME_RE.search(security_name))
+
+
 def _get_amc_group(fund_name: str) -> str:
+    """Derive the parent AMC group from a fund_name's BRAND_SCHEME naming convention.
+
+    fund_name is always BRAND_SCHEME_TYPE (e.g. HDFC_FLEXI_CAP, BAJAJ_FINSERV_LIQUID_FUND),
+    so the brand token is a reliable, self-updating group key — no hardcoded whitelist needed
+    (a whitelist previously collapsed every non-listed AMC, including HDFC/Kotak/SBI, into a
+    single meaningless 'OTHER' bucket, undercounting true cross-AMC consensus).
+
+    Historical Reliance Mutual Fund filings (pre-2019 rename) are folded into NIPPON so the
+    same AMC's holdings aren't split across the brand change.
+    """
     fn = fund_name.upper()
-    if fn.startswith("DSP"):     return "DSP"
-    if fn.startswith("NIPPON"):  return "NIPPON"
-    if fn.startswith("BAJAJ"):   return "BAJAJ"
-    if fn.startswith("ICICI"):   return "ICICI"
-    if fn.startswith("QUANT"):   return "QUANT"
-    return "OTHER"
+    if fn.startswith("RELIANCE"):
+        return "NIPPON"
+    return fn.split("_")[0]
 
 
 # ── AMFI category flow context ────────────────────────────────────────────────
@@ -162,6 +184,7 @@ def run_whale_scan(
     # ── 2. Assign AMC group + drop passive funds ──────────────────────────────
     df_raw["amc_group"] = df_raw["fund_name"].apply(_get_amc_group)
     df_raw = df_raw[~df_raw["fund_name"].apply(_is_passive)].copy()
+    df_raw = df_raw[~df_raw["security_name"].apply(_is_debt_instrument)].copy()
 
     if df_raw.empty:
         return {"error": "No active equity holdings after passive fund filter.",
@@ -169,15 +192,32 @@ def run_whale_scan(
 
     df_raw["as_of_month"] = pd.to_datetime(df_raw["as_of_month"])
 
-    # ── 3. Identify latest and comparison month ───────────────────────────────
-    all_months = sorted(df_raw["as_of_month"].unique())
-    latest_month = all_months[-1]
-    # Find the comparison month: closest to `lookback_months` ago
-    target_prev = latest_month - pd.DateOffset(months=lookback_months)
-    prev_month = min(all_months, key=lambda m: abs((m - target_prev).days))
+    # ── 3. Identify latest and comparison month (by calendar month) ──────────
+    # Different AMCs snapshot on different calendar days (1st, 15th, month-end),
+    # so comparing by *exact* as_of_month date starves the scan of cross-AMC
+    # breadth whenever one family's snapshot date happens to be globally latest
+    # (e.g. only BAJAJ_FINSERV_* funds report on the 15th while every other AMC
+    # reports on the 1st/month-end — the exact-date max used to resolve to a
+    # date where only one AMC group had any data at all).  Bucket to calendar
+    # month instead so every AMC's most recent snapshot in that month counts.
+    df_raw["report_month"] = df_raw["as_of_month"].values.astype("datetime64[M]")
+    all_report_months = sorted(df_raw["report_month"].unique())
+    latest_report_month = all_report_months[-1]
+    target_prev = pd.Timestamp(latest_report_month) - pd.DateOffset(months=lookback_months)
+    prev_report_month = min(all_report_months, key=lambda m: abs((pd.Timestamp(m) - target_prev).days))
 
-    df_latest = df_raw[df_raw["as_of_month"] == latest_month].copy()
-    df_prev   = df_raw[df_raw["as_of_month"] == prev_month].copy()
+    def _latest_per_fund(df: pd.DataFrame, report_month) -> pd.DataFrame:
+        """Within a calendar month, keep each fund's most recent snapshot
+        (guards against rare double-imports/backfills landing in the same month)."""
+        sub = df[df["report_month"] == report_month]
+        idx = sub.groupby("fund_name")["as_of_month"].idxmax()
+        return sub.loc[idx].copy()
+
+    df_latest = _latest_per_fund(df_raw, latest_report_month)
+    df_prev   = _latest_per_fund(df_raw, prev_report_month)
+
+    latest_month = pd.Timestamp(latest_report_month)
+    prev_month   = pd.Timestamp(prev_report_month)
 
     # ── 4. Aggregate per security_name × amc_group per month ─────────────────
     def _agg(df: pd.DataFrame) -> pd.DataFrame:

--- a/src/tools/whale_tools.py
+++ b/src/tools/whale_tools.py
@@ -177,9 +177,11 @@ def get_whale_consensus(symbol: str) -> str:
             "spelling may differ (try NSE symbol, e.g. 'SANSERA')."
         )
 
-    # Filter passives
-    from src.scripts.portfolio.whale_accumulation_scanner import _is_passive, _get_amc_group
+    # Filter passives and debt instruments (asset_type is stamped per-fund at
+    # import time, not per-holding, so G-Sec/NCD lines can leak in as 'equity')
+    from src.scripts.portfolio.whale_accumulation_scanner import _is_passive, _get_amc_group, _is_debt_instrument
     df = df[~df["fund_name"].apply(_is_passive)].copy()
+    df = df[~df["security_name"].apply(_is_debt_instrument)].copy()
     if df.empty:
         return f"No **active** fund holdings found for **{symbol}** (only passive/index funds hold it)."
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -6249,7 +6249,7 @@ with tab_whale:
         with _wh_col1:
             _wh_amc = st.selectbox(
                 "AMC Filter",
-                options=["all", "dsp", "nippon", "bajaj", "icici", "quant"],
+                options=["all", "dsp", "nippon", "bajaj", "icici", "quant", "hdfc", "kotak", "sbi"],
                 index=0,
                 key="whale_amc",
             )


### PR DESCRIPTION
## Summary
Fixes the 🐋 Cross-AMC Whale Accumulation Scanner tab, reported as showing incorrect data. Root-caused to **three independent bugs** in `src/scripts/portfolio/whale_accumulation_scanner.py`:

1. **AMC misclassification** — `_get_amc_group()` only recognized 5 hardcoded prefixes (DSP/Nippon/Bajaj/ICICI/Quant). Every other AMC — including HDFC (25 funds), Kotak (9), SBI (1), all with live current-month data — was collapsed into a generic `"OTHER"` bucket, undercounting true cross-AMC consensus and defeating the tool's entire premise ("multiple independent AMC funds simultaneously building positions"). Now derives the AMC generically from the fund_name's `BRAND_SCHEME` naming convention, with a `RELIANCE→NIPPON` alias for pre-2019-rename historical continuity.
2. **Empty results from a date mismatch** — the scanner picked the single globally-latest `as_of_month` across the whole table. Different AMCs snapshot on different calendar days (1st, 15th, month-end), so "latest" often resolved to a date where only one debt-oriented fund family (`BAJAJ_FINSERV_*`, reporting on the 15th) had any data, while every target multi-asset fund reports on the 1st/month-end — starving the scan of any real overlap and silently returning empty results. Now buckets by calendar month instead of exact date.
3. **Debt instruments leaking into an equity-only scan** — `market_data.mf_holdings.asset_type` is stamped per-fund at import time (the fund's own category), not per-holding, so equity funds with a small G-Sec/NCD sleeve had those lines mislabeled `asset_type='equity'` (~2% of rows). Added a name-pattern filter (coupon-rate prefix, `Govt Stock`, maturity-date-in-parens) since `asset_type` can't be trusted here.

Also applied the debt-instrument filter to `get_whale_consensus()` in `src/tools/whale_tools.py` for consistency (same underlying data issue, different consumer), and added `hdfc`/`kotak`/`sbi` to the UI's AMC filter dropdown now that they're properly recognized.

## Test plan
- [x] Verified against live ClickHouse data: before the fix, `run_whale_scan(amc='all', min_amcs=2)` returned **zero** top accumulators; after, Reliance Industries correctly shows as held by **5 independent AMCs** (BAJAJ, HDFC, ICICI, QUANT, SBI; ₹8,273 Cr aggregate) instead of an empty scan or a meaningless single `'OTHER'` label
- [x] Confirmed government bonds/NCDs (e.g. `"6.75% Govt Stock 2033"`, `"6.52% REC Limited (31/01/2028)"`) no longer appear in `top_by_value`
- [x] Confirmed `get_whale_consensus.invoke({"symbol": "RELIANCE"})` returns clean, sensible per-fund breakdown across 26 funds / 6 AMC groups
- [ ] Manually load the 🐋 Whale Scanner tab and run a scan with default params to confirm the UI renders correctly end-to-end