### PR TITLE
feat: add kubernetes manifests and implement qdrant batch upserts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,7 @@ data/*
 # has no regenerator, so it must be tracked or it silently vanishes on deletion.
 !data/news_quality_exemplars.json
 
+# Local Kubernetes Secrets
+mosaic-secrets.yaml
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -209,7 +209,7 @@ services:
     ports:
       - "8502:8502"
     volumes:
-      - ./output:/app/output ────────────────────────────────────────────────
+      - ./output:/app/output
   # Temporarily removed from compose (2026-07-01) — see git history to restore.
   # Was: serves the visual AI research workspace at http://localhost:8502,
   # built via the studio-builder stage in the Dockerfile.

--- a/mosaic-k8s.yaml
+++ b/mosaic-k8s.yaml
@@ -90,6 +90,13 @@ spec:
               value: market_data
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
+          resources:
+            requests:
+              cpu: "1"
+              memory: "2Gi"
+            limits:
+              cpu: "2"
+              memory: "4Gi"
           volumeMounts:
             - name: clickhouse-storage
               mountPath: /var/lib/clickhouse
@@ -190,6 +197,10 @@ spec:
           image: ollama/ollama:latest
           ports:
             - containerPort: 11434
+          # To enable GPU acceleration in cloud/GPU clusters, uncomment the block below:
+          # resources:
+          #   limits:
+          #     nvidia.com/gpu: "1"
           volumeMounts:
             - name: ollama-storage
               mountPath: /root/.ollama
@@ -246,9 +257,8 @@ spec:
               mountPath: /app/output
       volumes:
         - name: shared-output
-          hostPath:
-            path: /tmp/mosaic-output
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: shared-output-pvc
 ---
 # Mosaic Files Service & Deployment
 apiVersion: v1
@@ -292,6 +302,18 @@ spec:
               mountPath: /app/output
       volumes:
         - name: shared-output
-          hostPath:
-            path: /tmp/mosaic-output
-            type: DirectoryOrCreate
+          persistentVolumeClaim:
+            claimName: shared-output-pvc
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: shared-output-pvc
+  namespace: mosaic
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: standard

--- a/mosaic-k8s.yaml
+++ b/mosaic-k8s.yaml
@@ -1,0 +1,297 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mosaic
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mosaic-config
+  namespace: mosaic
+data:
+  LLM_PROVIDER: "anthropic"
+  LLM_MODEL: "claude-3-5-sonnet-20241022"
+  LLM_TEMPERATURE: "1.0"
+  LLM_CONTEXT_WINDOW: "200000"
+  KITE_MCP_URL: "https://mcp.kite.trade/mcp"
+  KITE_MCP_TIMEOUT: "30"
+  NEWS_ARTICLES_PER_STOCK: "5"
+  NEWS_LOOKBACK_DAYS: "7"
+  NEWSAPI_CACHE_TTL_SECONDS: "3600"
+  LOG_LEVEL: "INFO"
+  MAX_HOLDINGS_PER_RUN: "0"
+  SCRAPE_DELAY_SECONDS: "2"
+  COMEX_CACHE_TTL_SECONDS: "3600"
+  CLICKHOUSE_HOST: "clickhouse"
+  CLICKHOUSE_PORT: "8123"
+  CLICKHOUSE_DATABASE: "market_data"
+  CLICKHOUSE_USER: "default"
+  QDRANT_HOST: "qdrant"
+  QDRANT_PORT: "6333"
+  OLLAMA_HOST: "http://ollama:11434"
+  OUTPUT_DIR: "/app/output"
+  LLM_LOCAL_DISABLED: "false"
+  LLM_CACHE_ENABLED: "true"
+  LLM_CACHE_TTL_HOURS: "24"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ollama-pvc
+  namespace: mosaic
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+---
+# ClickHouse Service & StatefulSet
+apiVersion: v1
+kind: Service
+metadata:
+  name: clickhouse
+  namespace: mosaic
+spec:
+  ports:
+    - name: http
+      port: 8123
+      targetPort: 8123
+    - name: tcp
+      port: 9000
+      targetPort: 9000
+  selector:
+    app: clickhouse
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: clickhouse
+  namespace: mosaic
+spec:
+  serviceName: clickhouse
+  replicas: 1
+  selector:
+    matchLabels:
+      app: clickhouse
+  template:
+    metadata:
+      labels:
+        app: clickhouse
+    spec:
+      containers:
+        - name: clickhouse
+          image: clickhouse/clickhouse-server:24-alpine
+          ports:
+            - containerPort: 8123
+            - containerPort: 9000
+          env:
+            - name: CLICKHOUSE_DB
+              value: market_data
+            - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
+              value: "1"
+          volumeMounts:
+            - name: clickhouse-storage
+              mountPath: /var/lib/clickhouse
+  volumeClaimTemplates:
+    - metadata:
+        name: clickhouse-storage
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 5Gi
+---
+# Qdrant Service & StatefulSet
+apiVersion: v1
+kind: Service
+metadata:
+  name: qdrant
+  namespace: mosaic
+spec:
+  ports:
+    - name: rest
+      port: 6333
+      targetPort: 6333
+    - name: grpc
+      port: 6334
+      targetPort: 6334
+  selector:
+    app: qdrant
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: qdrant
+  namespace: mosaic
+spec:
+  serviceName: qdrant
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qdrant
+  template:
+    metadata:
+      labels:
+        app: qdrant
+    spec:
+      containers:
+        - name: qdrant
+          image: qdrant/qdrant:latest
+          ports:
+            - containerPort: 6333
+            - containerPort: 6334
+          env:
+            - name: QDRANT_SERVICE__MAX_REQUEST_SIZE_MB
+              value: "128"
+          volumeMounts:
+            - name: qdrant-storage
+              mountPath: /qdrant/storage
+  volumeClaimTemplates:
+    - metadata:
+        name: qdrant-storage
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: 2Gi
+---
+# Ollama Service & Deployment
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: mosaic
+spec:
+  ports:
+    - name: api
+      port: 11434
+      targetPort: 11434
+  selector:
+    app: ollama
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: mosaic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ollama
+  template:
+    metadata:
+      labels:
+        app: ollama
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:latest
+          ports:
+            - containerPort: 11434
+          volumeMounts:
+            - name: ollama-storage
+              mountPath: /root/.ollama
+      volumes:
+        - name: ollama-storage
+          persistentVolumeClaim:
+            claimName: ollama-pvc
+---
+# Mosaic UI Service & Deployment
+apiVersion: v1
+kind: Service
+metadata:
+  name: ui
+  namespace: mosaic
+spec:
+  type: NodePort
+  ports:
+    - name: streamlit
+      port: 8501
+      targetPort: 8501
+      nodePort: 30501
+  selector:
+    app: ui
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ui
+  namespace: mosaic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ui
+  template:
+    metadata:
+      labels:
+        app: ui
+    spec:
+      containers:
+        - name: ui
+          image: mosaic-fund-agent:latest
+          imagePullPolicy: Never
+          command: ["streamlit", "run", "src/ui/app.py", "--server.address=0.0.0.0", "--server.port=8501", "--server.headless=true"]
+          ports:
+            - containerPort: 8501
+          envFrom:
+            - configMapRef:
+                name: mosaic-config
+            - secretRef:
+                name: mosaic-secrets
+          volumeMounts:
+            - name: shared-output
+              mountPath: /app/output
+      volumes:
+        - name: shared-output
+          hostPath:
+            path: /tmp/mosaic-output
+            type: DirectoryOrCreate
+---
+# Mosaic Files Service & Deployment
+apiVersion: v1
+kind: Service
+metadata:
+  name: files
+  namespace: mosaic
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8502
+      targetPort: 8502
+      nodePort: 30502
+  selector:
+    app: files
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: files
+  namespace: mosaic
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: files
+  template:
+    metadata:
+      labels:
+        app: files
+    spec:
+      containers:
+        - name: files
+          image: python:3.11-slim
+          command: ["python", "-m", "http.server", "8502", "--directory", "/app/output/reports"]
+          ports:
+            - containerPort: 8502
+          volumeMounts:
+            - name: shared-output
+              mountPath: /app/output
+      volumes:
+        - name: shared-output
+          hostPath:
+            path: /tmp/mosaic-output
+            type: DirectoryOrCreate

--- a/mosaic.sh
+++ b/mosaic.sh
@@ -32,13 +32,11 @@ fi
 if [[ $# -eq 0 ]]; then
     # Check if a local Ollama instance is already running on the host
     if curl -s -I http://localhost:11434/ >/dev/null 2>&1; then
-        echo "Local Ollama detected running on host. Building and starting clickhouse + qdrant + ui + files + studio..."
-        docker compose build studio 2>/dev/null
-        docker compose up -d clickhouse qdrant ui files studio 2>/dev/null
+        echo "Local Ollama detected running on host. Building and starting clickhouse + qdrant + ui + files..."
+        docker compose up -d --build clickhouse qdrant ui files 2>/dev/null
     else
         echo "Starting services (pulling local embedding models on first run — grab a coffee)..."
-        docker compose build studio
-        docker compose up -d clickhouse qdrant ollama ui files studio
+        docker compose up -d --build clickhouse qdrant ollama ui files
         docker compose run --rm ollama-init || true   # no-op if already done
     fi
     echo ""

--- a/src/db/market_vector.py
+++ b/src/db/market_vector.py
@@ -140,8 +140,11 @@ def _upsert(points: list[Any]) -> None:
     if client is None or not _ensure_collection():
         return
     try:
-        client.upsert(collection_name=_COLLECTION, points=points)
-        log.debug("MarketVector: upserted %d points", len(points))
+        batch_size = 500
+        for i in range(0, len(points), batch_size):
+            batch = points[i : i + batch_size]
+            client.upsert(collection_name=_COLLECTION, points=batch)
+        log.debug("MarketVector: upserted %d points in batches", len(points))
     except Exception as e:
         log.warning("MarketVector: upsert failed: %s", e)
 


### PR DESCRIPTION
## Summary
This PR adds full Kubernetes deployment manifests for all Mosaic services and implements batching in the Qdrant database upsert function to prevent large payload failures.

### Changes
* **Kubernetes**: Added `mosaic-k8s.yaml` containing configurations for:
  - `mosaic` Namespace
  - `mosaic-config` ConfigMap for core app environment variables
  - ClickHouse StatefulSet & Service (alpine image, 5Gi persistent volume)
  - Qdrant StatefulSet & Service (latest image, 2Gi persistent volume)
  - Ollama Deployment & Service (10Gi persistent volume)
  - Streamlit UI Deployment & NodePort Service
  - Files Server Deployment & NodePort Service (serving output/reports directory)
* **Database**: Implemented batch upserts (chunk size 500) in `src/db/market_vector.py` to prevent HTTP payload size limit errors during large data insertions into Qdrant.
* **Docker/Compose**: Excluded the `studio` container from the active services in `docker-compose.yml` and `mosaic.sh`.
* **Git**: Added `mosaic-secrets.yaml` to `.gitignore` to prevent local K8s secrets from being tracked/committed.