### PR TITLE
fix: chart rendering pipeline, routing fixes, and skill visualization docs

### DIFF
--- a/.agents/skills/intraday/SKILL.md
+++ b/.agents/skills/intraday/SKILL.md
@@ -31,3 +31,6 @@ ALLOW_LOCAL_RUN=1 python src/agents/intraday_agent.py --symbol <SYMBOL> --interv
 
 ### Prompt-Driven Execution
 When the user invokes `/intraday <SYMBOL>`, execute the command with a default `--interval 5 --duration 15` to capture multiple tick frames and print the resulting dashboard verbatim.
+
+### Terminal ASCII Chart Output
+For terminal visualization, stream 5-minute VWAP deviation bands and cumulative delta bars using `plotext` or `render_sparkline()` from `src.tools.chart_tools`.

--- a/.agents/skills/stock-anomaly-news/SKILL.md
+++ b/.agents/skills/stock-anomaly-news/SKILL.md
@@ -29,12 +29,15 @@ Run the consolidated script inside Docker:
 - `--z-threshold` (optional): Raw GARCH residual Z-score cutoff (default `5.0`).
 - `--contamination` (optional): Isolation Forest outlier contamination rate (default `0.01`).
 
-## Output Files
+## Output Files & ASCII Visualizations
 
 The script generates a comprehensive markdown report in the output directory:
 - Report Path: `output/<symbol>_anomaly_report.md`
 - Visual timeline plots are saved to `output/reports/<SYMBOL>_correlation_timeline.png`
 - Lead-lag grids are saved to `output/reports/<SYMBOL>_lead_lag_grid.png`
+
+### Terminal ASCII Chart Integration
+For interactive CLI responses or inline summary reports, call `plot_price_chart(symbol, days)` or `render_sparkline(prices)` from `src.tools.chart_tools` to render ASCII candlestick charts and volume spike flags directly in the terminal output.
 
 ## Framework for Interpreting Results
 

--- a/config/agents/india_equity.yaml
+++ b/config/agents/india_equity.yaml
@@ -24,6 +24,11 @@ steps:
         params:
           symbol: "{{ symbol }}"
         fail_on_error: false
+      - tool_name: plot_price_chart
+        params:
+          symbol: "{{ symbol }}"
+          days: 365
+        fail_on_error: false
       - tool_name: get_nse_announcements
         params:
           input_str: "{{ symbol }}"
@@ -136,6 +141,9 @@ steps:
 
       ### Market Metrics (Yahoo Finance)
       {{ batch_enrichment.get_yahoo_finance_data }}
+
+      ### 1-Year Price Chart
+      [CHART:price]
 
       ## 2. Price Momentum & Technical
       {{ batch_enrichment.get_price_momentum }}

--- a/src/agents/declarative/declarative_runner.py
+++ b/src/agents/declarative/declarative_runner.py
@@ -295,8 +295,18 @@ class DeclarativeAgentRunner:
             return {"prompt": rendered_prompt, "output": err_msg, "status": "error"}
 
     def _execute_template_output(self, step: StepSpec, ctx: ContextRun) -> dict[str, Any]:
-        """Execute a template_output report rendering step."""
+        """Execute a template_output report rendering step.
+
+        After rendering, substitutes any [CHART:xxx] placeholders with the real
+        chart strings a `plot_*` tool call saved during this run (same
+        convention as `src/workflows/base.py::_render_report` and
+        `src/agents/sub_agents/base.py` — see those for the LLM-driven variants).
+        Declarative playbooks render deterministically via Jinja2, so no
+        box-drawing cleanup pass is needed here.
+        """
         rendered = self.render_string(step.template or "", ctx)
+        from src.tools.chart_tools import inject_chart_placeholders
+        rendered = inject_chart_placeholders(rendered)
         return {"output": rendered, "format": step.format, "status": "completed"}
 
     def _execute_use_tools(self, step: StepSpec, ctx: ContextRun) -> dict[str, Any]:
@@ -380,6 +390,11 @@ class DeclarativeAgentRunner:
 
     def run(self, input_params: dict[str, Any] | None = None) -> dict[str, Any]:
         """Execute the complete declarative agent playbook."""
+        try:
+            from src.tools.chart_tools import get_active_charts
+            get_active_charts().clear()
+        except Exception:
+            pass
         ctx = ContextRun(input_params=input_params or {})
 
         # Apply sample_input defaults if not provided

--- a/src/agents/mosaic_fund_agent.py
+++ b/src/agents/mosaic_fund_agent.py
@@ -323,6 +323,7 @@ AGENT_SYSTEM_PROMPT = (
     "  • Mutual Funds (MF): Use `analyze_mf_sectors` for sector breakdowns, `detect_amc_sector_rotation` for MoM/YoY rotation detection, `explain_rotation_thesis` for investment thesis rationale, `audit_exhaustive_stock_shifts` for 100% complete additions/subtractions audit, and `display_master_amc_dashboard` for full visual executive CLI dashboards. For whale-tracking or single-fund deep dives, call `delegate_to_mf_agent`.\n"
     "  • Single-stock / company research (price, financials, quarterly results, news, MF ownership): call `run_india_equity_research_workflow` — it runs 12 data-fetch tools in parallel and returns a full 8-section note for NSE/BSE stocks.\n"
     "  • Importing Stocks/ETFs: The import tools reuse the user's saved data source for 24 hours. If a tool returns `DATA_SOURCE_REQUIRED`, ask the user which source to use: 1. Shoonya, 2. NSE, or 3. yfinance, then retry with `data_source`. Never choose a source on the user's behalf. If the user names a SPECIFIC symbol (e.g. 'import ADVENZYMES', 'refresh GOLDBEES'), call `import_symbol_data(symbol, data_source=...)` — never `run_data_engineering_importer` for a single symbol. Only use `run_data_engineering_importer(category='stocks', data_source=...)` when the user asks to import ALL stocks generically without naming one. When the user specifies a particular year (e.g. '2019'), date, or month range, parse the dates and pass them as `start_date` (format YYYY-MM-DD) and `end_date` (format YYYY-MM-DD) parameters to `import_symbol_data` and `plot_price_chart` (e.g. for year 2019, `start_date='2019-01-01'` and `end_date='2019-12-31'`).\n"
+    "  • Charts & Visualizations: Use `plot_price_chart`, `plot_candlestick_chart`, `plot_multi_price_chart`, `plot_fii_dii_chart`, or `plot_macd_chart` whenever asked for price trends, technical charts, or visual analysis. These tools return a `[CHART:xxx]` placeholder token (e.g. `[CHART:price]`) plus a data table — write that exact token verbatim on its own line in your final answer where the chart should appear; it gets replaced with the real high-density ASCII chart. Never invent, retype, or paraphrase chart content yourself.\n"
     "  • News sweeps / sentiment: call `delegate_to_news_agent`.\n"
     "  • Macro / COMEX / FII-DII flows: call `delegate_to_macro_agent`.\n"
     "  • International ETFs (MAFANG, HNGSNGBEES, MON100, etc.): call `delegate_to_intl_etf_agent`.\n"
@@ -1022,6 +1023,8 @@ class MosaicFundAgent:
             if not msgs:
                 return "No answer generated."
             
+            from src.tools.chart_tools import inject_chart_placeholders
+
             # Search from the end for the first message with text content that isn't just a tool call
             for m in reversed(msgs):
                 # If it's an AIMessage, it might have content or tool_calls
@@ -1030,13 +1033,13 @@ class MosaicFundAgent:
                     if isinstance(content, list):
                         texts = [block.get("text", "") for block in content if isinstance(block, dict) and block.get("type") == "text"]
                         if texts:
-                            return "\n".join(texts)
+                            return inject_chart_placeholders("\n".join(texts))
                     elif isinstance(content, str) and content.strip():
-                        return content
+                        return inject_chart_placeholders(content)
             
             # Fallback to the very last message content if no pure text message found
             content = msgs[-1].content
-            return str(content) if content else "No answer generated."
+            return inject_chart_placeholders(str(content)) if content else "No answer generated."
         except Exception as exc:
             err_msg = str(exc).lower()
             is_connection_error = any(term in err_msg for term in ["connection refused", "connecterror", "connection error", "api connection"])
@@ -1269,7 +1272,8 @@ class MosaicFundAgent:
                 config=config,
             )
             msgs = result.get("messages", [])
-            return _get_message_text(msgs[-1].content) if msgs else "No answer generated."
+            from src.tools.chart_tools import inject_chart_placeholders
+            return inject_chart_placeholders(_get_message_text(msgs[-1].content)) if msgs else "No answer generated."
         except Exception as exc:
             err_msg = str(exc).lower()
             is_connection_error = any(term in err_msg for term in ["connection refused", "connecterror", "connection error", "api connection"])

--- a/src/prompts/router_system_prompt.txt
+++ b/src/prompts/router_system_prompt.txt
@@ -21,8 +21,7 @@ Special routing rules:
 - Questions about a SPECIFIC mutual fund (DSP / Nippon / Bajaj / Quant / ICICI Multi Asset, scheme codes, fund managers, MF holdings, fund cross-ownership, NAV returns, "which funds hold X", "find funds similar to X", "funds with gold/commodity/equity exposure", "smart-money consensus across funds") → "mf"
 - Questions mentioning specific Indian companies (RELIANCE, TCS, HDFC) → "india_equity"
 - "find similar anomaly", "historical anomaly precedents", "what past crashes looked like this", "similar regime history" → "signal"
-- "plot" or "chart" + macro keyword → "macro"; + ETF keyword → "signal"
-- "plot" or "chart" + Indian stock name (RELIANCE, TCS, ADVENZYMES, etc.) → "india_equity"
+- "plot" or "chart" requests → "main" (main agent has plot_price_chart, plot_multi_price_chart, plot_macd_chart tools)
 - When uncertain, prefer "main" over guessing
 
 Respond with ONLY a JSON object (no markdown, no explanation):

--- a/src/tools/chart_tools.py
+++ b/src/tools/chart_tools.py
@@ -17,8 +17,21 @@ from langchain_core.tools import tool
 
 logger = logging.getLogger(__name__)
 
-_SPARKS = "▁▂▃▄▅▆▇█"
+from typing import Any, Sequence  # noqa: F401
+
+_SPARKS = " ▂▃▄▅▆▇█"
 _CHART_HEIGHT = 20
+
+
+def render_sparkline(values: Sequence[float]) -> str:
+    """Render a sequence of numerical values as a compact Unicode sparkline string."""
+    clean = [v for v in values if v is not None and not (isinstance(v, float) and (v != v))]
+    if not clean:
+        return ""
+    min_v, max_v = min(clean), max(clean)
+    if min_v == max_v:
+        return _SPARKS[0] * len(clean)
+    return "".join(_SPARKS[min(7, max(0, int(7 * (val - min_v) / (max_v - min_v))))] for val in clean)
 
 
 def _chart_width() -> int:
@@ -231,6 +244,14 @@ def _build(plt: Any) -> str:
     return f"[CHART:{key}]"
 
 
+def _build_raw(plt: Any) -> str:
+    """Build and return chart string without saving to active_charts store.
+    Used for independent subplot rendering to avoid cursor positioning escape code loss."""
+    out = plt.build()
+    plt.clear_figure()
+    return out
+
+
 def _data_table(headers: list[str], rows: list[list], title: str = "") -> str:
     """
     Format chart data as a compact Markdown table appended below the chart.
@@ -345,11 +366,19 @@ def plot_price_chart(
 
         plt = _plt()
         plt.clear_figure()
-        plt.subplots(3, 1)
         xs = list(range(len(prices)))
 
-        # Subplot 1: Price
-        plt.subplot(1, 1)
+        # Each panel is built and rendered independently (its own clear_figure()
+        # + build() pair) rather than via plt.subplots()+one build() call.
+        # plotext's multi-subplot grid emits absolute cursor-positioning ANSI
+        # codes that only resolve correctly on a live, attached TTY — captured
+        # non-interactively (piped script, LangChain tool return value), those
+        # codes overwrite each other and only the last panel survives. Three
+        # independent full-width builds concatenated as plain text render
+        # correctly in both contexts.
+        plt.plot_size(_chart_width(), 14)
+
+        # Panel 1: Price
         plt.plot(xs, prices, label=symbol)
 
         # Overlay anomalies
@@ -405,20 +434,28 @@ def plot_price_chart(
         tick_lbl = [str(dates[i])[:10] for i in tick_idx]
         plt.xticks(tick_idx, tick_lbl)
 
-        # Subplot 2: 20D Annualized Volatility %
-        plt.subplot(2, 1)
+        price_panel = plt.build()
+        plt.clear_figure()
+
+        # Panel 2: 20D Annualized Volatility %
+        plt.plot_size(_chart_width(), 10)
         plt.plot(xs, vol_s, label="20D Vol (%)", color="magenta")
         plt.ylabel("Vol (%)")
         plt.xticks(tick_idx, tick_lbl)
+        vol_panel = plt.build()
+        plt.clear_figure()
 
-        # Subplot 3: Volume
-        plt.subplot(3, 1)
+        # Panel 3: Volume
+        plt.plot_size(_chart_width(), 10)
         plt.bar(xs, volumes, label="Volume", color="cyan")
         plt.ylabel("Volume")
         plt.xticks(tick_idx, tick_lbl)
+        volume_panel = plt.build()
+        plt.clear_figure()
 
-        plt.plot_size(_chart_width(), 26)
-        chart = _build(plt)
+        chart_text = price_panel + "\n" + vol_panel + "\n" + volume_panel
+        save_active_chart("price", chart_text)
+        chart = "[CHART:price]"
         table = _data_table(
             ["Date", "Open", "High", "Low", "Close", "Volume"],
             [

--- a/src/tools/chart_tools.py
+++ b/src/tools/chart_tools.py
@@ -64,6 +64,27 @@ def save_active_chart(key: str, chart_str: str) -> None:
 def clear_active_charts() -> None:
     get_active_charts().clear()
 
+
+def inject_chart_placeholders(text: str) -> str:
+    """Replace [CHART:xxx] tokens in text with the real chart strings a plot_*
+    tool call saved this run (via save_active_chart). Shared by every agent path
+    that lets an LLM/template write [CHART:xxx] placeholders instead of
+    reproducing chart glyphs itself — declarative playbooks (declarative_runner.py)
+    and the main tool-calling agent (mosaic_fund_agent.py) both call this."""
+    try:
+        chart_by_type = get_active_charts().copy()
+        for tname, chart_str in chart_by_type.items():
+            placeholders = [f"[CHART:{tname}]"]
+            if tname.startswith("plot_") and tname.endswith("_chart"):
+                placeholders.append(f"[CHART:{tname[5:-6]}]")
+            for ph in placeholders:
+                if ph in text:
+                    text = text.replace(ph, chart_str)
+                    break
+    except Exception:
+        logger.warning("Chart placeholder substitution failed", exc_info=True)
+    return text
+
 def clean_chart_tool_output(func):
     """
     No-op decorator since _build() now intercepts the plotting output directly


### PR DESCRIPTION
## Summary of Changes

### 1. Multi-subplot Chart Rendering & Routing Fixes (`src/tools/chart_tools.py`, `src/prompts/router_system_prompt.txt`)
- **Router Fix**: Re-route plot/chart queries from `india_equity` to `main` (since `india_equity` agent lacks chart tool bindings).
- **Non-TTY Rendering**: Render multi-subplot panels independently with separate `clear_figure()` / `build()` calls instead of `plt.subplots(3,1)`. This avoids Plotext ANSI absolute cursor positioning overwrites in non-TTY piped/tool environments.

### 2. Chart Placeholder Substitution (`src/tools/chart_tools.py`, `src/agents/mosaic_fund_agent.py`, `src/agents/declarative/declarative_runner.py`, `config/agents/india_equity.yaml`)
- **Shared Helper**: Added `inject_chart_placeholders()` in `chart_tools.py` to replace `[CHART:xxx]` tokens with actual rendered ASCII charts.
- **Agent Integration**: Call `inject_chart_placeholders()` on the final answer in `MosaicFundAgent.ask()` and `.chat()`. Updated system prompt instructing LLM to output `[CHART:price]` verbatim.
- **Declarative Runner**: Run placeholder substitution on template output step results and clear active charts before execution.

### 3. Skill Visualization Instructions (`.agents/skills/intraday/SKILL.md`, `.agents/skills/stock-anomaly-news/SKILL.md`)
- Added **Terminal ASCII Chart Output** guidelines to `/intraday` and `/stock-anomaly-news` skills.