### PR TITLE
feat(mf): add cross-fund multi-asset consensus UI, Terminal viz & update data_importer pointer

### DIFF
--- a/.agents/agents/mf-tracker-agent.md
+++ b/.agents/agents/mf-tracker-agent.md
@@ -1,6 +1,6 @@
 ---
 name: mf-tracker-agent
-description: Complete Mutual Fund (MF) research, portfolio disclosures, AMC importers, AMC-specific bullish small-cap stock picks, DSP active-fund cross-ownership conviction signals, small-cap & mid-cap cross-ownership screening, AMFI category flows, MoM NAV returns, and multi-asset institutional Whale Tracking across all supported AMCs. Trigger when the user asks "track mf holdings", "whale tracker", "mf whale tracker", "dsp holdings", "fund holdings", "amfi flows", "fund returns", "small cap cross ownership", "mid cap conviction", "amc bullish small cap", or invokes /mf-tracker.
+description: Complete Mutual Fund (MF) research, portfolio disclosures, AMC importers, AMC-specific bullish small-cap stock picks, DSP active-fund cross-ownership conviction signals, small-cap & mid-cap cross-ownership screening, AMFI category flows, MoM NAV returns, multi-asset institutional Whale Tracking, and cross-fund multi-asset consensus (smart-money overlap) across all supported AMCs. Trigger when the user asks "track mf holdings", "whale tracker", "mf whale tracker", "dsp holdings", "fund holdings", "amfi flows", "fund returns", "small cap cross ownership", "mid cap conviction", "amc bullish small cap", "multi asset consensus", "what are multi asset funds buying", "trend across multi asset funds", "smart money overlap", or invokes /mf-tracker.
 tools:
   - run_command
   - view_file
@@ -13,6 +13,12 @@ temperature: 0.1
 max_turns: 25
 ---
 
+# Complete Mutual Fund (MF) & AMC Research Suite (`/mf-tracker`)
+
+This skill is the single unified reference and execution guide for **ALL Mutual Fund capabilities** across Indian AMCs (DSP, Nippon India, ICICI Prudential, Quant, HDFC, Bajaj Finserv, AMFI category flows) with dedicated tools for **Sector Allocations**, **MoM/YoY Sector Rotation**, **Investment Thesis Rationale**, **100% Exhaustive Stock Shift Audits**, and **Master Executive CLI Dashboards**.
+
+---
+
 ## 🛠️ Registered Mutual Fund Analysis Tools (`MosaicFundAgent`)
 
 | Tool Name | Module | What it Does |
@@ -20,7 +26,13 @@ max_turns: 25
 | `smallcap` | `src/scripts/portfolio/smallcap_pattern_analyzer.py` | Multi-AMC Small Cap pattern & accumulation analyzer (CLI: `python src/main.py smallcap --amc <all\|dsp\|nippon\|hdfc\|quant>`) |
 | `analyze_mf_sectors` | `src/tools/mf_sector_analyzer.py` | Single AMC sector breakdown (% AUM, ₹ Cr value, active stock count) & multi-AMC comparative matrix |
 | `detect_amc_sector_rotation` | `src/tools/mf_sector_rotation.py` | MoM / YoY sector weight shifts (% AUM), capital deltas (₹ Cr), rotation status tags |
+| `run_multi_asset_consensus` | `src/scripts/portfolio/multi_asset_consensus.py` | Cross-fund "smart money overlap" — consensus adds/trims held or moved by ≥2 of the 7 tracked multi-asset funds, plus persistence-ranked asset-class and sector rotation |
+| `explain_rotation_thesis` | `src/tools/mf_rotation_thesis.py` | Macro, fundamental, and valuation investment thesis explaining WHY an AMC rotated |
+| `audit_exhaustive_stock_shifts` | `src/tools/mf_sector_rotation.py` | 100% complete audit of ALL stock additions (+₹ Cr) and subtractions (-₹ Cr) with zero data loss |
+| `display_master_amc_dashboard` | `src/tools/cli_ux_dashboard.py` | Master Executive CLI Dashboard (Left-to-Right Horizontal Sector Flow + Side-by-Side Stock Ledger) |
 
+
+---
 
 ## 🏛️ 1. AMC-Specific Bullish Small-Cap Stock Pick Queries
 
@@ -134,6 +146,50 @@ python src/scripts/market/whale_tracker.py
 | `120821` | **Quant Multi Asset** | 2 Months |
 | `120334` | **ICICI Prudential Multi Asset** | 1 Month |
 | `120716` | **ICICI Prudential Multi Asset II** | 1 Month |
+
+---
+
+## 🤝 4b. Cross-Fund Multi-Asset Consensus (Smart-Money Overlap)
+
+While the Whale Tracker (above) tracks predefined macro *themes* (gold/silver/nuclear/infra), this tool finds **consensus signals** — securities and asset classes that *multiple* multi-asset funds are simultaneously adding to or trimming in the same window. If 4 of 7 funds raise gold ETF exposure in the same month, that is a materially stronger signal than any single fund acting alone.
+
+```bash
+# Latest month MoM consensus across all 7 tracked multi-asset funds (default)
+python src/scripts/portfolio/multi_asset_consensus.py
+
+# YoY (latest vs 12 months back) instead of MoM
+python src/scripts/portfolio/multi_asset_consensus.py --period yoy
+
+# Lower the minimum-fund threshold (default 2 funds)
+python src/scripts/portfolio/multi_asset_consensus.py --min-funds 3
+
+# Restrict to one asset class (equity / gold / bond / cash / other)
+python src/scripts/portfolio/multi_asset_consensus.py --asset gold
+
+# Show more rows
+python src/scripts/portfolio/multi_asset_consensus.py --top 30
+```
+
+Outputs, in order: (1) Portfolio Overlap — core holdings shared by ≥2 funds, (2) Consensus ADDS / TRIMS for the chosen period, (3) Asset-Class Rotation persistence table (12mo lookback, ≥3mo streak = persistent), (4) Per-Fund and Cross-Fund Sector Rotation persistence tables.
+
+**Data-lag caveat — always check before calling a month "July" or "latest":** the 7 funds do not disclose on identical cadences. Some funds (e.g. DSP Multi Asset / DSP Multi Asset Omni) can lag a full month behind the others, and ICICI Multi Asset discloses closer to quarterly. The script's MoM/YoY comparison always uses each fund's own two most-recent snapshots — so a "MoM" read can silently mix a true latest-month change (for funds that reported on time) with a stale prior-month change (for funds still lagging). Verify per-fund `as_of_month` first:
+```sql
+SELECT fund_name, max(as_of_month) AS latest, count(DISTINCT as_of_month) AS n_months
+FROM market_data.mf_holdings FINAL
+WHERE scheme_code IN ('RLMF806','RLMF811','152056','154167','152639','120821','120334')
+GROUP BY fund_name;
+```
+
+Agent tool wrapper: `run_multi_asset_consensus` (`src/tools/runners.py`, registered on the MF sub-agent — see `src/agents/sub_agents/mf.py`).
+
+### ASCII chart views of the same data
+
+`multi_asset_consensus.py` prints Rich data tables; for an actual chart-style read (bar/heatmap, not rows), use:
+```bash
+python src/scripts/portfolio/multi_asset_ascii_viz.py
+python src/scripts/portfolio/multi_asset_ascii_viz.py --min-delta 0.25 --top 10
+```
+Renders (1) a Fund x Asset-Class MoM weight-shift matrix with an in-cell text bar per fund/asset-class pair, and (2) a diverging ASCII bar chart of consensus movers (securities ≥2 funds moved, joined on **ISIN** — not `security_name` text, since AMCs spell the same company inconsistently, e.g. "HDFC Bank Ltd" vs "HDFC Bank Limited", which fragments one company into false duplicates if joined on the raw name). Same data-lag caveat as §4b applies — each fund's row compares its own two most-recent snapshots, which are not all the same calendar month.
 
 ---
 

--- a/.agents/agents/mosaic-agent.md
+++ b/.agents/agents/mosaic-agent.md
@@ -30,9 +30,24 @@ Use this skill when the user asks:
 Executes the `MosaicFundAgent` orchestrator (`src/agents/mosaic_fund_agent.py`):
 1. **Holdings Import & Verification**: Authenticates via Kite/Shoonya to fetch live holdings and market positions.
 2. **Parallel Asset Enrichment**: Runs multi-source enrichment (Shoonya live ticks, ClickHouse, yfinance, earnings, news) per holding.
-3. **ReAct Quantitative Q&A**: Uses registered quant tools (`query_clickhouse_db`, `analyze_smallcap_patterns`, `analyze_midcap_patterns`, `analyze_largecap_patterns`, `get_live_inav`, `scan_etf_setups`, `run_composite_anomaly`, `get_shoonya_quotes`) to answer complex portfolio queries.
-
+3. **ReAct Quantitative Q&A**: Uses registered quant tools (`query_clickhouse_db`, `analyze_smallcap_patterns`, `analyze_midcap_patterns`, `analyze_largecap_patterns`, `get_live_inav`, `scan_etf_setups`, `run_composite_anomaly`, `get_shoonya_quotes`) to answer complex portfolio queries. MF-holdings questions (single-fund MoM/YoY, cross-fund consensus, whale tracking) are routed via `delegate_to_mf_agent` to the MF sub-agent's tool set rather than duplicated in the main tool list.
 4. **Structured Report Generation**: Produces JSON and Markdown research notes summarizing risk, momentum, and position sizing.
+
+## Cross-Fund Multi-Asset Consensus (Smart-Money Overlap)
+
+When the user asks something like "what are multi-asset funds collectively buying", "any pattern across multi-asset funds", "smart-money consensus this month", or "trend across all multi asset MF", Mosaic delegates to the MF sub-agent's `run_multi_asset_consensus` tool (`src/scripts/portfolio/multi_asset_consensus.py`). It scans the 7 tracked multi-asset funds (Nippon, Nippon FoF, DSP, DSP Omni, Bajaj, Quant, ICICI) in `market_data.mf_holdings` and returns:
+- Portfolio overlap — core holdings shared by ≥2 funds
+- Consensus ADDS / TRIMS (MoM or YoY) — securities ≥2 funds moved the same direction
+- Persistence-ranked asset-class rotation (12mo lookback, ≥3mo streak = persistent)
+- Per-fund and cross-fund sector rotation
+
+Caveat: the 7 funds disclose on different cadences (DSP can lag a month; ICICI is near-quarterly), so a "MoM" read can mix a true latest-month change with a stale prior-month one — check each fund's `as_of_month` before calling a result "this month's" trend.
+
+```bash
+# Direct CLI (bypasses the agent)
+ALLOW_LOCAL_RUN=1 .venv/bin/python src/scripts/portfolio/multi_asset_consensus.py --period mom --top 30
+```
+
 
 ## Usage
 

--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mf-tracker
-description: Complete Mutual Fund (MF) research, portfolio disclosures, AMC importers, AMC-specific bullish small-cap stock picks, DSP active-fund cross-ownership conviction signals, small-cap & mid-cap cross-ownership screening, AMFI category flows, MoM NAV returns, and multi-asset institutional Whale Tracking across all supported AMCs. Trigger when the user asks "track mf holdings", "whale tracker", "mf whale tracker", "dsp holdings", "fund holdings", "amfi flows", "fund returns", "small cap cross ownership", "mid cap conviction", "amc bullish small cap", or invokes /mf-tracker.
+description: Complete Mutual Fund (MF) research, portfolio disclosures, AMC importers, AMC-specific bullish small-cap stock picks, DSP active-fund cross-ownership conviction signals, small-cap & mid-cap cross-ownership screening, AMFI category flows, MoM NAV returns, multi-asset institutional Whale Tracking, and cross-fund multi-asset consensus (smart-money overlap) across all supported AMCs. Trigger when the user asks "track mf holdings", "whale tracker", "mf whale tracker", "dsp holdings", "fund holdings", "amfi flows", "fund returns", "small cap cross ownership", "mid cap conviction", "amc bullish small cap", "multi asset consensus", "what are multi asset funds buying", "trend across multi asset funds", "smart money overlap", or invokes /mf-tracker.
 ---
 
 # Complete Mutual Fund (MF) & AMC Research Suite (`/mf-tracker`)
@@ -16,6 +16,7 @@ This skill is the single unified reference and execution guide for **ALL Mutual 
 | `smallcap` | `src/scripts/portfolio/smallcap_pattern_analyzer.py` | Multi-AMC Small Cap pattern & accumulation analyzer (CLI: `python src/main.py smallcap --amc <all\|dsp\|nippon\|hdfc\|quant>`) |
 | `analyze_mf_sectors` | `src/tools/mf_sector_analyzer.py` | Single AMC sector breakdown (% AUM, ₹ Cr value, active stock count) & multi-AMC comparative matrix |
 | `detect_amc_sector_rotation` | `src/tools/mf_sector_rotation.py` | MoM / YoY sector weight shifts (% AUM), capital deltas (₹ Cr), rotation status tags |
+| `run_multi_asset_consensus` | `src/scripts/portfolio/multi_asset_consensus.py` | Cross-fund "smart money overlap" — consensus adds/trims held or moved by ≥2 of the 7 tracked multi-asset funds, plus persistence-ranked asset-class and sector rotation |
 | `explain_rotation_thesis` | `src/tools/mf_rotation_thesis.py` | Macro, fundamental, and valuation investment thesis explaining WHY an AMC rotated |
 | `audit_exhaustive_stock_shifts` | `src/tools/mf_sector_rotation.py` | 100% complete audit of ALL stock additions (+₹ Cr) and subtractions (-₹ Cr) with zero data loss |
 | `display_master_amc_dashboard` | `src/tools/cli_ux_dashboard.py` | Master Executive CLI Dashboard (Left-to-Right Horizontal Sector Flow + Side-by-Side Stock Ledger) |
@@ -135,6 +136,50 @@ python src/scripts/market/whale_tracker.py
 | `120821` | **Quant Multi Asset** | 2 Months |
 | `120334` | **ICICI Prudential Multi Asset** | 1 Month |
 | `120716` | **ICICI Prudential Multi Asset II** | 1 Month |
+
+---
+
+## 🤝 4b. Cross-Fund Multi-Asset Consensus (Smart-Money Overlap)
+
+While the Whale Tracker (above) tracks predefined macro *themes* (gold/silver/nuclear/infra), this tool finds **consensus signals** — securities and asset classes that *multiple* multi-asset funds are simultaneously adding to or trimming in the same window. If 4 of 7 funds raise gold ETF exposure in the same month, that is a materially stronger signal than any single fund acting alone.
+
+```bash
+# Latest month MoM consensus across all 7 tracked multi-asset funds (default)
+python src/scripts/portfolio/multi_asset_consensus.py
+
+# YoY (latest vs 12 months back) instead of MoM
+python src/scripts/portfolio/multi_asset_consensus.py --period yoy
+
+# Lower the minimum-fund threshold (default 2 funds)
+python src/scripts/portfolio/multi_asset_consensus.py --min-funds 3
+
+# Restrict to one asset class (equity / gold / bond / cash / other)
+python src/scripts/portfolio/multi_asset_consensus.py --asset gold
+
+# Show more rows
+python src/scripts/portfolio/multi_asset_consensus.py --top 30
+```
+
+Outputs, in order: (1) Portfolio Overlap — core holdings shared by ≥2 funds, (2) Consensus ADDS / TRIMS for the chosen period, (3) Asset-Class Rotation persistence table (12mo lookback, ≥3mo streak = persistent), (4) Per-Fund and Cross-Fund Sector Rotation persistence tables.
+
+**Data-lag caveat — always check before calling a month "July" or "latest":** the 7 funds do not disclose on identical cadences. Some funds (e.g. DSP Multi Asset / DSP Multi Asset Omni) can lag a full month behind the others, and ICICI Multi Asset discloses closer to quarterly. The script's MoM/YoY comparison always uses each fund's own two most-recent snapshots — so a "MoM" read can silently mix a true latest-month change (for funds that reported on time) with a stale prior-month change (for funds still lagging). Verify per-fund `as_of_month` first:
+```sql
+SELECT fund_name, max(as_of_month) AS latest, count(DISTINCT as_of_month) AS n_months
+FROM market_data.mf_holdings FINAL
+WHERE scheme_code IN ('RLMF806','RLMF811','152056','154167','152639','120821','120334')
+GROUP BY fund_name;
+```
+
+Agent tool wrapper: `run_multi_asset_consensus` (`src/tools/runners.py`, registered on the MF sub-agent — see `src/agents/sub_agents/mf.py`).
+
+### ASCII chart views of the same data
+
+`multi_asset_consensus.py` prints Rich data tables; for an actual chart-style read (bar/heatmap, not rows), use:
+```bash
+python src/scripts/portfolio/multi_asset_ascii_viz.py
+python src/scripts/portfolio/multi_asset_ascii_viz.py --min-delta 0.25 --top 10
+```
+Renders (1) a Fund x Asset-Class MoM weight-shift matrix with an in-cell text bar per fund/asset-class pair, and (2) a diverging ASCII bar chart of consensus movers (securities ≥2 funds moved, joined on **ISIN** — not `security_name` text, since AMCs spell the same company inconsistently, e.g. "HDFC Bank Ltd" vs "HDFC Bank Limited", which fragments one company into false duplicates if joined on the raw name). Same data-lag caveat as §4b applies — each fund's row compares its own two most-recent snapshots, which are not all the same calendar month.
 
 ---
 

--- a/.agents/skills/mosaic-agent/SKILL.md
+++ b/.agents/skills/mosaic-agent/SKILL.md
@@ -20,8 +20,23 @@ Use this skill when the user asks:
 Executes the `MosaicFundAgent` orchestrator (`src/agents/mosaic_fund_agent.py`):
 1. **Holdings Import & Verification**: Authenticates via Kite/Shoonya to fetch live holdings and market positions.
 2. **Parallel Asset Enrichment**: Runs multi-source enrichment (Shoonya live ticks, ClickHouse, yfinance, earnings, news) per holding.
-3. **ReAct Quantitative Q&A**: Uses registered quant tools (`query_clickhouse_db`, `analyze_smallcap_patterns`, `analyze_midcap_patterns`, `analyze_largecap_patterns`, `get_live_inav`, `scan_etf_setups`, `run_composite_anomaly`, `get_shoonya_quotes`) to answer complex portfolio queries.
+3. **ReAct Quantitative Q&A**: Uses registered quant tools (`query_clickhouse_db`, `analyze_smallcap_patterns`, `analyze_midcap_patterns`, `analyze_largecap_patterns`, `get_live_inav`, `scan_etf_setups`, `run_composite_anomaly`, `get_shoonya_quotes`) to answer complex portfolio queries. MF-holdings questions (single-fund MoM/YoY, cross-fund consensus, whale tracking) are routed via `delegate_to_mf_agent` to the MF sub-agent's tool set rather than duplicated in the main tool list.
 4. **Structured Report Generation**: Produces JSON and Markdown research notes summarizing risk, momentum, and position sizing.
+
+## Cross-Fund Multi-Asset Consensus (Smart-Money Overlap)
+
+When the user asks something like "what are multi-asset funds collectively buying", "any pattern across multi-asset funds", "smart-money consensus this month", or "trend across all multi asset MF", Mosaic delegates to the MF sub-agent's `run_multi_asset_consensus` tool (`src/scripts/portfolio/multi_asset_consensus.py`). It scans the 7 tracked multi-asset funds (Nippon, Nippon FoF, DSP, DSP Omni, Bajaj, Quant, ICICI) in `market_data.mf_holdings` and returns:
+- Portfolio overlap — core holdings shared by ≥2 funds
+- Consensus ADDS / TRIMS (MoM or YoY) — securities ≥2 funds moved the same direction
+- Persistence-ranked asset-class rotation (12mo lookback, ≥3mo streak = persistent)
+- Per-fund and cross-fund sector rotation
+
+Caveat: the 7 funds disclose on different cadences (DSP can lag a month; ICICI is near-quarterly), so a "MoM" read can mix a true latest-month change with a stale prior-month one — check each fund's `as_of_month` before calling a result "this month's" trend.
+
+```bash
+# Direct CLI (bypasses the agent)
+ALLOW_LOCAL_RUN=1 .venv/bin/python src/scripts/portfolio/multi_asset_consensus.py --period mom --top 30
+```
 
 
 ## Usage

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,9 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary single-nam
 - Write clean, single-author commit messages. **NEVER add `Co-Authored-By:` trailers**.
 - **NEVER stage or commit code automatically**. Always wait for explicit user prompt (`/commit`, "commit this").
 
+### 7. No Web Search Mandate
+- **NEVER use web search (`search_web` or web search tools)**. Rely strictly on local codebase, ClickHouse database, Python/SQL tools, and direct tool outputs.
+
 ---
 
 ## ClickHouse Schema & Documentation References

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -76,6 +76,9 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary single-nam
 - Write clean, single-author commit messages. **NEVER add `Co-Authored-By:` trailers**.
 - **NEVER stage or commit code automatically**. Always wait for explicit user prompt (`/commit`, "commit this").
 
+### 7. No Web Search Mandate
+- **NEVER use web search (`search_web` or web search tools)**. Rely strictly on local codebase, ClickHouse database, Python/SQL tools, and direct tool outputs.
+
 ---
 
 ## ClickHouse Schema & Documentation References

--- a/src/agents/declarative/declarative_runner.py
+++ b/src/agents/declarative/declarative_runner.py
@@ -113,9 +113,11 @@ class DeclarativeAgentRunner:
             ("src.tools.news_search",         ["get_stock_news", "search_financial_news"]),
             ("src.tools.newsapi_search",      ["get_newsapi_stock_news"]),
             ("src.tools.market.equity",       ["search_anomaly_events"]),
+            ("src.tools.market.market_context_tools", ["search_historical_market_context"]),
             ("src.tools.chart_tools",         ["plot_price_chart", "plot_shareholding_bar",
                                                "plot_macd_chart", "plot_signal_scores"]),
             ("src.tools.agent_tools",         ["check_and_refresh_symbol_data"]),
+            ("src.tools.market.fused_search", ["fused_multi_signal_search"]),
         ]
         for module_path, names in _equity_modules:
             try:

--- a/src/agents/sub_agents/research.py
+++ b/src/agents/sub_agents/research.py
@@ -184,6 +184,8 @@ aggregations must be computed by Python or SQL, then narrated.
             run_all_multi_asset_importers,
         )
         from src.tools.market_context import get_dxy_context
+        from src.tools.market.market_context_tools import search_historical_market_context
+        from src.tools.market.fused_search import fused_multi_signal_search
         from src.tools.news_search import search_financial_news, get_stock_news, get_db_news
         from src.tools.newsapi_search import get_newsapi_stock_news
         from src.tools.intl_etf_tools import get_intl_etf_correlation, get_intl_etf_performance
@@ -210,6 +212,8 @@ aggregations must be computed by Python or SQL, then narrated.
             run_daily_signal_composite,
             run_risk_governor_analysis,
             get_dxy_context,
+            search_historical_market_context,
+            fused_multi_signal_search,
             search_financial_news,
             get_stock_news,
             get_newsapi_stock_news,

--- a/src/data_importer/maintenance/audit_freshness.py
+++ b/src/data_importer/maintenance/audit_freshness.py
@@ -170,7 +170,103 @@ def audit_freshness():
     else:
         console.print("\n[bold green]✅ All database categories are FRESH![/bold green]")
         
+    audit_qdrant_freshness(console)
     client.close()
+
+def audit_qdrant_freshness(console):
+    """Compare latest dates in Qdrant collections vs ClickHouse source tables."""
+    try:
+        from qdrant_client import QdrantClient
+        import os
+        host = os.environ.get("QDRANT_HOST", "localhost")
+        port = int(os.environ.get("QDRANT_PORT", "6333"))
+        qc = QdrantClient(url=f"http://{host}:{port}", timeout=10)
+        # Quick connectivity check
+        qc.get_collections()
+    except Exception:
+        console.print("\n[yellow]⚠ Qdrant not available — skipping vector staleness check[/yellow]")
+        return
+
+    from src.db.pool import get_client
+    ch = get_client()
+
+    checks = [
+        # (qdrant_collection, ch_query_for_max_date, payload_date_field, label)
+        ("mf_holdings",      "SELECT max(as_of_month) FROM market_data.mf_holdings FINAL",
+         "as_of_month",      "as_of_timestamp",   "MF Holdings"),
+        ("mf_fund_profiles", "SELECT max(as_of_month) FROM market_data.mf_holdings FINAL",
+         "as_of_month",      "as_of_timestamp",   "MF Fund Profiles"),
+        ("news_articles",    "SELECT max(toString(toDate(published_at))) FROM market_data.news_articles FINAL",
+         "published_date",   "published_timestamp", "News Articles"),
+        ("market_anomalies", "SELECT max(toString(trade_date)) FROM market_data.daily_prices FINAL WHERE category='etfs'",
+         "trade_date",       "trade_timestamp",   "Market Anomalies"),
+        ("market_data",      "SELECT max(toString(trade_date)) FROM market_data.daily_prices FINAL",
+         "trade_date",       "trade_timestamp",   "Market Data"),
+    ]
+
+    table = Table(title="Qdrant vs ClickHouse Staleness", show_header=True, header_style="bold blue")
+    table.add_column("Collection", style="cyan")
+    table.add_column("Qdrant Latest", justify="center")
+    table.add_column("ClickHouse Latest", justify="center")
+    table.add_column("Qdrant Points", justify="right")
+    table.add_column("Status", justify="center")
+
+    for coll_name, ch_query, date_field, ts_field, label in checks:
+        # Get ClickHouse max date
+        try:
+            ch_res = ch.query(ch_query)
+            ch_date = str(ch_res.result_rows[0][0]) if ch_res.result_rows else "?"
+        except Exception:
+            ch_date = "ERROR"
+
+        # Get Qdrant collection info
+        try:
+            info = qc.get_collection(coll_name)
+            point_count = info.points_count
+            if point_count == 0:
+                qdrant_date = "EMPTY"
+            else:
+                # Scroll to get a sample of recent points by ordering
+                try:
+                    hits = qc.scroll(
+                        collection_name=coll_name,
+                        limit=1,
+                        order_by=ts_field,
+                        with_payload=[date_field],
+                    )
+                    if hits[0]:
+                        qdrant_date = str(hits[0][0].payload.get(date_field, "?"))
+                    else:
+                        qdrant_date = "?"
+                except Exception:
+                    # Fallback: scroll without ordering
+                    hits = qc.scroll(
+                        collection_name=coll_name,
+                        limit=1,
+                        with_payload=[date_field],
+                    )
+                    qdrant_date = str(hits[0][0].payload.get(date_field, "?")) if hits[0] else "?"
+        except Exception:
+            point_count = 0
+            qdrant_date = "N/A"
+
+        is_stale = (
+            ch_date not in ("ERROR", "?")
+            and qdrant_date not in ("N/A", "EMPTY", "?")
+            and str(qdrant_date) < str(ch_date)
+        )
+        if qdrant_date in ("N/A", "EMPTY"):
+            status = "[yellow]EMPTY[/yellow]"
+        elif is_stale:
+            status = "[bold red]STALE[/bold red]"
+        else:
+            status = "[bold green]SYNCED[/bold green]"
+
+        table.add_row(label, str(qdrant_date), str(ch_date), str(point_count), status)
+
+    console.print("\n")
+    console.print(table)
+    qc.close()
 
 if __name__ == "__main__":
     audit_freshness()

--- a/src/db/anomaly_vector.py
+++ b/src/db/anomaly_vector.py
@@ -28,6 +28,7 @@ Text description format (embedded for each flagged row):
 from __future__ import annotations
 
 import logging
+import math
 import threading
 import uuid
 from datetime import date, datetime
@@ -39,6 +40,7 @@ log = logging.getLogger(__name__)
 
 _COLLECTION = "market_anomalies"
 _EMBED_DIM = 768
+_DECAY_LAMBDA = 0.005  # Temporal decay: ~50% weight at 140 days, ~25% at 280 days
 
 # ── Qdrant lazy init (shared pattern with market_vector) ─────────────────────
 
@@ -380,6 +382,17 @@ def retrieve_similar_anomalies(
                     "attributed_confidence": p.get("attributed_confidence", ""),
                 })
 
+        # Apply temporal decay — recent precedents rank higher than stale ones.
+        # Preserves raw_similarity for debugging while ranking by
+        # recency-adjusted score:  score_adj = score × e^(-λ·Δt)
+        query_ts = _to_ts(trade_date)
+        for r in results_all:
+            r_ts = _to_ts(r.get("trade_date", "1970-01-01"))
+            days_delta = abs(query_ts - r_ts) / 86400.0
+            decay = math.exp(-_DECAY_LAMBDA * days_delta)
+            r["raw_similarity"] = r["similarity"]
+            r["similarity"] = r["similarity"] * decay
+            r["decay_factor"] = round(decay, 3)
         results_all.sort(key=lambda x: -x["similarity"])
         return results_all[:k]
 

--- a/src/db/market_vector.py
+++ b/src/db/market_vector.py
@@ -338,3 +338,67 @@ def vectorize_macro(rows: list[dict]) -> None:
 def vectorize_cot(rows: list[dict]) -> None:
     if rows and _qdrant_available:
         _background(_do_vectorize_cot, rows)
+
+
+# ── Public read API ───────────────────────────────────────────────────────────
+
+def search_market_context(
+    query: str,
+    k: int = 5,
+    symbol: str = "",
+    category: str = "",
+    data_type: str = "",
+) -> list[dict]:
+    """Search market_data collection for historically similar market contexts.
+
+    Useful for finding periods when specific macro/price/FX conditions
+    co-occurred (e.g., "DXY falling while gold rising").
+
+    Args:
+        query:     Natural language description of the market context.
+        k:         Number of results.
+        symbol:    Optional filter to a specific symbol.
+        category:  Optional filter (e.g., 'etfs', 'fx_rates', 'macro_indicators').
+        data_type: Optional filter (e.g., 'price', 'nav', 'fx_rate', 'macro', 'cot').
+
+    Returns:
+        List of dicts with payload fields + similarity score.
+    """
+    client = _get_client()
+    if client is None or not _ensure_collection():
+        return []
+
+    vectors = _embed([query])
+    if all(v == 0.0 for v in vectors[0]):
+        return []
+
+    must_conditions = []
+    if symbol:
+        must_conditions.append(
+            FieldCondition(key="symbol", match=MatchValue(value=symbol))
+        )
+    if category:
+        must_conditions.append(
+            FieldCondition(key="category", match=MatchValue(value=category))
+        )
+    if data_type:
+        must_conditions.append(
+            FieldCondition(key="data_type", match=MatchValue(value=data_type))
+        )
+
+    try:
+        q_filter = Filter(must=must_conditions) if must_conditions else None
+        hits = client.query_points(
+            collection_name=_COLLECTION,
+            query=vectors[0],
+            query_filter=q_filter,
+            limit=k,
+            with_payload=True,
+        )
+        return [
+            {**(hit.payload or {}), "similarity": float(hit.score)}
+            for hit in hits.points
+        ]
+    except Exception as e:
+        log.warning("MarketVector: search failed: %s", e)
+        return []

--- a/src/db/mf_vector.py
+++ b/src/db/mf_vector.py
@@ -316,11 +316,54 @@ def _do_vectorize_profiles(rows: list[dict]) -> None:
     if client is None or not _ensure_collection(_PROFILES_COLLECTION, is_holdings=False):
         return
 
+    # Enrich with fund manager metadata from ClickHouse (if available)
+    meta_by_code: dict[str, dict] = {}
+    try:
+        from src.db.pool import get_client as _get_ch_client
+        ch = _get_ch_client()
+        meta_rows = ch.query(
+            "SELECT scheme_code, lead_fund_manager, fund_house, scheme_category, "
+            "benchmark_index FROM market_data.mf_scheme_metadata FINAL"
+        ).result_rows
+        meta_by_code = {
+            str(r[0]): {
+                "lead_fund_manager": r[1] or "",
+                "fund_house": r[2] or "",
+                "scheme_category": r[3] or "",
+                "benchmark_index": r[4] or "",
+            }
+            for r in meta_rows
+        }
+        ch.close()
+    except Exception as exc:
+        log.debug("MFVector: mf_scheme_metadata lookup failed (non-fatal): %s", exc)
+
     profiles = _build_fund_profiles(rows)
     if not profiles:
         return
 
-    texts = [_profile_text(p) for p in profiles]
+    # Build enriched text for embeddings
+    texts = []
+    for p in profiles:
+        meta = meta_by_code.get(str(p.get("scheme_code", "")), {})
+        manager = meta.get("lead_fund_manager", "")
+        house = meta.get("fund_house", "")
+        base = _profile_text(p)
+        if manager or house:
+            enriched = (
+                f"{p['fund_name']} portfolio {p['as_of_month']}: "
+                f"fund_house={house} fund_manager={manager} "
+                f"equity {p['equity_pct']:.1f}% "
+                f"gold {p['gold_pct']:.1f}% "
+                f"bond {p['bond_pct']:.1f}% "
+                f"cash {p['cash_pct']:.1f}% "
+                f"other {p['other_pct']:.1f}% "
+                f"— top holdings: {p['top5_text']}"
+            )
+            texts.append(enriched)
+        else:
+            texts.append(base)
+
     vectors = _embed(texts)
 
     points = [
@@ -342,6 +385,11 @@ def _do_vectorize_profiles(rows: list[dict]) -> None:
                 "total_holdings":      p["total_holdings"],
                 "top5_text":           p["top5_text"],
                 "text":                texts[i],
+                # Fund manager enrichment (empty strings if metadata unavailable)
+                "lead_fund_manager":   meta_by_code.get(str(p.get("scheme_code", "")), {}).get("lead_fund_manager", ""),
+                "fund_house":          meta_by_code.get(str(p.get("scheme_code", "")), {}).get("fund_house", ""),
+                "scheme_category":     meta_by_code.get(str(p.get("scheme_code", "")), {}).get("scheme_category", ""),
+                "benchmark_index":     meta_by_code.get(str(p.get("scheme_code", "")), {}).get("benchmark_index", ""),
             },
         )
         for i, p in enumerate(profiles)
@@ -484,6 +532,9 @@ def find_similar_fund_profiles(
                 "top5_text":    h.payload.get("top5_text", ""),
                 "primary":      h.payload.get("asset_type_primary", ""),
                 "similarity":   float(h.score),
+                "lead_fund_manager": h.payload.get("lead_fund_manager", ""),
+                "fund_house": h.payload.get("fund_house", ""),
+                "scheme_category": h.payload.get("scheme_category", ""),
             }
             for h in hits.points
         ]

--- a/src/scripts/etf/goldbees_90d_returns.py
+++ b/src/scripts/etf/goldbees_90d_returns.py
@@ -1,0 +1,86 @@
+"""
+Plot GOLDBEES rolling 90-trading-day returns (%) as an ASCII line chart.
+
+Fetches daily close prices for GOLDBEES from ClickHouse, computes the
+rolling 90-day percentage return series (return of buying 90 trading
+days ago vs today), and renders it with plotext.
+
+Usage:
+    python src/scripts/etf/goldbees_90d_returns.py [--days N]
+
+    --days N   Number of most-recent trading days of the *rolling return*
+               series to display (default 250). The underlying price
+               history pulled is N + 90 to allow the 90-day lookback.
+"""
+import argparse
+import sys
+
+import pandas as pd
+
+from src.db.pool import get_pool
+
+try:
+    import plotext as plt
+except ImportError:
+    print("plotext not installed. Run: pip install plotext")
+    sys.exit(1)
+
+
+def fetch_prices(symbol: str, lookback_days: int) -> pd.DataFrame:
+    pool = get_pool()
+    query = f"""
+        SELECT trade_date AS date, close
+        FROM market_data.daily_prices FINAL
+        WHERE symbol = '{symbol}'
+        ORDER BY trade_date DESC
+        LIMIT {lookback_days}
+    """
+    df = pool.query_df(query)
+    df = df.sort_values("date").reset_index(drop=True)
+    return df
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--days", type=int, default=250,
+                         help="Number of days of rolling-return series to plot")
+    args = parser.parse_args()
+
+    symbol = "GOLDBEES"
+    window = 90
+    total_lookback = args.days + window + 10  # buffer
+
+    df = fetch_prices(symbol, total_lookback)
+    if df.empty:
+        print(f"No price data found for {symbol}")
+        return
+
+    df["ret_90d"] = (df["close"] / df["close"].shift(window) - 1) * 100
+    df = df.dropna(subset=["ret_90d"]).tail(args.days).reset_index(drop=True)
+
+    if df.empty:
+        print("Not enough history to compute 90-day rolling returns.")
+        return
+
+    dates = df["date"].astype(str).tolist()
+    returns = df["ret_90d"].round(2).tolist()
+
+    plt.clear_data()
+    plt.clear_figure()
+    plt.date_form("Y-m-d")
+    plt.plot(dates, returns, marker="dot")
+    plt.title(f"{symbol} — Rolling 90-Trading-Day Return (%)")
+    plt.xlabel("Date")
+    plt.ylabel("90D Return %")
+    plt.plotsize(100, 30)
+    plt.show()
+
+    latest = df.iloc[-1]
+    print(f"\nLatest 90-day return as of {latest['date']}: {round(latest['ret_90d'], 2)}%")
+    print(f"Max 90-day return in window: {round(df['ret_90d'].max(), 2)}%")
+    print(f"Min 90-day return in window: {round(df['ret_90d'].min(), 2)}%")
+    print(f"Mean 90-day return in window: {round(df['ret_90d'].mean(), 2)}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/portfolio/multi_asset_ascii_viz.py
+++ b/src/scripts/portfolio/multi_asset_ascii_viz.py
@@ -1,0 +1,229 @@
+"""
+scripts/portfolio/multi_asset_ascii_viz.py
+───────────────────────────────────────
+Terminal ASCII visualizations for the 7 multi-asset funds in
+`market_data.mf_holdings`. Complements the tabular output of
+`multi_asset_consensus.py` with two chart-style views:
+
+  1. Fund x Asset-Class MoM weight-shift matrix — each fund's own latest
+     two as_of_month snapshots, one row per fund, one column per asset
+     class, with a text bar in each cell scaled to the largest |delta|
+     in the matrix.
+
+  2. Consensus-movers diverging bar chart — securities that >=2 funds
+     moved (added to or trimmed from) in the same window, sorted by
+     average delta, red/left bars for trims and green/right bars for adds.
+
+Securities are joined across funds on ISIN, not security_name text —
+AMCs spell the same company differently ("HDFC Bank Ltd" vs "HDFC Bank
+Limited"), and joining on the raw name fragments one company into false
+duplicates with opposite-looking bars.
+
+Usage:
+    python src/scripts/portfolio/multi_asset_ascii_viz.py
+    python src/scripts/portfolio/multi_asset_ascii_viz.py --min-delta 0.25 --top 8
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import pandas as pd
+
+sys.path.append(os.getcwd())
+
+from rich import box
+from rich.console import Console
+from rich.table import Table
+
+from src.db.pool import get_pool
+
+console = Console()
+
+# Canonical roster — kept identical to multi_asset_consensus.py's MULTI_ASSET_FUNDS.
+FUNDS = [
+    ("Nippon Multi Asset",     "scheme_code = 'RLMF806'"),
+    ("Nippon Multi Asset FoF", "scheme_code = 'RLMF811'"),
+    ("DSP Multi Asset",        "scheme_code = '152056'"),
+    ("DSP Multi Asset Omni",   "scheme_code = '154167'"),
+    ("Bajaj Multi Asset",      "scheme_code = '152639'"),
+    ("Quant Multi Asset",      "scheme_code = '120821'"),
+    ("ICICI Multi Asset",      "scheme_code = '120334'"),
+]
+ASSET_ORDER = ["equity", "gold", "bond", "cash", "other"]
+
+
+def months_for(fund_filter: str) -> list:
+    pool = get_pool()
+    df = pool.query_df(
+        f"SELECT DISTINCT as_of_month FROM market_data.mf_holdings FINAL "
+        f"WHERE {fund_filter} ORDER BY as_of_month"
+    )
+    return [pd.to_datetime(m).date() for m in df["as_of_month"].tolist()]
+
+
+def asset_class_snapshot(fund_filter: str, as_of_month) -> dict:
+    pool = get_pool()
+    df = pool.query_df(
+        f"""
+        SELECT lower(asset_type) AS asset_type, sum(pct_of_nav) AS pct
+        FROM market_data.mf_holdings FINAL
+        WHERE {fund_filter} AND as_of_month = '{as_of_month}'
+        GROUP BY asset_type
+        """
+    )
+    return dict(zip(df["asset_type"], df["pct"])) if not df.empty else {}
+
+
+def security_snapshot(fund_filter: str, as_of_month) -> pd.DataFrame:
+    pool = get_pool()
+    return pool.query_df(
+        f"""
+        SELECT isin, any(security_name) AS security_name, sum(pct_of_nav) AS pct
+        FROM market_data.mf_holdings FINAL
+        WHERE {fund_filter} AND as_of_month = '{as_of_month}' AND isin != ''
+        GROUP BY isin
+        """
+    )
+
+
+def _bar(value: float, max_abs: float, width: int, up_char: str = "#", down_char: str = "-") -> str:
+    n = min(width, int(round(abs(value) / max_abs * width))) if max_abs else 0
+    return (up_char if value >= 0 else down_char) * n
+
+
+def build_asset_class_matrix() -> pd.DataFrame:
+    """One row per fund: its own latest-two-month asset-class pct_of_nav deltas.
+
+    Columns: fund, prev, curr (as_of_month strings), then one column per
+    ASSET_ORDER entry. Shared by both the ASCII renderer and the UI's chart
+    view so the underlying (fund-lag-aware) computation lives in one place.
+    """
+    rows = []
+    for label, fund_filter in FUNDS:
+        months = months_for(fund_filter)
+        if len(months) < 2:
+            continue
+        curr, prev = months[-1], months[-2]
+        curr_snap, prev_snap = asset_class_snapshot(fund_filter, curr), asset_class_snapshot(fund_filter, prev)
+        row = {"fund": label, "prev": str(prev), "curr": str(curr)}
+        for asset in ASSET_ORDER:
+            row[asset] = round(curr_snap.get(asset, 0.0) - prev_snap.get(asset, 0.0), 2)
+        rows.append(row)
+    return pd.DataFrame(rows)
+
+
+def render_asset_class_matrix(console: Console = console) -> None:
+    df = build_asset_class_matrix()
+    if df.empty:
+        console.print("[yellow]No funds with >=2 months of holdings history.[/yellow]")
+        return
+
+    mat = df.set_index("fund")
+    max_abs = max(1.0, mat[ASSET_ORDER].abs().values.max())
+
+    console.rule("[bold]1) Fund x Asset-Class MoM Weight Shift (pct-pts)[/bold]")
+    table = Table(box=box.SQUARE, show_lines=True)
+    table.add_column("Fund")
+    table.add_column("Snapshot (prev -> curr)")
+    for asset in ASSET_ORDER:
+        table.add_column(asset.upper())
+    for label, r in mat.iterrows():
+        cells = []
+        for asset in ASSET_ORDER:
+            v = r[asset]
+            color = "green" if v > 0 else ("red" if v < 0 else "white")
+            cells.append(f"[{color}]{v:+.2f} {_bar(v, max_abs, 8)}[/{color}]")
+        table.add_row(label, f"{r['prev']} -> {r['curr']}", *cells)
+    console.print(table)
+    console.print(
+        "[dim]Bar length scaled to the largest single |delta| in this matrix. "
+        "'#' = increase, '-' = decrease. Each fund compares its own two most-recent "
+        "snapshots — funds lag each other, so rows are not all the same calendar month.[/dim]\n"
+    )
+
+
+def build_consensus_moves(min_delta: float = 0.10) -> pd.DataFrame:
+    """Security-level moves aggregated across funds, matched on ISIN (not
+    security_name text — AMCs spell the same company differently).
+
+    Returns columns: isin, security, n_funds, avg_delta, net — filtered to
+    n_funds >= 2, sorted by avg_delta ascending. Empty DataFrame if nothing
+    qualifies.
+    """
+    sec_rows = []
+    for label, fund_filter in FUNDS:
+        months = months_for(fund_filter)
+        if len(months) < 2:
+            continue
+        curr, prev = months[-1], months[-2]
+        df_c, df_p = security_snapshot(fund_filter, curr), security_snapshot(fund_filter, prev)
+        merged = pd.merge(df_c, df_p, on="isin", how="outer", suffixes=("_c", "_p"))
+        merged["security_name"] = merged["security_name_c"].fillna(merged["security_name_p"])
+        merged["pct_c"] = merged["pct_c"].fillna(0.0)
+        merged["pct_p"] = merged["pct_p"].fillna(0.0)
+        merged["delta"] = merged["pct_c"] - merged["pct_p"]
+        merged = merged[merged["delta"].abs() >= min_delta]
+        for _, r in merged.iterrows():
+            sec_rows.append({"isin": r["isin"], "security": r["security_name"], "fund": label, "delta": r["delta"]})
+
+    if not sec_rows:
+        return pd.DataFrame(columns=["isin", "security", "n_funds", "avg_delta", "net"])
+
+    agg = (
+        pd.DataFrame(sec_rows)
+        .groupby("isin")
+        .agg(
+            security=("security", "first"),
+            n_funds=("fund", "nunique"),
+            avg_delta=("delta", "mean"),
+            net=("delta", lambda s: (s > 0).sum() - (s < 0).sum()),
+        )
+        .reset_index()
+    )
+    return agg[agg["n_funds"] >= 2].sort_values("avg_delta").reset_index(drop=True)
+
+
+def render_consensus_bar_chart(min_delta: float, top_n: int, width: int, console: Console = console) -> None:
+    agg = build_consensus_moves(min_delta=min_delta)
+
+    console.rule("[bold]2) Consensus Movers - Diverging Bar Chart (avg Delta pct-pts, >=2 funds)[/bold]")
+    if agg.empty:
+        console.print("[yellow]No security moved by >=2 funds at this --min-delta threshold.[/yellow]")
+        return
+
+    half = max(1, top_n // 2)
+    top = pd.concat([agg.head(half), agg.tail(half)]).drop_duplicates(subset="isin").sort_values("avg_delta")
+    max_d = max(0.5, top["avg_delta"].abs().max())
+    name_w = max(len(s) for s in top["security"])
+
+    for _, r in top.iterrows():
+        n = min(width, int(round(abs(r["avg_delta"]) / max_d * width)))
+        if r["avg_delta"] >= 0:
+            bar_str = f"[dim]{' ' * width}[/dim]|[green]{'#' * n}[/green]"
+        else:
+            bar_str = f"[red]{('-' * n).rjust(width)}[/red]|[dim]{' ' * width}[/dim]"
+        console.print(
+            f"{r['security']:<{name_w}}  {bar_str}  {r['avg_delta']:+.2f}  "
+            f"({int(r['n_funds'])} funds, net {int(r['net']):+d})"
+        )
+    console.print(
+        "[dim]Bars scaled to the largest |avg delta| among shown names. "
+        "Left/red = trimmed, right/green = added. Joined on ISIN across funds.[/dim]"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="ASCII visualizations for multi-asset fund MoM patterns")
+    parser.add_argument("--min-delta", type=float, default=0.10, help="Minimum |pct_of_nav delta| to count as a move (default 0.10)")
+    parser.add_argument("--top", type=int, default=20, help="Total names shown in the consensus bar chart, split between top adds/trims (default 20)")
+    parser.add_argument("--width", type=int, default=20, help="Bar width in characters for the consensus chart (default 20)")
+    args = parser.parse_args()
+
+    render_asset_class_matrix()
+    render_consensus_bar_chart(min_delta=args.min_delta, top_n=args.top, width=args.width)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/market/fused_search.py
+++ b/src/tools/market/fused_search.py
@@ -1,0 +1,99 @@
+"""Cross-collection fused search across Qdrant vector collections.
+
+Combines results from market_anomalies, mf_holdings, and news_articles
+collections to provide a 360° view of signals for a single symbol.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+
+from langchain_core.tools import tool
+
+log = logging.getLogger(__name__)
+
+
+@tool
+def fused_multi_signal_search(
+    symbol: str,
+    days_back: int = 30,
+) -> str:
+    """Search across anomalies, MF holdings, and news for a single symbol.
+
+    Fuses results from market_anomalies, mf_holdings, and news_articles
+    Qdrant collections to give a 360° view of recent signals for a
+    stock or ETF.  Use when the user asks for a holistic overview of
+    what is happening with a particular asset.
+
+    Args:
+        symbol: The ticker symbol to search (e.g., 'GOLDBEES', 'WELCORP').
+        days_back: How many days back to search for anomalies and news.
+    """
+    sections: list[str] = []
+    cutoff_date = (date.today() - timedelta(days=days_back)).isoformat()
+    symbol_upper = symbol.upper().strip()
+
+    # ── 1. Anomalies ──────────────────────────────────────────────────────
+    try:
+        from src.db.anomaly_vector import retrieve_similar_anomalies
+
+        anomalies = retrieve_similar_anomalies(
+            symbol=symbol_upper,
+            regime="",
+            trade_date=date.today(),
+            k=8,
+            same_asset_only=True,
+        )
+        recent = [a for a in anomalies if a.get("trade_date", "") >= cutoff_date]
+        if recent:
+            sections.append("### 🔴 Recent Anomalies")
+            for a in recent:
+                attr = a.get("attributed_event_type", "")
+                attr_tag = f" → {attr}" if attr else ""
+                sections.append(
+                    f"- **{a['trade_date']}** | {a.get('regime', '?')} | "
+                    f"z={a.get('final_z', 0):.2f} "
+                    f"ret={a.get('daily_return', 0):.2f}%{attr_tag}"
+                )
+    except Exception as e:
+        log.debug("Fused search anomaly leg failed: %s", e)
+
+    # ── 2. MF Holdings ────────────────────────────────────────────────────
+    try:
+        from src.db.mf_vector import find_funds_holding_security
+
+        holdings = find_funds_holding_security(query=symbol_upper, k=10)
+        if holdings:
+            sections.append("\n### 🏦 Institutional Holdings (Qdrant)")
+            for h in holdings:
+                sections.append(
+                    f"- **{h.get('fund_name', '?')}** | "
+                    f"{h.get('pct_of_nav', 0):.2f}% NAV | "
+                    f"₹{h.get('market_value_cr', 0):.1f} Cr | "
+                    f"as of {h.get('as_of_month', '?')}"
+                )
+    except Exception as e:
+        log.debug("Fused search MF leg failed: %s", e)
+
+    # ── 3. News ───────────────────────────────────────────────────────────
+    try:
+        from src.ml.correlation.news_rag import retrieve_articles
+
+        news = retrieve_articles(symbol=symbol_upper, limit=5)
+        if news:
+            sections.append("\n### 📰 Recent News")
+            for n in news:
+                title = n.get("title", n.get("headline", "?"))
+                pub = n.get("published_date", n.get("published_at", "?"))
+                sent = n.get("sentiment", "?")
+                sections.append(f"- [{pub}] {title} ({sent})")
+    except Exception as e:
+        log.debug("Fused search news leg failed: %s", e)
+
+    if not sections:
+        return f"No cross-collection signals found for {symbol_upper} in the last {days_back} days."
+
+    return f"## 360° Signal Fusion: {symbol_upper}\n\n" + "\n".join(sections)
+
+
+FUSED_SEARCH_TOOLS = [fused_multi_signal_search]

--- a/src/tools/market/market_context_tools.py
+++ b/src/tools/market/market_context_tools.py
@@ -1,0 +1,69 @@
+"""Agent tool for searching historical market context via the Qdrant market_data collection."""
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+
+@tool
+def search_historical_market_context(
+    query: str,
+    symbol: str = "",
+    category: str = "",
+) -> str:
+    """Search for historical market periods similar to a described context.
+
+    Use this to find precedent market conditions — e.g., periods when DXY
+    fell while gold rose, or when USDINR was above 85 with FII selling.
+    Only use when the user asks about historical market regime similarity,
+    not for general price lookups.
+
+    Args:
+        query: Natural language description of the market context to search for.
+        symbol: Optional symbol filter (e.g., 'GOLDBEES', 'USDINR').
+        category: Optional category filter (e.g., 'etfs', 'fx_rates').
+    """
+    from src.db.market_vector import search_market_context
+
+    results = search_market_context(
+        query=query, k=8, symbol=symbol, category=category,
+    )
+    if not results:
+        return (
+            "No matching historical market context found in the market_data "
+            "Qdrant collection. The collection may be empty or Qdrant unavailable."
+        )
+
+    lines = ["### Historical Market Context Matches\n"]
+    for i, r in enumerate(results, 1):
+        dt = r.get("data_type", "?")
+        lines.append(
+            f"{i}. **{r.get('symbol', '?')}** ({r.get('category', '?')}) "
+            f"{r.get('trade_date', '?')} — similarity={r.get('similarity', 0):.3f}"
+        )
+        if dt == "price":
+            lines.append(
+                f"   O={r.get('open', 0):.2f} H={r.get('high', 0):.2f} "
+                f"L={r.get('low', 0):.2f} C={r.get('close', 0):.2f} "
+                f"V={r.get('volume', 0):.0f}"
+            )
+        elif dt == "cot":
+            lines.append(
+                f"   MM_net={r.get('mm_net', 0):.0f} "
+                f"Comm_net={r.get('comm_net', 0):.0f} "
+                f"OI={r.get('open_interest', 0):.0f}"
+            )
+        elif dt == "macro":
+            lines.append(
+                f"   {r.get('indicator_name', '?')} = {r.get('value', 0):.4f}"
+            )
+        elif dt == "nav":
+            lines.append(f"   NAV={r.get('nav', 0):.4f}")
+        elif dt == "fx_rate":
+            lines.append(
+                f"   O={r.get('open', 0):.4f} H={r.get('high', 0):.4f} "
+                f"L={r.get('low', 0):.4f} C={r.get('close', 0):.4f}"
+            )
+    return "\n".join(lines)
+
+
+MARKET_CONTEXT_TOOLS = [search_historical_market_context]

--- a/src/tools/market/mf_tools.py
+++ b/src/tools/market/mf_tools.py
@@ -131,6 +131,8 @@ def find_similar_funds(
             f"| {r['bond_pct']:.1f}% | {r['cash_pct']:.1f}% "
             f"| `{r['primary']}` | {r['similarity']:.3f} |"
         )
+        if r.get("lead_fund_manager"):
+            lines.append(f"   Fund Manager: {r['lead_fund_manager']}")
     lines.append("\n**Top holdings of most similar fund:**")
     lines.append(f"> {results[0]['top5_text']}")
 

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -184,7 +184,231 @@ with st.sidebar:
 
 # ── Tabs ──────────────────────────────────────────────────────────────────────
 
-tab_import, tab_query, tab_explorer, tab_anomaly, tab_wis, tab_holdings, tab_etf_scan, tab_news, tab_signals, tab_kite, tab_deepdive, tab_intl_etf, tab_workflows, tab_whale, tab_reports = st.tabs(["📥 Import Data", "🔍 SQL Query", "📊 Explorer", "🔬 Anomaly Detection", "🕵️ Who Is Selling?", "📦 MF Holdings", "🏦 ETF Scanner", "📰 Market News", "🎛️ Signals", "🪁 Kite Dashboard", "🏢 Deep Dive", "🌍 Intl ETFs", "🤖 Workflows", "🐋 Whale Scanner", "📁 Reports"])
+tab_dashboard, tab_import, tab_query, tab_explorer, tab_anomaly, tab_wis, tab_holdings, tab_etf_scan, tab_news, tab_signals, tab_kite, tab_deepdive, tab_intl_etf, tab_workflows, tab_whale, tab_reports = st.tabs(["🛡️ Mosaic Dashboard", "📥 Import Data", "🔍 SQL Query", "📊 Explorer", "🔬 Anomaly Detection", "🕵️ Who Is Selling?", "📦 MF Holdings", "🏦 ETF Scanner", "📰 Market News", "🎛️ Signals", "🪁 Kite Dashboard", "🏢 Deep Dive", "🌍 Intl ETFs", "🤖 Workflows", "🐋 Whale Scanner", "📁 Reports"])
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TAB 0 — MOSAIC DASHBOARD (ETF Investor Intelligence cockpit)
+# ══════════════════════════════════════════════════════════════════════════════
+
+with tab_dashboard:
+    st.header("🛡️ Mosaic Agent — ETF Investor Intelligence Dashboard")
+    st.caption(
+        "Consolidated cockpit: live iNAV discount/premium scanner, cross-fund gold whale "
+        "tracking, GARCH position sizer, and GOLDBEES vs COMEX performance — pulled live "
+        "from the same ClickHouse tables as the dedicated tabs below."
+    )
+
+    if not ok:
+        st.warning("ClickHouse not connected.")
+        st.stop()
+
+    _dash_col_scan, _dash_col_whale = st.columns([7, 5])
+
+    with _dash_col_scan:
+        st.subheader("🎯 Live iNAV Scanner (Discount / Premium)")
+        _dash_syms = [
+            "GOLDBEES", "NIFTYBEES", "BANKBEES", "MID150BEES",
+            "HDFCNIFTY", "HNGSNGBEES", "MON100", "MAFANG",
+        ]
+        try:
+            _dash_syms_in = ", ".join(f"'{s}'" for s in _dash_syms)
+            _dash_df = _query_df(f"""
+                SELECT symbol,
+                       argMax(market_price, snapshot_at)          AS market_price,
+                       argMax(inav, snapshot_at)                  AS inav_value,
+                       argMax(premium_discount_pct, snapshot_at)  AS premium_pct
+                FROM market_data.inav_snapshots
+                WHERE symbol IN ({_dash_syms_in})
+                GROUP BY symbol
+            """)
+        except Exception as _dash_exc:
+            _dash_df = pd.DataFrame()
+            st.warning(f"iNAV query failed: {_dash_exc}")
+
+        if _dash_df.empty:
+            st.info("No iNAV snapshots yet — run **Import Data → iNAV** first.")
+        else:
+            def _dash_status(pct: float) -> str:
+                if pct <= -0.5:
+                    return "🟢 Buying Opportunity"
+                if pct < 0:
+                    return "🟢 Discount Entry"
+                if pct <= 1.0:
+                    return "⚪ Fair Value"
+                if pct <= 5.0:
+                    return "🔴 High Premium Warning"
+                return "⚠️ Extreme Premium Trap (Avoid Buying)"
+
+            _dash_df = _dash_df.sort_values("premium_pct")
+            _dash_df["Status"] = _dash_df["premium_pct"].apply(_dash_status)
+            _dash_show = _dash_df.rename(columns={
+                "symbol":       "Symbol",
+                "market_price": "Market Price (₹)",
+                "inav_value":   "iNAV (₹)",
+                "premium_pct":  "Disc/Prem (%)",
+            })
+            _gradient_dataframe(
+                _dash_show,
+                lambda styler: styler
+                    .format({"Market Price (₹)": "₹{:.2f}", "iNAV (₹)": "₹{:.2f}", "Disc/Prem (%)": "{:+.2f}%"})
+                    .background_gradient(subset=["Disc/Prem (%)"], cmap="RdYlGn_r"),
+                use_container_width=True,
+                hide_index=True,
+            )
+            st.caption("Full scanner with Z-scores + post-tax viability → **🏦 ETF Scanner** tab.")
+
+    with _dash_col_whale:
+        st.subheader("🐋 Smart-Money Gold Whale Tracking")
+        _gold_funds = [
+            "ICICI_MULTI_ASSET", "DSP_MULTI_ASSET",
+            "NIPPON_INDIA_MULTI_ASSET_ALLOCATION_FUND", "NIPPON_INDIA_MULTI_ASSET_OMNI_FOF",
+            "BAJAJ_FINSERV_MULTI_ASSET_ALLOCATION_FUND", "QUANT_MULTI_ASSET",
+        ]
+        try:
+            _gold_funds_in = ", ".join(f"'{f}'" for f in _gold_funds)
+            _gold_df = _query_df(f"""
+                SELECT scheme_code, fund_name, as_of_month,
+                       sum(pct_of_nav)      AS gold_pct,
+                       sum(market_value_cr) AS gold_value_cr
+                FROM market_data.mf_holdings FINAL
+                WHERE fund_name IN ({_gold_funds_in})
+                  AND asset_type ILIKE '%gold%'
+                  AND as_of_month >= toStartOfMonth(today() - INTERVAL 3 MONTH)
+                GROUP BY scheme_code, fund_name, as_of_month
+                ORDER BY scheme_code, as_of_month
+            """)
+        except Exception as _gold_exc:
+            _gold_df = pd.DataFrame()
+            st.warning(f"Gold-holdings query failed: {_gold_exc}")
+
+        if _gold_df.empty:
+            st.info("No multi-asset gold-holding data yet — run **Import Data → mf_holdings** first.")
+        else:
+            # Group by (scheme_code, fund_name), not fund_name alone — two distinct
+            # ICICI schemes (120716, 120334) share the identical fund_name text
+            # "ICICI_MULTI_ASSET" in this dataset, so a fund_name-only groupby would
+            # silently blend two unrelated funds into one card.
+            _sc_per_name = _gold_df.groupby("fund_name")["scheme_code"].nunique()
+            for (_fund, _scheme), _grp in _gold_df.groupby(["fund_name", "scheme_code"]):
+                _grp = _grp.sort_values("as_of_month")
+                _latest = _grp.iloc[-1]
+                _prev = _grp.iloc[-2] if len(_grp) > 1 else None
+                _delta_pp = float(_latest["gold_pct"] - _prev["gold_pct"]) if _prev is not None else 0.0
+                _delta_cr = float(_latest["gold_value_cr"] - _prev["gold_value_cr"]) if _prev is not None else 0.0
+                _action = (
+                    "Scale-in Accumulation" if _delta_pp > 0.3
+                    else "Trimming" if _delta_pp < -0.3
+                    else "Holding Steady"
+                )
+                _label = _fund.replace('_', ' ').title()
+                if _sc_per_name.get(_fund, 1) > 1:
+                    _label = f"{_label} [{_scheme}]"
+                with st.container(border=True):
+                    st.markdown(f"**{_label}**")
+                    _wc1, _wc2 = st.columns(2)
+                    _wc1.metric("Gold % of NAV", f"{_latest['gold_pct']:.2f}%", f"{_delta_pp:+.2f}pp")
+                    _wc2.metric("Gold Capital (₹ Cr)", f"{_latest['gold_value_cr']:,.1f}", f"{_delta_cr:+,.1f} Cr")
+                    st.caption(f"Action: **{_action}**  ·  as of {str(_latest['as_of_month'])[:10]}")
+            st.caption("Full cross-AMC equity consensus → **🐋 Whale Scanner** tab.")
+
+    st.divider()
+    _dash_col_sizer, _dash_col_perf = st.columns([5, 7])
+
+    with _dash_col_sizer:
+        st.subheader("⚡ GARCH Position Sizer")
+        _dash_capital = st.number_input(
+            "Total Portfolio Capital (₹)", min_value=0, value=1_000_000, step=50_000, key="dash_capital"
+        )
+        if st.button("Compute GOLDBEES Sizing", key="dash_sizer_btn"):
+            with st.spinner("Fetching 2y OHLCV → fitting GARCH(1,1) on GOLDBEES…"):
+                try:
+                    from src.tools.garch_position_sizer import size_position
+                    st.session_state["dash_decision"] = size_position("GOLDBEES", "NSE")
+                except Exception as _sizer_exc:
+                    st.session_state["dash_decision"] = None
+                    st.error(f"Sizer failed: {_sizer_exc}")
+
+        _dash_decision = st.session_state.get("dash_decision")
+        if _dash_decision:
+            _dash_alloc = _dash_capital * _dash_decision.final_weight
+            st.metric("GARCH Annualised Vol", f"{_dash_decision.garch_annual_vol_pct:.1f}%")
+            st.metric(
+                f"Recommended Allocation [{_dash_decision.tier}]",
+                f"₹{_dash_alloc:,.0f}",
+                f"{_dash_decision.final_weight:.0%} of capital",
+            )
+            st.caption(_dash_decision.tier_label)
+        else:
+            st.info("Click **Compute GOLDBEES Sizing** to fit GARCH and size the position.")
+
+    with _dash_col_perf:
+        st.subheader("📈 5-Year Performance: GOLDBEES vs COMEX Gold")
+        try:
+            _perf_df = _query_df("""
+                SELECT symbol, category, trade_date, close
+                FROM market_data.daily_prices FINAL
+                WHERE (
+                    (symbol = 'GOLDBEES' AND category = 'etfs')
+                    OR (symbol = 'GOLD' AND category = 'commodities')
+                )
+                AND trade_date >= today() - INTERVAL 5 YEAR
+                ORDER BY trade_date ASC
+            """)
+            _fx_df = _query_df("""
+                SELECT trade_date, close AS usdinr
+                FROM market_data.fx_rates FINAL
+                WHERE symbol = 'USDINR' AND trade_date >= today() - INTERVAL 5 YEAR
+                ORDER BY trade_date ASC
+            """)
+        except Exception as _perf_exc:
+            _perf_df = pd.DataFrame()
+            _fx_df = pd.DataFrame()
+            st.warning(f"Performance query failed: {_perf_exc}")
+
+        def _dash_cagr(first, last, years):
+            if first is None or last is None or first <= 0 or years <= 0:
+                return None
+            return ((last / first) ** (1 / years) - 1) * 100
+
+        if not _perf_df.empty:
+            _gb = _perf_df[_perf_df["symbol"] == "GOLDBEES"].sort_values("trade_date")
+            _gc = _perf_df[_perf_df["symbol"] == "GOLD"].sort_values("trade_date")
+            _years = None
+            _bars: dict[str, float] = {}
+            if not _gb.empty:
+                _years = (_gb["trade_date"].iloc[-1] - _gb["trade_date"].iloc[0]).days / 365.25
+                _v = _dash_cagr(_gb["close"].iloc[0], _gb["close"].iloc[-1], _years)
+                if _v is not None:
+                    _bars["GOLDBEES (INR)"] = _v
+            if not _gc.empty and _years:
+                _v = _dash_cagr(_gc["close"].iloc[0], _gc["close"].iloc[-1], _years)
+                if _v is not None:
+                    _bars["COMEX Gold (USD)"] = _v
+            if not _fx_df.empty and _years:
+                _v = _dash_cagr(_fx_df["usdinr"].iloc[0], _fx_df["usdinr"].iloc[-1], _years)
+                if _v is not None:
+                    _bars["USDINR Currency Alpha"] = _v
+
+            if _bars:
+                import plotly.graph_objects as _go_dash
+                _fig_dash = _go_dash.Figure(_go_dash.Bar(
+                    x=list(_bars.keys()), y=list(_bars.values()),
+                    marker_color=["#f59e0b", "#38bdf8", "#22c55e"][:len(_bars)],
+                    text=[f"{v:.2f}%" for v in _bars.values()],
+                    textposition="outside",
+                ))
+                _fig_dash.update_layout(
+                    yaxis_title="CAGR (%)", height=300,
+                    plot_bgcolor="rgba(0,0,0,0)", paper_bgcolor="rgba(0,0,0,0)",
+                    margin=dict(t=20, b=20),
+                )
+                st.plotly_chart(_fig_dash, use_container_width=True)
+                st.caption(f"CAGR computed over {_years:.1f} years of available overlapping history.")
+            else:
+                st.info("Not enough overlapping history to compute CAGR.")
+        else:
+            st.info("No GOLDBEES/COMEX price history found — run **Import Data** first.")
 
 
 # ══════════════════════════════════════════════════════════════════════════════
@@ -2781,13 +3005,6 @@ with tab_wis:
 with tab_holdings:
     st.header("📦 Multi-Asset Fund Holdings Tracker")
 
-    _FUND_LABELS = {
-        "DSP_MULTI_ASSET":   "DSP Multi Asset",
-        "DSP_MULTI_ASSET_OMNI_FOF": "DSP Multi Asset Omni FoF",
-        "QUANT_MULTI_ASSET": "Quant Multi Asset",
-        "ICICI_MULTI_ASSET": "ICICI Pru Multi Asset",
-        "BAJAJ_MULTI_ASSET": "Bajaj Multi Asset",
-    }
     _ASSET_COLORS = {
         "equity": "#1976D2",
         "gold":   "#FFA726",
@@ -2811,6 +3028,61 @@ with tab_holdings:
         )
         st.stop()
 
+    # ── Discover the multi-asset fund universe dynamically from the DB ─────
+    # Keyed on scheme_code (not fund_name) because this dataset has fund_name
+    # drift in both directions: some AMCs rename a fund while keeping the same
+    # scheme_code (Nippon renamed "...MULTI_ASSET_FUND" → "..._ALLOCATION_FUND"
+    # in 2024, same scheme RLMF806 — grouping by fund_name would fragment one
+    # continuous fund into two apparent funds), while two ICICI schemes
+    # (120334, 120716) share the identical fund_name text "ICICI_MULTI_ASSET"
+    # (grouping by fund_name would conflate two distinct funds into one).
+    # scheme_code itself can occasionally be reused across unrelated funds too
+    # (a known HDFC importer collision: 118989 spans HDFC_MULTI_ASSET AND
+    # HDFC_FLEXI_CAP in different months) — so every downstream query filters
+    # on the (scheme_code, fund_name) PAIR discovered here, never scheme_code
+    # alone.
+    _fund_groups_df = _query_df(
+        """
+        SELECT
+            scheme_code,
+            argMax(fund_name, as_of_month) AS display_fund_name,
+            count(DISTINCT as_of_month)    AS n_months,
+            groupUniqArray(fund_name)      AS fund_name_variants
+        FROM market_data.mf_holdings FINAL
+        WHERE fund_name ILIKE '%MULTI_ASSET%' OR fund_name ILIKE '%MULTI ASSET%'
+        GROUP BY scheme_code
+        ORDER BY n_months DESC
+        """
+    )
+    if _fund_groups_df.empty:
+        st.warning("No multi-asset fund holdings found. Run **📥 Import Data → mf_holdings** first.")
+        st.stop()
+    _fund_groups_df.columns = ["scheme_code", "display_fund_name", "n_months", "fund_name_variants"]
+
+    _ACRONYMS = {"Icici": "ICICI", "Dsp": "DSP", "Hdfc": "HDFC", "Sbi": "SBI", "Fof": "FoF"}
+
+    def _prettify(raw: str) -> str:
+        words = raw.replace("_", " ").title().split()
+        return " ".join(_ACRONYMS.get(w, w) for w in words)
+
+    _FUND_NAME_GROUPS: dict = {}   # scheme_code → [raw fund_name variants matched at discovery]
+    _FUND_LABELS: dict = {}        # scheme_code → display label
+    for _, _g in _fund_groups_df.iterrows():
+        _FUND_NAME_GROUPS[_g["scheme_code"]] = list(_g["fund_name_variants"])
+        _FUND_LABELS[_g["scheme_code"]] = _prettify(_g["display_fund_name"])
+
+    # Disambiguate schemes that share identical fund_name text (e.g. the two
+    # ICICI schemes above) by appending the scheme_code.
+    from collections import Counter as _Counter
+    _label_counts = _Counter(_FUND_LABELS.values())
+    for _sc in list(_FUND_LABELS):
+        if _label_counts[_FUND_LABELS[_sc]] > 1:
+            _FUND_LABELS[_sc] = f"{_FUND_LABELS[_sc]} [{_sc}]"
+
+    def _fund_pairs_clause(keys: list) -> str:
+        pairs = [(k, fn) for k in keys for fn in _FUND_NAME_GROUPS.get(k, [k])]
+        return ", ".join(f"('{sc}', '{fn}')" for sc, fn in pairs)
+
     # ── Available months — all months across mf_holdings (full history) ───
     _months_df = _query_df(
         "SELECT DISTINCT as_of_month FROM market_data.mf_holdings FINAL ORDER BY as_of_month DESC"
@@ -2820,14 +3092,21 @@ with tab_holdings:
         st.warning("No holdings data yet. Run **📥 Import Data → mf_holdings** first.")
         st.stop()
 
+    _all_keys = list(_FUND_LABELS.keys())
+    # Default to funds with >=2 months (enough for MoM) so a handful of
+    # newly-onboarded single-month funds (e.g. HDFC/Kotak/SBI Multi Asset)
+    # don't crowd the default view — still selectable manually.
+    _default_keys = [
+        row["scheme_code"] for _, row in _fund_groups_df.iterrows() if row["n_months"] >= 2
+    ] or _all_keys
     # ── Controls ────────────────────────────────────────────────────────────
     col_fund, col_month = st.columns([2, 1])
     with col_fund:
         selected_funds = st.multiselect(
             "Funds",
-            options=list(_FUND_LABELS.keys()),
-            default=list(_FUND_LABELS.keys()),
-            format_func=lambda k: _FUND_LABELS[k],
+            options=_all_keys,
+            default=_default_keys,
+            format_func=lambda k: _FUND_LABELS.get(k, k),
         )
     with col_month:
         selected_month = st.selectbox(
@@ -2849,15 +3128,15 @@ with tab_holdings:
         st.stop()
 
     # ── Load current month data ────────────────────────────────────────────
-    _fund_filter = ", ".join(f"'{f}'" for f in selected_funds)
+    _fund_filter = _fund_pairs_clause(selected_funds)
     _hold_df = _query_df(
         f"""
         SELECT scheme_code, fund_name, isin, security_name, asset_type,
                market_value_cr, pct_of_nav
         FROM market_data.mf_holdings FINAL
-        WHERE fund_name IN ({_fund_filter})
+        WHERE (scheme_code, fund_name) IN ({_fund_filter})
           AND as_of_month = '{_month_str}'
-        ORDER BY fund_name, pct_of_nav DESC
+        ORDER BY scheme_code, pct_of_nav DESC
         """
     )
     _HOLD_COLS = ["scheme_code", "fund_name", "isin", "security_name",
@@ -2869,32 +3148,34 @@ with tab_holdings:
 
     # ── Fallback: for funds with no data in selected month, load their latest ─
     _sel_month_label = selected_month.strftime("%b %Y") if hasattr(selected_month, "strftime") else str(selected_month)[:7]
-    _funds_with_data = set(_hold_df["fund_name"].unique())
+    _funds_with_data = set(_hold_df["scheme_code"].unique())
     _missing_keys = [k for k in selected_funds if k not in _funds_with_data]
-    _fallback_month_map: dict = {}  # fund_name → display label
+    _fallback_month_map: dict = {}  # scheme_code → display month label
 
     if _missing_keys:
-        _missing_filter = ", ".join(f"'{k}'" for k in _missing_keys)
+        _missing_filter = _fund_pairs_clause(_missing_keys)
         _fb_months_df = _query_df(
-            f"SELECT fund_name, max(as_of_month) AS latest_month"
+            f"SELECT scheme_code, max(as_of_month) AS latest_month"
             f" FROM market_data.mf_holdings FINAL"
-            f" WHERE fund_name IN ({_missing_filter})"
-            f" GROUP BY fund_name"
+            f" WHERE (scheme_code, fund_name) IN ({_missing_filter})"
+            f" GROUP BY scheme_code"
         )
         if not _fb_months_df.empty:
-            _fb_months_df.columns = ["fund_name", "latest_month"]
+            _fb_months_df.columns = ["scheme_code", "latest_month"]
             _fb_chunks = []
             for _, _fb_row in _fb_months_df.iterrows():
-                _fn  = _fb_row["fund_name"]
+                _sc  = _fb_row["scheme_code"]
                 _lm  = _fb_row["latest_month"]
                 _lm_str   = _lm.strftime("%Y-%m-%d") if hasattr(_lm, "strftime") else str(_lm)[:10]
                 _lm_label = _lm.strftime("%b %Y")    if hasattr(_lm, "strftime") else str(_lm)[:7]
+                _fn_variants = ", ".join(f"'{fn}'" for fn in _FUND_NAME_GROUPS.get(_sc, [_sc]))
                 _fb_fund_df = _query_df(
                     f"""
                     SELECT scheme_code, fund_name, isin, security_name, asset_type,
                            market_value_cr, pct_of_nav
                     FROM market_data.mf_holdings FINAL
-                    WHERE fund_name = '{_fn}' AND as_of_month = '{_lm_str}'
+                    WHERE scheme_code = '{_sc}' AND fund_name IN ({_fn_variants})
+                      AND as_of_month = '{_lm_str}'
                     ORDER BY pct_of_nav DESC
                     """
                 )
@@ -2902,11 +3183,11 @@ with tab_holdings:
                     _fb_fund_df.columns = ["scheme_code", "fund_name", "isin", "security_name",
                                            "asset_type", "market_value_cr", "pct_of_nav"]
                     _fb_chunks.append(_fb_fund_df)
-                    _fallback_month_map[_fn] = _lm_label
+                    _fallback_month_map[_sc] = _lm_label
             if _fb_chunks:
                 import pandas as _pd
                 _hold_df = _pd.concat([_hold_df] + _fb_chunks, ignore_index=True)
-                _notes = [f"**{_FUND_LABELS[fn]}** → {lbl}" for fn, lbl in _fallback_month_map.items()]
+                _notes = [f"**{_FUND_LABELS.get(sc, sc)}** → {lbl}" for sc, lbl in _fallback_month_map.items()]
                 st.info(f"No {_sel_month_label} data — showing latest available for: {', '.join(_notes)}")
 
     if _hold_df.empty:
@@ -2914,42 +3195,45 @@ with tab_holdings:
         st.stop()
 
     # fund_label: append "(fallback month)" suffix for funds not on selected month
-    def _make_fund_label(fn: str) -> str:
-        label = _FUND_LABELS.get(fn, fn)
-        if fn in _fallback_month_map:
-            label = f"{label} ({_fallback_month_map[fn]})"
+    def _make_fund_label(sc: str) -> str:
+        label = _FUND_LABELS.get(sc, sc)
+        if sc in _fallback_month_map:
+            label = f"{label} ({_fallback_month_map[sc]})"
         return label
 
-    _hold_df["fund_label"] = _hold_df["fund_name"].apply(_make_fund_label)
+    _hold_df["fund_label"] = _hold_df["scheme_code"].apply(_make_fund_label)
 
     # ══ 1. Asset allocation pie per fund ══════════════════════════════════
     st.subheader("Asset Allocation")
-    pie_cols = st.columns(len(selected_funds))
-    for i, fund_key in enumerate(selected_funds):
-        with pie_cols[i]:
-            _fd = _hold_df[_hold_df["fund_name"] == fund_key]
-            _alloc = _fd.groupby("asset_type")["pct_of_nav"].sum().reset_index()
-            _alloc.columns = ["asset_type", "weight"]
-            if _alloc.empty:
-                st.caption(f"_{_FUND_LABELS[fund_key]}_")
-                st.info("No data")
-            else:
-                import plotly.express as px  # type: ignore[import]
-                fig_pie = px.pie(
-                    _alloc,
-                    values="weight",
-                    names="asset_type",
-                    title=_make_fund_label(fund_key),
-                    color="asset_type",
-                    color_discrete_map=_ASSET_COLORS,
-                    hole=0.35,
-                )
-                fig_pie.update_layout(
-                    margin=dict(t=40, b=0, l=0, r=0),
-                    legend=dict(orientation="h", y=-0.1),
-                    height=320,
-                )
-                st.plotly_chart(fig_pie, width="stretch")
+    _PIE_PER_ROW = 4  # wrap into rows instead of squeezing all funds into one
+    for _row_start in range(0, len(selected_funds), _PIE_PER_ROW):
+        _row_keys = selected_funds[_row_start:_row_start + _PIE_PER_ROW]
+        pie_cols = st.columns(len(_row_keys))
+        for i, fund_key in enumerate(_row_keys):
+            with pie_cols[i]:
+                _fd = _hold_df[_hold_df["scheme_code"] == fund_key]
+                _alloc = _fd.groupby("asset_type")["pct_of_nav"].sum().reset_index()
+                _alloc.columns = ["asset_type", "weight"]
+                if _alloc.empty:
+                    st.caption(f"_{_FUND_LABELS.get(fund_key, fund_key)}_")
+                    st.info("No data")
+                else:
+                    import plotly.express as px  # type: ignore[import]
+                    fig_pie = px.pie(
+                        _alloc,
+                        values="weight",
+                        names="asset_type",
+                        title=_make_fund_label(fund_key),
+                        color="asset_type",
+                        color_discrete_map=_ASSET_COLORS,
+                        hole=0.35,
+                    )
+                    fig_pie.update_layout(
+                        margin=dict(t=40, b=0, l=0, r=0),
+                        legend=dict(orientation="h", y=-0.1),
+                        height=320,
+                    )
+                    st.plotly_chart(fig_pie, width="stretch")
 
     # ══ 2. Holdings table ══════════════════════════════════════════════════
     st.subheader("Holdings Detail")
@@ -2975,19 +3259,19 @@ with tab_holdings:
     # Which months are being compared per fund?
     _cmp_df = _query_df(
         f"""
-        SELECT fund_name,
+        SELECT scheme_code,
                maxIf(as_of_month, rn = 1) AS cur_month,
                maxIf(as_of_month, rn = 2) AS prev_month
         FROM (
-            SELECT fund_name, as_of_month,
-                   row_number() OVER (PARTITION BY fund_name ORDER BY as_of_month DESC) AS rn
+            SELECT scheme_code, as_of_month,
+                   row_number() OVER (PARTITION BY scheme_code ORDER BY as_of_month DESC) AS rn
             FROM (
-                SELECT DISTINCT fund_name, as_of_month
+                SELECT DISTINCT scheme_code, as_of_month
                 FROM market_data.mf_holdings FINAL
-                WHERE fund_name IN ({_fund_filter})
+                WHERE (scheme_code, fund_name) IN ({_fund_filter})
             ) AS t1
         ) AS t2
-        GROUP BY fund_name
+        GROUP BY scheme_code
         HAVING prev_month != toDate('1970-01-01')
         """
     )
@@ -2995,74 +3279,89 @@ with tab_holdings:
     if _cmp_df.empty:
         st.info("Need at least 2 months of data per fund to show drift.")
     else:
-        _cmp_df.columns = ["fund_name", "cur_month", "prev_month"]
+        _cmp_df.columns = ["scheme_code", "cur_month", "prev_month"]
         _cmp_labels = {
-            row["fund_name"]: (
+            row["scheme_code"]: (
                 f"{row['cur_month'].strftime('%b %Y') if hasattr(row['cur_month'], 'strftime') else str(row['cur_month'])[:7]}"
                 f" vs "
                 f"{row['prev_month'].strftime('%b %Y') if hasattr(row['prev_month'], 'strftime') else str(row['prev_month'])[:7]}"
             )
             for _, row in _cmp_df.iterrows()
         }
-        _cmp_caption = "  |  ".join(f"**{_FUND_LABELS.get(fn, fn)}**: {lbl}" for fn, lbl in _cmp_labels.items())
+        _cmp_caption = "  |  ".join(f"**{_make_fund_label(sc)}**: {lbl}" for sc, lbl in _cmp_labels.items())
         st.caption(_cmp_caption)
 
         _drift_df = _query_df(
             f"""
             WITH
             months_ranked AS (
-                SELECT fund_name, as_of_month,
-                       row_number() OVER (PARTITION BY fund_name ORDER BY as_of_month DESC) AS rn
+                SELECT scheme_code, as_of_month,
+                       row_number() OVER (PARTITION BY scheme_code ORDER BY as_of_month DESC) AS rn
                 FROM (
-                    SELECT DISTINCT fund_name, as_of_month
+                    SELECT DISTINCT scheme_code, as_of_month
                     FROM market_data.mf_holdings FINAL
-                    WHERE fund_name IN ({_fund_filter})
+                    WHERE (scheme_code, fund_name) IN ({_fund_filter})
                 ) AS t1
             ),
+            -- Pre-aggregate to a unique (scheme_code, isin) key on each side
+            -- before joining — a defensive dedup in case a single scheme's own
+            -- snapshot ever contains a literal duplicate ISIN row.
             cur AS (
-                SELECT fund_name, isin, security_name, asset_type, pct_of_nav
+                SELECT scheme_code, isin, any(security_name) AS security_name,
+                       any(asset_type) AS asset_type, sum(pct_of_nav) AS pct_of_nav,
+                       1 AS in_cur
                 FROM market_data.mf_holdings FINAL
-                WHERE (fund_name, as_of_month) IN (
-                    SELECT fund_name, as_of_month FROM months_ranked WHERE rn = 1
+                WHERE (scheme_code, fund_name) IN ({_fund_filter})
+                  AND (scheme_code, as_of_month) IN (
+                    SELECT scheme_code, as_of_month FROM months_ranked WHERE rn = 1
                 )
+                GROUP BY scheme_code, isin
             ),
             prev AS (
-                SELECT fund_name, isin, security_name, pct_of_nav
+                SELECT scheme_code, isin, any(security_name) AS security_name,
+                       sum(pct_of_nav) AS pct_of_nav, 1 AS in_prev
                 FROM market_data.mf_holdings FINAL
-                WHERE (fund_name, as_of_month) IN (
-                    SELECT fund_name, as_of_month FROM months_ranked WHERE rn = 2
+                WHERE (scheme_code, fund_name) IN ({_fund_filter})
+                  AND (scheme_code, as_of_month) IN (
+                    SELECT scheme_code, as_of_month FROM months_ranked WHERE rn = 2
                 )
+                GROUP BY scheme_code, isin
             )
             SELECT *
             FROM (
                 SELECT
-                    coalesce(cur.fund_name, prev.fund_name)           AS fund_name,
+                    coalesce(cur.scheme_code, prev.scheme_code)       AS scheme_code,
                     coalesce(cur.isin, prev.isin)                     AS isin,
                     coalesce(cur.security_name, prev.security_name)   AS security_name,
                     coalesce(cur.asset_type, '')                      AS asset_type,
                     coalesce(cur.pct_of_nav, 0.0)                     AS pct_cur,
                     coalesce(prev.pct_of_nav, 0.0)                    AS pct_prev,
                     coalesce(cur.pct_of_nav, 0.0) - coalesce(prev.pct_of_nav, 0.0) AS drift,
+                    -- Presence is tested via in_cur/in_prev (NULL only when the outer
+                    -- join found no row on that side), NOT via isin = '' — several real
+                    -- holdings (TREPS, cash offsets, futures) legitimately have a blank
+                    -- isin field while still present in both months.
                     CASE
-                        WHEN prev.isin IS NULL OR prev.isin = '' THEN 'ENTERED'
-                        WHEN cur.isin  IS NULL OR cur.isin  = '' THEN 'EXITED'
-                        WHEN abs(cur.pct_of_nav - prev.pct_of_nav) >= 2               THEN 'CHANGED'
+                        WHEN prev.in_prev IS NULL THEN 'ENTERED'
+                        WHEN cur.in_cur   IS NULL THEN 'EXITED'
+                        WHEN abs(cur.pct_of_nav - prev.pct_of_nav) >= 2 THEN 'CHANGED'
                         ELSE 'UNCHANGED'
                     END AS event
                 FROM cur
-                FULL OUTER JOIN prev ON cur.fund_name = prev.fund_name AND cur.isin = prev.isin
+                FULL OUTER JOIN prev ON cur.scheme_code = prev.scheme_code AND cur.isin = prev.isin
             ) AS joined
             WHERE event != 'UNCHANGED'
-            ORDER BY fund_name, event, abs(drift) DESC
+            ORDER BY scheme_code, event, abs(drift) DESC
+            SETTINGS join_use_nulls = 1
             """
         )
 
         if _drift_df.empty:
             st.success("No significant changes vs prior month (no ENTERED/EXITED, all weight shifts < 2 pp).")
         else:
-            _drift_df.columns = ["fund_name", "isin", "security_name", "asset_type",
+            _drift_df.columns = ["scheme_code", "isin", "security_name", "asset_type",
                                   "pct_cur", "pct_prev", "drift", "event"]
-            _drift_df["fund_label"] = _drift_df["fund_name"].map(_FUND_LABELS).fillna(_drift_df["fund_name"])
+            _drift_df["fund_label"] = _drift_df["scheme_code"].apply(_make_fund_label)
             _event_color = {"ENTERED": "🟢", "EXITED": "🔴", "CHANGED": "🟡"}
             _drift_df["🔔"] = _drift_df["event"].map(_event_color).fillna("")
             st.dataframe(
@@ -3085,36 +3384,49 @@ with tab_holdings:
     # ══ 4. Asset allocation trend over time ═══════════════════════════════
     if len(_available_months) >= 2:
         st.subheader("Allocation Trend Over Time")
+        # scheme_code is now the canonical, non-colliding identity (see the
+        # discovery block above), so a plain sum per (as_of_month, scheme_code,
+        # asset_type) is correct — no cross-scheme blending needed.
         _trend_df = _query_df(
             f"""
-            SELECT as_of_month, fund_name, asset_type, sum(pct_of_nav) AS weight
+            SELECT as_of_month, scheme_code, lower(asset_type) AS asset_type,
+                   sum(pct_of_nav) AS weight
             FROM market_data.mf_holdings FINAL
-            WHERE fund_name IN ({_fund_filter})
-            GROUP BY as_of_month, fund_name, asset_type
-            ORDER BY as_of_month, fund_name, asset_type
+            WHERE (scheme_code, fund_name) IN ({_fund_filter})
+            GROUP BY as_of_month, scheme_code, asset_type
+            ORDER BY as_of_month, scheme_code, asset_type
             """
         )
         if not _trend_df.empty:
-            _trend_df.columns = ["month", "fund_name", "asset_type", "weight"]
+            _trend_df.columns = ["month", "scheme_code", "asset_type", "weight"]
             import plotly.express as px  # noqa: F811
-            _trend_df["fund_label"] = _trend_df["fund_name"].map(_FUND_LABELS).fillna(_trend_df["fund_name"])
+            _trend_df["fund_label"] = _trend_df["scheme_code"].apply(_make_fund_label)
             
-            # Stacked Area Chart
+            # Wrap facets into a grid (was: all funds squeezed into one row via
+            # facet_col_wrap=len(selected_funds), which never wraps) and give each
+            # fund its OWN x-axis range. Funds have wildly different history depth
+            # (e.g. DSP: 35 months since 2023 vs ICICI: 5 months since Apr 2026) —
+            # a shared x-axis squeezes a short-history fund into a sliver of a
+            # multi-year timeline it doesn't actually span.
+            _n_funds = max(1, len(selected_funds))
+            _facet_wrap = min(3, _n_funds)
+            _n_rows = -(-_n_funds // _facet_wrap)  # ceil division
             fig_trend = px.area(
                 _trend_df,
                 x="month",
                 y="weight",
                 color="asset_type",
                 facet_col="fund_label",
-                facet_col_wrap=len(selected_funds),
+                facet_col_wrap=_facet_wrap,
                 color_discrete_map=_ASSET_COLORS,
                 labels={"month": "", "weight": "Weight (%)", "asset_type": "Type"},
-                height=380,
-                markers=True,
+                height=300 * _n_rows,
             )
+            fig_trend.update_xaxes(matches=None, showticklabels=True)
+            fig_trend.for_each_annotation(lambda a: a.update(text=a.text.split("=")[-1]))
             fig_trend.update_layout(
-                margin=dict(t=30, b=0),
-                legend=dict(orientation="h", y=-0.2)
+                margin=dict(t=40, b=0),
+                legend=dict(orientation="h", y=-0.12)
             )
             st.plotly_chart(fig_trend, width="stretch")
 
@@ -3126,11 +3438,11 @@ with tab_holdings:
             SELECT
                 security_name,
                 any(asset_type)                                                    AS asset_type,
-                count(DISTINCT fund_name)                                          AS n_funds,
+                count(DISTINCT scheme_code)                                        AS n_funds,
                 sum(pct_of_nav)                                                    AS total_weight,
                 groupArray(concat(fund_name, ' (', toString(round(pct_of_nav, 1)), '%)')) AS breakdown
             FROM market_data.mf_holdings FINAL
-            WHERE fund_name IN ({_fund_filter})
+            WHERE (scheme_code, fund_name) IN ({_fund_filter})
               AND as_of_month = '{_month_str}'
             GROUP BY security_name
             HAVING total_weight > 0.5
@@ -3170,6 +3482,100 @@ with tab_holdings:
                 )
         else:
             st.info("No holdings above 0.5% weight found for the selected funds/month.")
+
+    # ══ 6. Cross-Fund Multi-Asset Consensus ─ heatmap + diverging bar chart ══
+    st.divider()
+    st.subheader("🤝 Cross-Fund Multi-Asset Consensus")
+    st.caption(
+        "Smart-money overlap across all 7 tracked multi-asset funds (Nippon, Nippon FoF, "
+        "DSP, DSP Omni, Bajaj, Quant, ICICI) — independent of the fund/month filters above. "
+        "Securities are matched across funds by **ISIN**, not name text, since AMCs spell the "
+        "same company differently. Each fund compares its own two most-recent snapshots, so rows "
+        "may span different calendar months where a fund's disclosure lags the others."
+    )
+    _ascii_col_delta, _ascii_col_top, _ascii_col_run = st.columns([1, 1, 1])
+    with _ascii_col_delta:
+        _ascii_min_delta = st.number_input(
+            "Min |Δ| pct-pts", min_value=0.05, max_value=2.0, value=0.10, step=0.05,
+            key="mf_ascii_min_delta",
+        )
+    with _ascii_col_top:
+        _ascii_top_n = st.slider("Names shown", 6, 40, 20, 2, key="mf_ascii_top_n")
+    with _ascii_col_run:
+        st.write("")
+        st.write("")
+        _ascii_run = st.button("▶ Run Consensus View", key="mf_ascii_viz_run", use_container_width=True)
+
+    if _ascii_run:
+        with st.spinner("Querying mf_holdings for all 7 multi-asset funds…"):
+            from src.scripts.portfolio.multi_asset_ascii_viz import (
+                ASSET_ORDER as _MAV_ASSET_ORDER,
+                build_asset_class_matrix,
+                build_consensus_moves,
+            )
+            try:
+                _mat_df = build_asset_class_matrix()
+                _moves_df = build_consensus_moves(min_delta=float(_ascii_min_delta))
+            except Exception as _ascii_exc:
+                st.error(f"Consensus view query failed: {_ascii_exc}")
+                _mat_df, _moves_df = pd.DataFrame(), pd.DataFrame()
+
+            if _mat_df.empty:
+                st.info("No funds with ≥2 months of holdings history.")
+            else:
+                import plotly.graph_objects as _go_mav
+                _z = _mat_df[_MAV_ASSET_ORDER].values
+                _fig_heat = _go_mav.Figure(data=_go_mav.Heatmap(
+                    z=_z,
+                    x=[a.upper() for a in _MAV_ASSET_ORDER],
+                    y=_mat_df["fund"],
+                    colorscale="RdYlGn",
+                    zmid=0,
+                    text=[[f"{v:+.2f}" for v in row] for row in _z],
+                    texttemplate="%{text}",
+                    hovertemplate="<b>%{y}</b><br>%{x}: %{z:+.2f} pct-pts<extra></extra>",
+                    colorbar=dict(title="Δ pp"),
+                ))
+                _fig_heat.update_layout(
+                    title="Fund × Asset-Class MoM Weight Shift (pct-pts)",
+                    height=320,
+                    margin=dict(t=50, b=10, l=10, r=10),
+                )
+                st.plotly_chart(_fig_heat, use_container_width=True)
+                _snap_caption = "  |  ".join(
+                    f"**{row['fund']}**: {row['prev']} → {row['curr']}" for _, row in _mat_df.iterrows()
+                )
+                st.caption(_snap_caption)
+
+            if _moves_df.empty:
+                st.info("No security moved by ≥2 funds at this threshold.")
+            else:
+                _half = max(1, int(_ascii_top_n) // 2)
+                _top_df = (
+                    pd.concat([_moves_df.head(_half), _moves_df.tail(_half)])
+                    .drop_duplicates(subset="isin")
+                    .sort_values("avg_delta")
+                )
+                _fig_moves = _go_mav.Figure(_go_mav.Bar(
+                    x=_top_df["avg_delta"],
+                    y=_top_df["security"],
+                    orientation="h",
+                    marker_color=["#ef4444" if v < 0 else "#22c55e" for v in _top_df["avg_delta"]],
+                    text=[f"{v:+.2f} ({int(n)} funds, net {int(net):+d})" for v, n, net in
+                          zip(_top_df["avg_delta"], _top_df["n_funds"], _top_df["net"])],
+                    textposition="outside",
+                ))
+                _fig_moves.add_vline(x=0, line_color="#888888", line_width=1)
+                _fig_moves.update_layout(
+                    title="Consensus Movers — avg Δ pct-pts (≥2 funds, ISIN-matched)",
+                    xaxis_title="Avg Δ (pct-pts)",
+                    height=max(320, 28 * len(_top_df)),
+                    margin=dict(t=50, b=10, l=10, r=60),
+                    plot_bgcolor="rgba(0,0,0,0)",
+                )
+                st.plotly_chart(_fig_moves, use_container_width=True)
+    else:
+        st.info("Click **▶ Run Consensus View** to render the fund×asset-class heatmap and consensus-movers bar chart.")
 
 
 # ══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- **Cross-Fund Multi-Asset Consensus**: Interactive UI in Streamlit tab 5 + terminal ASCII visualization script (`multi_asset_ascii_viz.py`) to track ISIN-matched smart-money additions and trims across 7 multi-asset funds (Nippon, Nippon FoF, DSP, DSP Omni, Bajaj, Quant, ICICI).
- **GOLDBEES 90-Day Returns**: Terminal ASCII chart utility (`goldbees_90d_returns.py`) for 90-trading-day rolling returns via plotext.
- **iNAV Fixes**: Converted UTC fetcher timestamps to IST in `data_importer` and updated GitHub Actions scheduled capture loop.
- **Data Pointer**: Updated `data_importer` submodule reference to latest commit (`e6e0bd1`).