### PR TITLE
fix(ui): pin starlette<1.4.0 to fix Streamlit GZip 500 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,6 +52,7 @@ tenacity>=8.2.0                  # Exponential-backoff retry wrapper for fetcher
 
 # ── Web UI ────────────────────────────────────────────────────────────────────
 streamlit>=1.35.0                # Data management UI (streamlit run src/ui/app.py)
+starlette>=0.49.1,<1.4.0         # Pin <1.4.0: Starlette 1.4.0 breaking change in GZipResponder breaks Streamlit
 altair>=5.0.0                    # Declarative charts for anomaly detection tab
 scikit-learn>=1.4.0              # Isolation Forest anomaly detection (Random Forest removed — use GARCH)
 arch>=6.3.0                      # GARCH(1,1) Student-t conditional volatility — replaces RF in anomaly pipeline


### PR DESCRIPTION
### Summary
Starlette `1.4.0+` added a required keyword-only parameter `thread_minimum_size` to `GZipResponder.__init__`. When Streamlit initializes its `_MediaAwareGZipResponder` middleware, it invokes the constructor without that parameter, causing a `TypeError: GZipResponder.__init__() missing 1 required keyword-only argument: 'thread_minimum_size'` and resulting in HTTP 500 responses for static assets and WebSocket streaming.

### Changes
- Pin `starlette>=0.49.1,<1.4.0` in `requirements.txt`.

### Verification
- Tested in Docker container: rebuilt image and verified `http://localhost:8501/` and `http://localhost:8501/_stcore/health` return `200 OK`.