### PR TITLE
feat(importer): add Abakkus Mutual Fund monthly portfolio importer

### DIFF
--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -97,6 +97,7 @@ python src/main.py import --category icici        # ICICI Prudential multi-asset
 python src/main.py import --category icici-index  # ICICI Index funds
 python src/main.py import --category quant        # Quant active funds
 python src/main.py import --category bajaj        # Bajaj Finserv funds
+python src/main.py import --category abakkus      # Abakkus Mutual Fund (Flexi Cap, Small Cap, Liquid)
 python src/main.py import --category amfi         # AMFI category flows & AUM
 ```
 
@@ -107,6 +108,7 @@ python src/scripts/fund_imports/run.py nippon       # Nippon holdings backfill
 python src/scripts/fund_imports/run.py icici        # ICICI holdings backfill
 python src/scripts/fund_imports/run.py quant        # Quant holdings backfill
 python src/scripts/fund_imports/run.py bajaj        # Bajaj holdings backfill
+python src/scripts/fund_imports/run.py abakkus      # Abakkus holdings backfill
 python src/scripts/fund_imports/run.py amfi         # AMFI category-wise net flows
 python src/scripts/fund_imports/run.py all          # Run all registered AMC importers
 ```

--- a/src/data_importer/abakkus_holdings/__init__.py
+++ b/src/data_importer/abakkus_holdings/__init__.py
@@ -1,0 +1,1 @@
+"""Abakkus holdings import package."""

--- a/src/data_importer/abakkus_holdings/import_all_abakkus.py
+++ b/src/data_importer/abakkus_holdings/import_all_abakkus.py
@@ -1,0 +1,64 @@
+"""
+src/data_importer/abakkus_holdings/import_all_abakkus.py
+────────────────────────────────────────────────────────
+Standalone script to fetch and import Abakkus Mutual Fund portfolio holdings into ClickHouse.
+
+Usage:
+    python src/data_importer/abakkus_holdings/import_all_abakkus.py
+    python src/data_importer/abakkus_holdings/import_all_abakkus.py --full
+    python src/data_importer/abakkus_holdings/import_all_abakkus.py --dry-run
+    python src/data_importer/abakkus_holdings/import_all_abakkus.py --month 2026-07
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.getcwd())
+
+from rich.console import Console
+
+from src.data_importer.amc_holdings.importers.abakkus import AbakkusImporter
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import Abakkus Mutual Fund monthly portfolio holdings")
+    parser.add_argument("--full", action="store_true", help="Ignore watermarks and re-import all historical files")
+    parser.add_argument("--dry-run", action="store_true", help="Download and parse files without writing to ClickHouse")
+    parser.add_argument("--month", type=str, default="", help="Specific month to import (YYYY-MM, e.g. 2026-07)")
+    parser.add_argument("--fresh", type=int, default=0, help="Re-import the N most recent months")
+    parser.add_argument("--year", type=int, default=2024, help="Earliest year to consider (default: 2024)")
+    args = parser.parse_args()
+
+    target_month = None
+    if args.month:
+        try:
+            target_month = datetime.strptime(args.month, "%Y-%m").date()
+        except ValueError:
+            console.print(f"[red]Invalid month format: {args.month}. Expected YYYY-MM.[/red]")
+            sys.exit(1)
+
+    console.print(
+        f"[bold blue]Starting Abakkus Portfolio Import[/bold blue] "
+        f"(full={args.full}, dry_run={args.dry_run}, target_month={target_month}, fresh={args.fresh})"
+    )
+
+    importer = AbakkusImporter(
+        full_reimport=args.full,
+        from_year=args.year,
+        target_month=target_month,
+        freshness_months=args.fresh,
+    )
+    importer.run(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_importer/amc_holdings/factory.py
+++ b/src/data_importer/amc_holdings/factory.py
@@ -26,6 +26,7 @@ from src.data_importer.amc_holdings.importers.quant import QuantImporter
 from src.data_importer.amc_holdings.importers.amfi import AmfiImporter
 from src.data_importer.amc_holdings.importers.hdfc import HdfcImporter
 from src.data_importer.amc_holdings.importers.kotak import KotakImporter
+from src.data_importer.amc_holdings.importers.abakkus import AbakkusImporter
 
 REGISTRY: dict[str, type[BaseFundImporter]] = {
     "icici":       IciciMFImporter,
@@ -37,6 +38,8 @@ REGISTRY: dict[str, type[BaseFundImporter]] = {
     "amfi":        AmfiImporter,
     "kotak":       KotakImporter,
     "hdfc":        HdfcImporter,
+    "abakkus":     AbakkusImporter,
+    "abacus":      AbakkusImporter,
 }
 
 

--- a/src/data_importer/amc_holdings/importers/abakkus.py
+++ b/src/data_importer/amc_holdings/importers/abakkus.py
@@ -1,0 +1,417 @@
+"""
+src/data_importer/amc_holdings/importers/abakkus.py
+────────────────────────────────────────────────────
+Abakkus Mutual Fund (AMC) monthly portfolio holdings importer.
+
+Scrapes statutory disclosures from https://www.abakkusmf.com/statutory-disclosures.html,
+downloads monthly XLS/XLSX workbooks across all active schemes (Flexi Cap, Small Cap,
+Liquid, Large & Mid Cap), parses instrument holdings, classifies asset types, converts
+values to Crores, and stores rows into market_data.mf_holdings with delta sync and watermarking.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+import re
+from datetime import date, datetime
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from src.data_importer.amc_holdings.base import (
+    COMMON_HEADERS,
+    BaseFundImporter,
+    classify_asset,
+)
+
+logger = logging.getLogger(__name__)
+
+DISCLOSURES_URL = "https://www.abakkusmf.com/statutory-disclosures.html"
+BASE_URL = "https://www.abakkusmf.com"
+_TIMEOUT = 30.0
+
+_ISIN_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
+
+# Static / canonical scheme mapping
+SCHEME_MAP: dict[str, tuple[str, str]] = {
+    "ABAFC":  ("ABAKKUS_FLEXI_CAP", "Abakkus Flexi Cap Fund"),
+    "ABASC":  ("ABAKKUS_SMALL_CAP", "Abakkus Small Cap Fund"),
+    "ABALI":  ("ABAKKUS_LIQUID", "Abakkus Liquid Fund"),
+    "ABALMC": ("ABAKKUS_LARGE_AND_MID_CAP", "Abakkus Large & Mid Cap Fund"),
+}
+
+_COLUMNS = [
+    "scheme_code",
+    "fund_name",
+    "as_of_month",
+    "isin",
+    "security_name",
+    "asset_type",
+    "market_value_cr",
+    "pct_of_nav",
+    "imported_at",
+]
+
+
+def _parse_disclosure_date(title_str: str, fname_str: str) -> date | None:
+    """Parse date from disclosure title or filename."""
+    clean = re.sub(r"(st|nd|rd|th)", "", title_str)
+    m = re.search(
+        r"(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2}),?\s+(\d{4})",
+        clean,
+        re.I,
+    )
+    if m:
+        month_name, day, year = m.groups()
+        try:
+            return datetime.strptime(f"{year}-{month_name}-{day}", "%Y-%B-%d").date()
+        except ValueError:
+            pass
+
+    m2 = re.search(
+        r"(\d{1,2})[\s\-_\.](January|February|March|April|May|June|July|August|September|October|November|December|\d{1,2})[\s\-_\.](\d{4})",
+        clean,
+        re.I,
+    )
+    if m2:
+        d, mon, y = m2.groups()
+        try:
+            if mon.isdigit():
+                return datetime(int(y), int(mon), int(d)).date()
+            return datetime.strptime(f"{y}-{mon}-{d}", "%Y-%B-%d").date()
+        except ValueError:
+            pass
+
+    # Try filename fallback e.g. Abakkus_Mutual_Fund_31.05.2026.xls
+    m3 = re.search(r"(\d{1,2})[\._\-](\d{1,2})[\._\-](\d{4})", fname_str)
+    if m3:
+        d, mon, y = m3.groups()
+        try:
+            return datetime(int(y), int(mon), int(d)).date()
+        except ValueError:
+            pass
+
+    return None
+
+
+def _normalise_fund_identity(sheet_name: str, row0_text: str = "", row1_text: str = "") -> tuple[str, str]:
+    """Resolve (scheme_code, fund_name) from sheet name or text snippet."""
+    key = sheet_name.strip().upper()
+    if key in SCHEME_MAP:
+        return SCHEME_MAP[key]
+
+    comb = f"{sheet_name} {row0_text} {row1_text}".upper()
+    if "FLEXI" in comb:
+        return SCHEME_MAP["ABAFC"]
+    if "SMALL" in comb:
+        return SCHEME_MAP["ABASC"]
+    if "LIQUID" in comb:
+        return SCHEME_MAP["ABALI"]
+    if "LARGE" in comb or "MID" in comb:
+        return SCHEME_MAP["ABALMC"]
+
+    norm_code = re.sub(r"[^A-Z0-9_]", "", key.replace(" ", "_"))
+    if not norm_code.startswith("ABAKKUS_"):
+        norm_code = f"ABAKKUS_{norm_code}"
+    return (norm_code, f"Abakkus {sheet_name.strip()}")
+
+
+class AbakkusImporter(BaseFundImporter):
+    """
+    Abakkus Mutual Fund monthly portfolio importer.
+    Supports auto-discovery, delta sync, watermarking, and historical re-imports.
+    """
+
+    REQUEST_DELAY = 1.0
+
+    def __init__(
+        self,
+        full_reimport: bool = False,
+        from_year: int = 2024,
+        target_month: date | None = None,
+        freshness_months: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(target_month=target_month, freshness_months=freshness_months)
+        self.full_reimport = full_reimport
+        self.from_year = from_year
+        self._latest_imported_date: date | None = None
+
+    def fund_name(self) -> str:
+        return "Abakkus Mutual Fund"
+
+    def table_name(self) -> str:
+        return "market_data.mf_holdings"
+
+    def column_names(self) -> list[str]:
+        return _COLUMNS
+
+    def watermark_source(self) -> str:
+        return "mf_holdings"
+
+    def fetch_sources(self) -> list[tuple[date, str, str]]:
+        """
+        Scrape statutory disclosures page to discover all monthly portfolio workbooks.
+        Returns list of (as_of_date, filename, full_download_url).
+        """
+        sources: list[tuple[date, str, str]] = []
+        with httpx.Client(headers=COMMON_HEADERS, timeout=_TIMEOUT, follow_redirects=True) as http:
+            try:
+                resp = http.get(DISCLOSURES_URL)
+                resp.raise_for_status()
+                html = resp.text
+            except Exception as exc:
+                self._console.print(f"[red]Abakkus: failed to load disclosures page: {exc}[/red]")
+                return []
+
+            m = re.search(r"const verticals = (\[.*?\]);\s*\n", html, re.DOTALL)
+            if not m:
+                self._console.print("[red]Abakkus: could not extract verticals JSON from page[/red]")
+                return []
+
+            try:
+                verticals_data = json.loads(m.group(1))
+            except Exception as exc:
+                self._console.print(f"[red]Abakkus: failed to parse verticals JSON: {exc}[/red]")
+                return []
+
+            for v in verticals_data:
+                v_title = v.get("title", "")
+                if "monthly portfolio" not in v_title.lower():
+                    continue
+
+                for sec in v.get("sections", []):
+                    for sub in sec.get("subSections", []):
+                        for item in sub.get("items", []):
+                            title = item.get("title", "")
+                            media = item.get("downloadMedia") or {}
+                            url = media.get("url") or ""
+                            fname = media.get("name") or ""
+                            ext = media.get("ext") or ""
+
+                            if ext.lower() not in [".xls", ".xlsx"]:
+                                continue
+
+                            as_of = _parse_disclosure_date(title, fname)
+                            if as_of is None:
+                                continue
+
+                            if as_of.year < self.from_year:
+                                continue
+
+                            full_url = url if url.startswith("http") else BASE_URL + url
+                            sources.append((as_of, fname, full_url))
+
+        # Deduplicate sources by date and filename
+        seen: set[tuple[date, str]] = set()
+        deduped: list[tuple[date, str, str]] = []
+        for as_of, fn, u in sorted(sources, key=lambda x: x[0]):
+            key = (as_of, fn)
+            if key not in seen:
+                seen.add(key)
+                deduped.append((as_of, fn, u))
+
+        self._console.print(f"[dim]Abakkus: discovered {len(deduped)} monthly portfolio file(s).[/dim]")
+        return deduped
+
+    def filter_sources(
+        self, sources: list[tuple[date, str, str]], client: Any
+    ) -> list[tuple[date, str, str]]:
+        """Filter out months already imported into ClickHouse, unless full_reimport is active."""
+        if self.full_reimport:
+            return sources
+
+        last_date: date | None = None
+        try:
+            rows = client.query(
+                "SELECT max(last_date) FROM market_data.import_watermarks "
+                "WHERE source = 'mf_holdings' AND symbol = 'ABAKKUS_MONTHLY'"
+            ).result_rows
+            if rows and rows[0][0]:
+                last_date = rows[0][0]
+        except Exception as exc:
+            logger.warning("Failed to query Abakkus watermark: %s", exc)
+
+        if last_date is None:
+            return sources
+
+        filtered = [s for s in sources if s[0] > last_date]
+        skipped = len(sources) - len(filtered)
+        if skipped:
+            self._console.print(
+                f"[dim]Delta sync: {skipped} Abakkus file(s) already in DB (watermark {last_date}), "
+                f"{len(filtered)} to fetch.[/dim]"
+            )
+        return filtered
+
+    def parse_source(
+        self, source: tuple[date, str, str], http: httpx.Client
+    ) -> list[dict]:
+        """
+        Download and parse an Abakkus monthly Excel workbook across all scheme sheets.
+        """
+        as_of_date, fname, url = source
+        try:
+            resp = http.get(url, timeout=_TIMEOUT)
+            resp.raise_for_status()
+        except Exception as exc:
+            self._console.print(f"  [red]Download failed ({url}): {exc}[/red]")
+            return []
+
+        # Load Excel workbook with engine fallback
+        xl: pd.ExcelFile | None = None
+        for engine in ("openpyxl", "xlrd"):
+            try:
+                xl = pd.ExcelFile(io.BytesIO(resp.content), engine=engine)
+                break
+            except Exception:
+                continue
+
+        if xl is None:
+            self._console.print(f"  [red]Cannot parse Abakkus workbook '{fname}'[/red]")
+            return []
+
+        all_holdings: list[dict] = []
+        imported_at = datetime.now()
+
+        for sheet in xl.sheet_names:
+            if sheet.strip().lower() == "index":
+                continue
+
+            try:
+                df = xl.parse(sheet, header=None)
+            except Exception as exc:
+                logger.debug("Failed parsing sheet %s: %s", sheet, exc)
+                continue
+
+            if df.shape[0] < 5 or df.shape[1] < 6:
+                continue
+
+            row0_str = str(df.iloc[0, 1]) if df.shape[1] > 1 and pd.notna(df.iloc[0, 1]) else ""
+            row1_str = str(df.iloc[1, 1]) if df.shape[0] > 1 and df.shape[1] > 1 and pd.notna(df.iloc[1, 1]) else ""
+            scheme_code, fund_name = _normalise_fund_identity(sheet, row0_str, row1_str)
+
+            # Locate column header row dynamically
+            header_row_idx: int | None = None
+            for r in range(min(15, len(df))):
+                r_vals = [str(x).strip().lower() for x in df.iloc[r].tolist() if pd.notna(x)]
+                if any("isin" in x for x in r_vals) and any("instrument" in x or "name" in x for x in r_vals):
+                    header_row_idx = r
+                    break
+
+            if header_row_idx is None:
+                continue
+
+            headers_list = [str(x).strip() if pd.notna(x) else "" for x in df.iloc[header_row_idx].tolist()]
+
+            isin_col: int | None = None
+            name_col: int | None = None
+            ind_col: int | None = None
+            mv_col: int | None = None
+            pct_col: int | None = None
+
+            for c_idx, h in enumerate(headers_list):
+                hl = h.lower()
+                if "isin" in hl:
+                    isin_col = c_idx
+                elif "instrument" in hl or "name" in hl:
+                    if name_col is None:
+                        name_col = c_idx
+                elif "industry" in hl or "rating" in hl:
+                    ind_col = c_idx
+                elif "market" in hl or "fair value" in hl:
+                    mv_col = c_idx
+                elif "%" in hl or "net assets" in hl or "nav" in hl:
+                    pct_col = c_idx
+
+            # Standard layout fallback
+            if isin_col is None:
+                isin_col = 2
+            if name_col is None:
+                name_col = 1
+            if ind_col is None:
+                ind_col = 3
+            if mv_col is None:
+                mv_col = 5
+            if pct_col is None:
+                pct_col = 6
+
+            sheet_raw_rows: list[tuple[str, str, str, float, float]] = []
+            for r_idx in range(header_row_idx + 1, len(df)):
+                row = df.iloc[r_idx].tolist()
+                if len(row) <= max(isin_col, name_col, ind_col, mv_col, pct_col):
+                    continue
+
+                isin_val = str(row[isin_col]).strip()
+                if not _ISIN_RE.match(isin_val):
+                    continue
+
+                name_val = str(row[name_col]).strip() if pd.notna(row[name_col]) else ""
+                ind_val = str(row[ind_col]).strip() if pd.notna(row[ind_col]) else ""
+
+                try:
+                    mv_raw = float(row[mv_col])
+                except (TypeError, ValueError):
+                    mv_raw = 0.0
+
+                try:
+                    pct_raw = float(row[pct_col])
+                except (TypeError, ValueError):
+                    pct_raw = 0.0
+
+                sheet_raw_rows.append((isin_val, name_val, ind_val, mv_raw, pct_raw))
+
+            if not sheet_raw_rows:
+                continue
+
+            # Check percentage scaling (fraction 0-1 vs percentage 0-100)
+            valid_pcts = [r[4] for r in sheet_raw_rows if r[4] == r[4] and r[4] != 0]
+            raw_sum = sum(valid_pcts)
+            pct_scale = 100.0 if raw_sum <= 5.0 else 1.0
+
+            sheet_holdings: list[dict] = []
+            for isin_val, name_val, ind_val, mv_raw, pct_raw in sheet_raw_rows:
+                pct_val = round(pct_raw * pct_scale, 4)
+                if pct_val > 50.0:
+                    logger.warning(
+                        "Skipping anomalous row '%s' (%s, %s): pct_of_nav=%.2f%% > 50%%",
+                        name_val,
+                        scheme_code,
+                        as_of_date,
+                        pct_val,
+                    )
+                    continue
+
+                sheet_holdings.append({
+                    "scheme_code": scheme_code,
+                    "fund_name": fund_name,
+                    "as_of_month": as_of_date,
+                    "isin": isin_val,
+                    "security_name": name_val,
+                    "asset_type": classify_asset(name_val, ind_val),
+                    "market_value_cr": round(mv_raw / 100.0, 4),  # Rs Lakhs -> Rs Cr
+                    "pct_of_nav": pct_val,
+                    "imported_at": imported_at,
+                })
+
+            if sheet_holdings:
+                pct_total = sum(h["pct_of_nav"] for h in sheet_holdings)
+                color = "green" if pct_total <= 105.0 else "yellow"
+                self._console.print(
+                    f"  [{color}]{fund_name} ({sheet}): {len(sheet_holdings)} holdings, "
+                    f"pct_total={pct_total:.1f}% ({as_of_date})[/{color}]"
+                )
+                all_holdings.extend(sheet_holdings)
+
+        if self._latest_imported_date is None or as_of_date > self._latest_imported_date:
+            self._latest_imported_date = as_of_date
+
+        return all_holdings
+
+    def watermark_rows(self, all_rows: list[dict]) -> list[tuple[str, date]]:
+        if self._latest_imported_date:
+            return [("ABAKKUS_MONTHLY", self._latest_imported_date)]
+        return []

--- a/src/data_importer/cli.py
+++ b/src/data_importer/cli.py
@@ -307,7 +307,7 @@ def run_import(
 
 
     # ── AMC Fund-Holdings Importers ───────────────────────────────────────────
-    _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant") if c in categories]
+    _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant", "hdfc", "kotak", "abakkus", "abacus") if c in categories]
     if _amc_cats:
         from src.data_importer.fetchers.amc_holdings_fetcher import fetch_amc_holdings
 

--- a/src/data_importer/fetchers/amc_holdings_fetcher.py
+++ b/src/data_importer/fetchers/amc_holdings_fetcher.py
@@ -25,7 +25,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Valid values for the `amc` argument — mirrors factory.REGISTRY keys.
-AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi"})
+AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus"})
 
 
 def fetch_amc_holdings(
@@ -56,7 +56,7 @@ def fetch_amc_holdings(
     from src.data_importer.amc_holdings.factory import create_importer
 
     kwargs: dict = {}
-    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi"):
+    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus"):
         kwargs["full_reimport"] = full_reimport
 
     if target_month:

--- a/src/data_importer/maintenance/audit_freshness.py
+++ b/src/data_importer/maintenance/audit_freshness.py
@@ -155,7 +155,7 @@ def audit_freshness():
             elif import_name == "inav": import_name = "inav"
             elif import_name == "indian_macro": import_name = "indian_macro"
             elif import_name == "fii_dii": import_name = "fii_dii"
-            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj"
+            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus"
             stale_categories.append(import_name)
 
         table.add_row(cat, tbl_name, str(max_date), status)

--- a/src/main.py
+++ b/src/main.py
@@ -939,7 +939,7 @@ def import_data(
             "cot, cb_reserves, etf_aum, mf_holdings, fii_dii, amfi_flows, "
             "earnings, insider, valuation, "
             "world_bank, imf_weo, indian_macro, indian_macro_indicators, "
-            "icici, nippon, icici-index, dsp, bajaj, quant, all. "
+            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, all. "
             "Default: all."
         ),
     ),

--- a/src/scripts/abakkus/import_all_abakkus.py
+++ b/src/scripts/abakkus/import_all_abakkus.py
@@ -1,0 +1,23 @@
+"""
+src/scripts/abakkus/import_all_abakkus.py
+──────────────────────────────────────────
+CLI shortcut to fetch and import Abakkus Mutual Fund portfolio holdings into ClickHouse.
+
+Usage:
+    python src/scripts/abakkus/import_all_abakkus.py
+    python src/scripts/abakkus/import_all_abakkus.py --full
+    python src/scripts/abakkus/import_all_abakkus.py --dry-run
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.getcwd())
+
+from src.data_importer.abakkus_holdings.import_all_abakkus import main
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/fund_imports/importers/abakkus.py
+++ b/src/scripts/fund_imports/importers/abakkus.py
@@ -1,0 +1,4 @@
+"""Compat shim — real module is src.data_importer.amc_holdings.importers.abakkus."""
+import sys as _sys
+import src.data_importer.amc_holdings.importers.abakkus as _real
+_sys.modules[__name__] = _real

--- a/src/scripts/portfolio/smallcap_pattern_analyzer.py
+++ b/src/scripts/portfolio/smallcap_pattern_analyzer.py
@@ -41,6 +41,8 @@ AMC_ALIAS_MAP = {
     "bajaj": "lower(fund_name) LIKE 'bajaj%'",
     "sbi": "lower(fund_name) LIKE 'sbi%'",
     "axis": "lower(fund_name) LIKE 'axis%'",
+    "abakkus": "lower(fund_name) LIKE 'abakkus%'",
+    "abacus": "lower(fund_name) LIKE 'abakkus%'",
 }
 
 # Per-category fund_name / AMFI-category membership rules and the ETF symbols

--- a/tests/test_abakkus_importer.py
+++ b/tests/test_abakkus_importer.py
@@ -1,0 +1,169 @@
+"""
+tests/test_abakkus_importer.py
+───────────────────────────────
+Unit tests for Abakkus Mutual Fund holdings importer (AbakkusImporter).
+
+All tests are offline — HTTP calls and database calls are mocked.
+
+Run:
+    pytest tests/test_abakkus_importer.py -v
+"""
+
+import io
+from datetime import date
+from unittest.mock import MagicMock, patch
+import pandas as pd
+import pytest
+
+from src.data_importer.amc_holdings.factory import create_importer, REGISTRY
+from src.data_importer.amc_holdings.importers.abakkus import (
+    AbakkusImporter,
+    SCHEME_MAP,
+    _parse_disclosure_date,
+    _normalise_fund_identity,
+)
+
+
+class TestAbakkusCatalogue:
+    def test_registered_in_factory(self):
+        """Verify 'abakkus' and 'abacus' are registered in factory."""
+        assert "abakkus" in REGISTRY
+        assert "abacus" in REGISTRY
+        assert REGISTRY["abakkus"] == AbakkusImporter
+        assert REGISTRY["abacus"] == AbakkusImporter
+
+    def test_factory_instantiation(self):
+        """Verify create_importer('abakkus') returns an AbakkusImporter instance."""
+        imp = create_importer("abakkus", full_reimport=True)
+        assert isinstance(imp, AbakkusImporter)
+        assert imp.full_reimport is True
+
+    def test_scheme_map_coverage(self):
+        """Verify key Abakkus schemes are present in SCHEME_MAP."""
+        assert "ABAFC" in SCHEME_MAP
+        assert "ABASC" in SCHEME_MAP
+        assert "ABALI" in SCHEME_MAP
+        assert "ABALMC" in SCHEME_MAP
+
+        assert SCHEME_MAP["ABAFC"] == ("ABAKKUS_FLEXI_CAP", "Abakkus Flexi Cap Fund")
+        assert SCHEME_MAP["ABASC"] == ("ABAKKUS_SMALL_CAP", "Abakkus Small Cap Fund")
+        assert SCHEME_MAP["ABALI"] == ("ABAKKUS_LIQUID", "Abakkus Liquid Fund")
+
+
+class TestAbakkusDateParsing:
+    def test_parse_disclosure_date_formats(self):
+        assert _parse_disclosure_date("December 31, 2025", "AbakkusMF.xlsx") == date(2025, 12, 31)
+        assert _parse_disclosure_date("January 15, 2026", "IN_MF.xls") == date(2026, 1, 15)
+        assert _parse_disclosure_date("31st March 2026", "portfolio.xls") == date(2026, 3, 31)
+        assert _parse_disclosure_date("July 31, 2026", "Final.xls") == date(2026, 7, 31)
+        assert _parse_disclosure_date("", "Abakkus_Mutual_Fund_31.05.2026.xls") == date(2026, 5, 31)
+
+
+class TestAbakkusNormalisation:
+    def test_normalise_fund_identity(self):
+        code, name = _normalise_fund_identity("ABAFC")
+        assert code == "ABAKKUS_FLEXI_CAP"
+        assert name == "Abakkus Flexi Cap Fund"
+
+        code, name = _normalise_fund_identity("ABASC")
+        assert code == "ABAKKUS_SMALL_CAP"
+        assert name == "Abakkus Small Cap Fund"
+
+        code, name = _normalise_fund_identity("Custom", "Abakkus Flexi Cap Fund")
+        assert code == "ABAKKUS_FLEXI_CAP"
+
+        code, name = _normalise_fund_identity("NEW_FUND", "")
+        assert code == "ABAKKUS_NEW_FUND"
+
+
+class TestAbakkusImporterParams:
+    def test_default_params(self):
+        importer = AbakkusImporter()
+        assert importer.full_reimport is False
+        assert importer.fund_name() == "Abakkus Mutual Fund"
+        assert importer.table_name() == "market_data.mf_holdings"
+        assert importer.watermark_source() == "mf_holdings"
+
+
+class TestAbakkusParsing:
+    def test_parse_source_mock_excel(self):
+        """Test parsing an in-memory Excel workbook."""
+        # Create a mock Excel file
+        data = [
+            ["ABAFC", "Abakkus Mutual Fund", "", "", "", "", "", ""],
+            ["", "Abakkus Flexi Cap Fund", "", "", "", "", "", ""],
+            ["", "Monthly Portfolio Statement as on July 31, 2026", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", ""],
+            ["", "Name of the Instrument", "ISIN", "Industry* / Rating", "Quantity", "Market/Fair Value (Rs. in Lakhs)", "% to Net Assets", ""],
+            ["", "Equity & Equity related", "", "", "", "", "", ""],
+            ["", "(a) Listed / awaiting listing on Stock Exchanges", "", "", "", "", "", ""],
+            ["IBCL05", "ICICI Bank Limited", "INE090A01021", "Banks", "2450000", "35167.3", "5.55", ""],
+            ["HDFB03", "HDFC Bank Limited", "INE040A01034", "Banks", "4000000", "29926.0", "4.72", ""],
+            ["FAKE01", "Rogue Holding", "INE123A01010", "Other", "1000", "1000000.0", "65.0", ""],  # > 50% guard
+        ]
+        df = pd.DataFrame(data)
+        out = io.BytesIO()
+        with pd.ExcelWriter(out, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="ABAFC", header=False, index=False)
+        excel_bytes = out.getvalue()
+
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = excel_bytes
+        mock_http.get.return_value = mock_resp
+
+        importer = AbakkusImporter()
+        source = (date(2026, 7, 31), "Final_Monthly_Portfolio_Jul_31.xls", "https://example.com/file.xls")
+        rows = importer.parse_source(source, mock_http)
+
+        # 3 rows total, 1 skipped due to >50% guard -> 2 rows
+        assert len(rows) == 2
+
+        r0 = rows[0]
+        assert r0["scheme_code"] == "ABAKKUS_FLEXI_CAP"
+        assert r0["fund_name"] == "Abakkus Flexi Cap Fund"
+        assert r0["as_of_month"] == date(2026, 7, 31)
+        assert r0["isin"] == "INE090A01021"
+        assert r0["security_name"] == "ICICI Bank Limited"
+        assert r0["asset_type"] == "equity"
+        assert r0["market_value_cr"] == 351.673  # 35167.3 / 100
+        assert r0["pct_of_nav"] == 5.55
+
+        r1 = rows[1]
+        assert r1["isin"] == "INE040A01034"
+        assert r1["market_value_cr"] == 299.26
+        assert r1["pct_of_nav"] == 4.72
+
+        watermarks = importer.watermark_rows(rows)
+        assert watermarks == [("ABAKKUS_MONTHLY", date(2026, 7, 31))]
+
+    def test_fractional_pct_scaling(self):
+        """Verify decimal fractions (e.g. 0.0555) get scaled by 100 to 5.55%."""
+        data = [
+            ["ABASC", "Abakkus Mutual Fund", "", "", "", "", "", ""],
+            ["", "Abakkus Small Cap Fund", "", "", "", "", "", ""],
+            ["", "Monthly Portfolio Statement as on March 31, 2026", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", ""],
+            ["", "Name of the Instrument", "ISIN", "Industry* / Rating", "Quantity", "Market/Fair Value (Rs. in Lakhs)", "% to Net Assets", ""],
+            ["", "Equity & Equity related", "", "", "", "", "", ""],
+            ["KAVY06", "Karur Vysya Bank Limited", "INE036D01028", "Banks", "1000000", "3000.0", "0.0350", ""],
+            ["DLPL01", "Dr. Lal Path Labs Limited", "INE600L01024", "Healthcare Services", "100000", "2000.0", "0.0250", ""],
+        ]
+        df = pd.DataFrame(data)
+        out = io.BytesIO()
+        with pd.ExcelWriter(out, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="ABASC", header=False, index=False)
+        excel_bytes = out.getvalue()
+
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = excel_bytes
+        mock_http.get.return_value = mock_resp
+
+        importer = AbakkusImporter()
+        source = (date(2026, 3, 31), "March.xls", "https://example.com/march.xls")
+        rows = importer.parse_source(source, mock_http)
+
+        assert len(rows) == 2
+        assert rows[0]["pct_of_nav"] == 3.50
+        assert rows[1]["pct_of_nav"] == 2.50


### PR DESCRIPTION
## Summary

- Implements `AbakkusImporter` in `src/data_importer/amc_holdings/importers/abakkus.py` with dynamic disclosure discovery from https://www.abakkusmf.com/statutory-disclosures.html and multi-engine Excel parsing (`openpyxl`/`xlrd`).
- Adds support for Abakkus Flexi Cap, Small Cap, Liquid, and Large & Mid Cap schemes with automatic asset classification, fractional/percentage scale handling, Lakhs-to-Crores conversion, and single-holding guard rails.
- Registers `abakkus` and `abacus` in factory `REGISTRY`, canonical fetcher, main CLI import options, and freshness auditing.
- Adds Abakkus AMC alias support in `src/scripts/portfolio/smallcap_pattern_analyzer.py`.
- Adds standalone CLI entry points and compat shims under `src/data_importer/abakkus_holdings/` and `src/scripts/abakkus/`.
- Adds comprehensive unit test suite in `tests/test_abakkus_importer.py`.

## Verification
- `pytest tests/test_abakkus_importer.py` passed (8/8).
- Live dry-run tested against abakkusmf.com: 831 rows successfully parsed across 9 months.
- ClickHouse insertion and `smallcap_pattern_analyzer.py --category small --amc abakkus` verified.