### PR TITLE
feat(importer): add Helios Mutual Fund monthly portfolio importer

### DIFF
--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -98,6 +98,7 @@ python src/main.py import --category icici-index  # ICICI Index funds
 python src/main.py import --category quant        # Quant active funds
 python src/main.py import --category bajaj        # Bajaj Finserv funds
 python src/main.py import --category abakkus      # Abakkus Mutual Fund (Flexi Cap, Small Cap, Liquid)
+python src/main.py import --category helios       # Helios Mutual Fund (Small Cap, Flexi Cap, Mid Cap, BAF, etc.)
 python src/main.py import --category amfi         # AMFI category flows & AUM
 ```
 
@@ -109,6 +110,7 @@ python src/scripts/fund_imports/run.py icici        # ICICI holdings backfill
 python src/scripts/fund_imports/run.py quant        # Quant holdings backfill
 python src/scripts/fund_imports/run.py bajaj        # Bajaj holdings backfill
 python src/scripts/fund_imports/run.py abakkus      # Abakkus holdings backfill
+python src/scripts/fund_imports/run.py helios       # Helios holdings backfill
 python src/scripts/fund_imports/run.py amfi         # AMFI category-wise net flows
 python src/scripts/fund_imports/run.py all          # Run all registered AMC importers
 ```

--- a/src/data_importer/amc_holdings/factory.py
+++ b/src/data_importer/amc_holdings/factory.py
@@ -27,6 +27,7 @@ from src.data_importer.amc_holdings.importers.amfi import AmfiImporter
 from src.data_importer.amc_holdings.importers.hdfc import HdfcImporter
 from src.data_importer.amc_holdings.importers.kotak import KotakImporter
 from src.data_importer.amc_holdings.importers.abakkus import AbakkusImporter
+from src.data_importer.amc_holdings.importers.helios import HeliosImporter
 
 REGISTRY: dict[str, type[BaseFundImporter]] = {
     "icici":       IciciMFImporter,
@@ -40,6 +41,7 @@ REGISTRY: dict[str, type[BaseFundImporter]] = {
     "hdfc":        HdfcImporter,
     "abakkus":     AbakkusImporter,
     "abacus":      AbakkusImporter,
+    "helios":      HeliosImporter,
 }
 
 

--- a/src/data_importer/amc_holdings/importers/helios.py
+++ b/src/data_importer/amc_holdings/importers/helios.py
@@ -1,0 +1,445 @@
+"""
+src/data_importer/amc_holdings/importers/helios.py
+───────────────────────────────────────────────────
+Helios Mutual Fund (AMC) monthly portfolio holdings importer.
+
+Scrapes downloads page from https://www.heliosmf.in/downloads,
+downloads monthly XLS/XLSX workbooks across all active schemes (Small Cap, Flexi Cap,
+Mid Cap, Large & Mid Cap, Balanced Advantage, Financial Services, Arbitrage, Overnight),
+parses instrument holdings, classifies asset types, converts values from Rs. Lakhs to
+Crores, scales percentages, and stores rows into market_data.mf_holdings with delta sync
+and watermarking.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+from datetime import date, datetime
+from typing import Any
+
+import httpx
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from src.data_importer.amc_holdings.base import (
+    COMMON_HEADERS,
+    BaseFundImporter,
+    classify_asset,
+)
+
+logger = logging.getLogger(__name__)
+
+DOWNLOADS_URL = "https://www.heliosmf.in/downloads"
+BASE_URL = "https://www.heliosmf.in"
+_TIMEOUT = 30.0
+
+_ISIN_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
+
+# Static / canonical scheme mapping by sheet code or slug
+SCHEME_MAP: dict[str, tuple[str, str]] = {
+    "HFCF":  ("HELIOS_FLEXI_CAP", "Helios Flexi Cap Fund"),
+    "HSCF":  ("HELIOS_SMALL_CAP", "Helios Small Cap Fund"),
+    "HMCF":  ("HELIOS_MID_CAP", "Helios Mid Cap Fund"),
+    "HLMCF": ("HELIOS_LARGE_AND_MID_CAP", "Helios Large & Mid Cap Fund"),
+    "HLMC":  ("HELIOS_LARGE_AND_MID_CAP", "Helios Large & Mid Cap Fund"),
+    "HBAF":  ("HELIOS_BALANCED_ADVANTAGE", "Helios Balanced Advantage Fund"),
+    "HFSF":  ("HELIOS_FINANCIAL_SERVICES", "Helios Financial Services Fund"),
+    "HARF":  ("HELIOS_ARBITRAGE", "Helios Arbitrage Fund"),
+    "HOF":   ("HELIOS_OVERNIGHT", "Helios Overnight Fund"),
+    "HONF":  ("HELIOS_OVERNIGHT", "Helios Overnight Fund"),
+}
+
+_COLUMNS = [
+    "scheme_code",
+    "fund_name",
+    "as_of_month",
+    "isin",
+    "security_name",
+    "asset_type",
+    "market_value_cr",
+    "pct_of_nav",
+    "imported_at",
+]
+
+
+def _get_helios_headers() -> dict[str, str]:
+    """Helios web server requires Accept header to avoid HTTP 406 on file downloads."""
+    headers = dict(COMMON_HEADERS)
+    headers["Accept"] = (
+        "text/html,application/xhtml+xml,application/xml;q=0.9,"
+        "image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7"
+    )
+    headers["Accept-Language"] = "en-US,en;q=0.9"
+    return headers
+
+
+def _parse_disclosure_date(title_str: str, fname_str: str) -> date | None:
+    """Parse date from disclosure link text or URL filename."""
+    text = f"{title_str} {fname_str}".lower()
+    # Strip ordinal suffixes ONLY from numbers (e.g. 31st -> 31, preserving 'August')
+    clean = re.sub(r"(\d{1,2})(st|nd|rd|th)", r"\1", text, flags=re.I)
+
+    m = re.search(
+        r"(january|february|march|april|may|june|july|august|september|october|november|december)\s+(\d{1,2}),?\s+(\d{4})",
+        clean,
+        re.I,
+    )
+    if m:
+        mon, d, y = m.groups()
+        try:
+            return datetime.strptime(f"{y}-{mon}-{d}", "%Y-%B-%d").date()
+        except ValueError:
+            pass
+
+    m2 = re.search(
+        r"(\d{1,2})[\s\-_\.](january|february|march|april|may|june|july|august|september|october|november|december|\d{1,2})[\s\-_\.](\d{4})",
+        clean,
+        re.I,
+    )
+    if m2:
+        d, mon, y = m2.groups()
+        try:
+            if mon.isdigit():
+                return datetime(int(y), int(mon), int(d)).date()
+            return datetime.strptime(f"{y}-{mon}-{d}", "%Y-%B-%d").date()
+        except ValueError:
+            pass
+
+    m3 = re.search(
+        r"(january|february|march|april|may|june|july|august|september|october|november|december)[\s\-_\.](\d{4})",
+        clean,
+        re.I,
+    )
+    if m3:
+        mon, y = m3.groups()
+        try:
+            import calendar
+            dt = datetime.strptime(f"{y}-{mon}-01", "%Y-%B-%d").date()
+            _, last_day = calendar.monthrange(dt.year, dt.month)
+            return date(dt.year, dt.month, last_day)
+        except ValueError:
+            pass
+
+    return None
+
+
+def _normalise_fund_identity(sheet_name: str, fname_str: str = "", text_snippet: str = "") -> tuple[str, str]:
+    """Resolve (scheme_code, fund_name) from sheet name, filename, or text snippet."""
+    key = sheet_name.strip().upper()
+    if key in SCHEME_MAP:
+        return SCHEME_MAP[key]
+
+    comb = f"{sheet_name} {fname_str} {text_snippet}".upper()
+    if "SMALL" in comb:
+        return SCHEME_MAP["HSCF"]
+    if "FLEXI" in comb:
+        return SCHEME_MAP["HFCF"]
+    if "MID" in comb and "LARGE" not in comb:
+        return SCHEME_MAP["HMCF"]
+    if "LARGE" in comb or "LMC" in comb:
+        return SCHEME_MAP["HLMCF"]
+    if "BALANCED" in comb or "ADVANTAGE" in comb or "BAF" in comb:
+        return SCHEME_MAP["HBAF"]
+    if "FINANCIAL" in comb or "BANKING" in comb or "FSF" in comb:
+        return SCHEME_MAP["HFSF"]
+    if "ARBITRAGE" in comb:
+        return SCHEME_MAP["HARF"]
+    if "OVERNIGHT" in comb:
+        return SCHEME_MAP["HOF"]
+
+    clean_code = re.sub(r"[^A-Z0-9_]", "", key.replace(" ", "_"))
+    if not clean_code.startswith("HELIOS_"):
+        clean_code = f"HELIOS_{clean_code}"
+    return (clean_code, f"Helios {sheet_name.strip()}")
+
+
+class HeliosImporter(BaseFundImporter):
+    """
+    Helios Mutual Fund monthly portfolio importer.
+    Supports auto-discovery, delta sync, watermarking, and historical re-imports.
+    """
+
+    REQUEST_DELAY = 0.5
+
+    def __init__(
+        self,
+        full_reimport: bool = False,
+        from_year: int = 2023,
+        target_month: date | None = None,
+        freshness_months: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(target_month=target_month, freshness_months=freshness_months)
+        self.full_reimport = full_reimport
+        self.from_year = from_year
+        self._latest_imported_date: date | None = None
+
+    def fund_name(self) -> str:
+        return "Helios Mutual Fund"
+
+    def table_name(self) -> str:
+        return "market_data.mf_holdings"
+
+    def column_names(self) -> list[str]:
+        return _COLUMNS
+
+    def watermark_source(self) -> str:
+        return "mf_holdings"
+
+    def fetch_sources(self) -> list[tuple[date, str, str]]:
+        """
+        Scrape downloads page to discover all monthly portfolio workbooks.
+        Returns list of (as_of_date, filename, full_download_url).
+        """
+        headers = _get_helios_headers()
+        sources: list[tuple[date, str, str]] = []
+
+        with httpx.Client(headers=headers, timeout=_TIMEOUT, follow_redirects=True) as http:
+            try:
+                resp = http.get(DOWNLOADS_URL)
+                resp.raise_for_status()
+                html = resp.text
+            except Exception as exc:
+                self._console.print(f"[red]Helios: failed to load downloads page: {exc}[/red]")
+                return []
+
+            soup = BeautifulSoup(html, "html.parser")
+            for a in soup.find_all("a", href=True):
+                href = a["href"]
+                text = a.get_text(" ", strip=True)
+                lower_href = href.lower()
+
+                if not (".xlsx" in lower_href or ".xls" in lower_href):
+                    continue
+
+                if "monthly-portfolio" not in lower_href and "monthly_portfolio" not in lower_href:
+                    continue
+
+                as_of = _parse_disclosure_date(text, href)
+                if as_of is None:
+                    continue
+
+                if as_of.year < self.from_year:
+                    continue
+
+                fname = href.split("/")[-1]
+                full_url = href if href.startswith("http") else BASE_URL + href
+                sources.append((as_of, fname, full_url))
+
+        # Deduplicate sources by date and filename
+        seen: set[tuple[date, str]] = set()
+        deduped: list[tuple[date, str, str]] = []
+        for as_of, fn, u in sorted(sources, key=lambda x: (x[0], x[1])):
+            key = (as_of, fn)
+            if key not in seen:
+                seen.add(key)
+                deduped.append((as_of, fn, u))
+
+        self._console.print(f"[dim]Helios: discovered {len(deduped)} monthly portfolio file(s).[/dim]")
+        return deduped
+
+    def filter_sources(
+        self, sources: list[tuple[date, str, str]], client: Any
+    ) -> list[tuple[date, str, str]]:
+        """Filter out months already imported into ClickHouse, unless full_reimport is active."""
+        if self.full_reimport:
+            return sources
+
+        last_date: date | None = None
+        try:
+            rows = client.query(
+                "SELECT max(last_date) FROM market_data.import_watermarks "
+                "WHERE source = 'mf_holdings' AND symbol = 'HELIOS_MONTHLY'"
+            ).result_rows
+            if rows and rows[0][0]:
+                last_date = rows[0][0]
+        except Exception as exc:
+            logger.warning("Failed to query Helios watermark: %s", exc)
+
+        if last_date is None:
+            return sources
+
+        filtered = [s for s in sources if s[0] > last_date]
+        skipped = len(sources) - len(filtered)
+        if skipped:
+            self._console.print(
+                f"[dim]Delta sync: {skipped} Helios file(s) already in DB (watermark {last_date}), "
+                f"{len(filtered)} to fetch.[/dim]"
+            )
+        return filtered
+
+    def parse_source(
+        self, source: tuple[date, str, str], http: httpx.Client
+    ) -> list[dict]:
+        """
+        Download and parse a Helios monthly Excel workbook.
+        """
+        as_of_date, fname, url = source
+        headers = _get_helios_headers()
+
+        try:
+            resp = http.get(url, headers=headers, timeout=_TIMEOUT)
+            resp.raise_for_status()
+        except Exception as exc:
+            self._console.print(f"  [red]Download failed ({url}): {exc}[/red]")
+            return []
+
+        # Load Excel workbook with engine fallback
+        xl: pd.ExcelFile | None = None
+        for engine in ("openpyxl", "xlrd"):
+            try:
+                xl = pd.ExcelFile(io.BytesIO(resp.content), engine=engine)
+                break
+            except Exception:
+                continue
+
+        if xl is None:
+            self._console.print(f"  [red]Cannot parse Helios workbook '{fname}'[/red]")
+            return []
+
+        all_holdings: list[dict] = []
+        imported_at = datetime.now()
+
+        for sheet in xl.sheet_names:
+            if sheet.strip().lower() in ("index", "summary"):
+                continue
+
+            try:
+                df = xl.parse(sheet, header=None)
+            except Exception as exc:
+                logger.debug("Failed parsing sheet %s: %s", sheet, exc)
+                continue
+
+            if df.shape[0] < 5 or df.shape[1] < 5:
+                continue
+
+            row0_str = str(df.iloc[0, 1]) if df.shape[1] > 1 and pd.notna(df.iloc[0, 1]) else ""
+            row2_str = str(df.iloc[2, 2]) if df.shape[0] > 2 and df.shape[1] > 2 and pd.notna(df.iloc[2, 2]) else ""
+            scheme_code, fund_name = _normalise_fund_identity(sheet, fname, f"{row0_str} {row2_str}")
+
+            # Locate column header row dynamically
+            header_row_idx: int | None = None
+            for r in range(min(15, len(df))):
+                r_vals = [str(x).strip().lower() for x in df.iloc[r].tolist() if pd.notna(x)]
+                if any("isin" in x for x in r_vals) and any("instrument" in x or "name" in x or "issuer" in x for x in r_vals):
+                    header_row_idx = r
+                    break
+
+            if header_row_idx is None:
+                continue
+
+            headers_list = [str(x).strip() if pd.notna(x) else "" for x in df.iloc[header_row_idx].tolist()]
+
+            isin_col: int | None = None
+            name_col: int | None = None
+            ind_col: int | None = None
+            mv_col: int | None = None
+            pct_col: int | None = None
+
+            for c_idx, h in enumerate(headers_list):
+                hl = h.lower()
+                if "isin" in hl:
+                    isin_col = c_idx
+                elif "instrument" in hl or "name" in hl or "issuer" in hl:
+                    if name_col is None:
+                        name_col = c_idx
+                elif "rating" in hl or "industry" in hl:
+                    ind_col = c_idx
+                elif "market value" in hl or "market/fair" in hl or "market" in hl:
+                    if mv_col is None:
+                        mv_col = c_idx
+                elif "aum" in hl or "net assets" in hl or "nav" in hl:
+                    pct_col = c_idx
+                elif "%" in hl and pct_col is None and "ytm" not in hl and "ytc" not in hl:
+                    pct_col = c_idx
+
+            # Standard layout fallback if not detected
+            if isin_col is None:
+                isin_col = 3
+            if name_col is None:
+                name_col = 2
+            if ind_col is None:
+                ind_col = 4
+            if mv_col is None:
+                mv_col = 6
+            if pct_col is None:
+                pct_col = 7
+
+            sheet_raw_rows: list[tuple[str, str, str, float, float]] = []
+            for r_idx in range(header_row_idx + 1, len(df)):
+                row = df.iloc[r_idx].tolist()
+                if len(row) <= max([c for c in (isin_col, name_col, ind_col, mv_col, pct_col) if c is not None]):
+                    continue
+
+                isin_val = str(row[isin_col]).strip() if isin_col is not None else ""
+                if not _ISIN_RE.match(isin_val):
+                    continue
+
+                name_val = str(row[name_col]).strip() if name_col is not None and pd.notna(row[name_col]) else ""
+                ind_val = str(row[ind_col]).strip() if ind_col is not None and pd.notna(row[ind_col]) else ""
+
+                try:
+                    mv_raw = float(row[mv_col]) if mv_col is not None else 0.0
+                except (TypeError, ValueError):
+                    mv_raw = 0.0
+
+                try:
+                    pct_raw = float(row[pct_col]) if pct_col is not None else 0.0
+                except (TypeError, ValueError):
+                    pct_raw = 0.0
+
+                sheet_raw_rows.append((isin_val, name_val, ind_val, mv_raw, pct_raw))
+
+            if not sheet_raw_rows:
+                continue
+
+            # Check percentage scaling (fraction 0-1 vs percentage 0-100)
+            valid_pcts = [r[4] for r in sheet_raw_rows if r[4] == r[4] and r[4] != 0]
+            raw_sum = sum(valid_pcts)
+            pct_scale = 100.0 if raw_sum <= 5.0 else 1.0
+
+            sheet_holdings: list[dict] = []
+            for isin_val, name_val, ind_val, mv_raw, pct_raw in sheet_raw_rows:
+                pct_val = round(pct_raw * pct_scale, 4)
+                if pct_val > 50.0:
+                    logger.warning(
+                        "Skipping anomalous row '%s' (%s, %s): pct_of_nav=%.2f%% > 50%%",
+                        name_val,
+                        scheme_code,
+                        as_of_date,
+                        pct_val,
+                    )
+                    continue
+
+                sheet_holdings.append({
+                    "scheme_code": scheme_code,
+                    "fund_name": fund_name,
+                    "as_of_month": as_of_date,
+                    "isin": isin_val,
+                    "security_name": name_val,
+                    "asset_type": classify_asset(name_val, ind_val),
+                    "market_value_cr": round(mv_raw / 100.0, 4),  # Rs Lakhs -> Rs Cr
+                    "pct_of_nav": pct_val,
+                    "imported_at": imported_at,
+                })
+
+            if sheet_holdings:
+                pct_total = sum(h["pct_of_nav"] for h in sheet_holdings)
+                color = "green" if pct_total <= 105.0 else "yellow"
+                self._console.print(
+                    f"  [{color}]{fund_name} ({sheet}): {len(sheet_holdings)} holdings, "
+                    f"pct_total={pct_total:.1f}% ({as_of_date})[/{color}]"
+                )
+                all_holdings.extend(sheet_holdings)
+
+        if self._latest_imported_date is None or as_of_date > self._latest_imported_date:
+            self._latest_imported_date = as_of_date
+
+        return all_holdings
+
+    def watermark_rows(self, all_rows: list[dict]) -> list[tuple[str, date]]:
+        if self._latest_imported_date:
+            return [("HELIOS_MONTHLY", self._latest_imported_date)]
+        return []

--- a/src/data_importer/cli.py
+++ b/src/data_importer/cli.py
@@ -307,7 +307,7 @@ def run_import(
 
 
     # ── AMC Fund-Holdings Importers ───────────────────────────────────────────
-    _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant", "hdfc", "kotak", "abakkus", "abacus") if c in categories]
+    _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant", "hdfc", "kotak", "abakkus", "abacus", "helios") if c in categories]
     if _amc_cats:
         from src.data_importer.fetchers.amc_holdings_fetcher import fetch_amc_holdings
 

--- a/src/data_importer/fetchers/amc_holdings_fetcher.py
+++ b/src/data_importer/fetchers/amc_holdings_fetcher.py
@@ -25,7 +25,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Valid values for the `amc` argument — mirrors factory.REGISTRY keys.
-AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus"})
+AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios"})
 
 
 def fetch_amc_holdings(
@@ -56,7 +56,7 @@ def fetch_amc_holdings(
     from src.data_importer.amc_holdings.factory import create_importer
 
     kwargs: dict = {}
-    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus"):
+    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios"):
         kwargs["full_reimport"] = full_reimport
 
     if target_month:

--- a/src/data_importer/helios_holdings/__init__.py
+++ b/src/data_importer/helios_holdings/__init__.py
@@ -1,0 +1,1 @@
+"""Helios holdings import package."""

--- a/src/data_importer/helios_holdings/import_all_helios.py
+++ b/src/data_importer/helios_holdings/import_all_helios.py
@@ -1,0 +1,64 @@
+"""
+src/data_importer/helios_holdings/import_all_helios.py
+───────────────────────────────────────────────────────
+Standalone script to fetch and import Helios Mutual Fund portfolio holdings into ClickHouse.
+
+Usage:
+    python src/data_importer/helios_holdings/import_all_helios.py
+    python src/data_importer/helios_holdings/import_all_helios.py --full
+    python src/data_importer/helios_holdings/import_all_helios.py --dry-run
+    python src/data_importer/helios_holdings/import_all_helios.py --month 2026-07
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.getcwd())
+
+from rich.console import Console
+
+from src.data_importer.amc_holdings.importers.helios import HeliosImporter
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import Helios Mutual Fund monthly portfolio holdings")
+    parser.add_argument("--full", action="store_true", help="Ignore watermarks and re-import all historical files")
+    parser.add_argument("--dry-run", action="store_true", help="Download and parse files without writing to ClickHouse")
+    parser.add_argument("--month", type=str, default="", help="Specific month to import (YYYY-MM, e.g. 2026-07)")
+    parser.add_argument("--fresh", type=int, default=0, help="Re-import the N most recent months")
+    parser.add_argument("--year", type=int, default=2023, help="Earliest year to consider (default: 2023)")
+    args = parser.parse_args()
+
+    target_month = None
+    if args.month:
+        try:
+            target_month = datetime.strptime(args.month, "%Y-%m").date()
+        except ValueError:
+            console.print(f"[red]Invalid month format: {args.month}. Expected YYYY-MM.[/red]")
+            sys.exit(1)
+
+    console.print(
+        f"[bold blue]Starting Helios Portfolio Import[/bold blue] "
+        f"(full={args.full}, dry_run={args.dry_run}, target_month={target_month}, fresh={args.fresh})"
+    )
+
+    importer = HeliosImporter(
+        full_reimport=args.full,
+        from_year=args.year,
+        target_month=target_month,
+        freshness_months=args.fresh,
+    )
+    importer.run(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_importer/maintenance/audit_freshness.py
+++ b/src/data_importer/maintenance/audit_freshness.py
@@ -155,7 +155,7 @@ def audit_freshness():
             elif import_name == "inav": import_name = "inav"
             elif import_name == "indian_macro": import_name = "indian_macro"
             elif import_name == "fii_dii": import_name = "fii_dii"
-            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus"
+            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus,helios"
             stale_categories.append(import_name)
 
         table.add_row(cat, tbl_name, str(max_date), status)

--- a/src/main.py
+++ b/src/main.py
@@ -939,7 +939,7 @@ def import_data(
             "cot, cb_reserves, etf_aum, mf_holdings, fii_dii, amfi_flows, "
             "earnings, insider, valuation, "
             "world_bank, imf_weo, indian_macro, indian_macro_indicators, "
-            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, all. "
+            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, helios, all. "
             "Default: all."
         ),
     ),

--- a/src/scripts/fund_imports/importers/helios.py
+++ b/src/scripts/fund_imports/importers/helios.py
@@ -1,0 +1,4 @@
+"""Compat shim — real module is src.data_importer.amc_holdings.importers.helios."""
+import sys as _sys
+import src.data_importer.amc_holdings.importers.helios as _real
+_sys.modules[__name__] = _real

--- a/src/scripts/helios/import_all_helios.py
+++ b/src/scripts/helios/import_all_helios.py
@@ -1,0 +1,23 @@
+"""
+src/scripts/helios/import_all_helios.py
+────────────────────────────────────────
+CLI shortcut to fetch and import Helios Mutual Fund portfolio holdings into ClickHouse.
+
+Usage:
+    python src/scripts/helios/import_all_helios.py
+    python src/scripts/helios/import_all_helios.py --full
+    python src/scripts/helios/import_all_helios.py --dry-run
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.getcwd())
+
+from src.data_importer.helios_holdings.import_all_helios import main
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/portfolio/smallcap_pattern_analyzer.py
+++ b/src/scripts/portfolio/smallcap_pattern_analyzer.py
@@ -43,6 +43,7 @@ AMC_ALIAS_MAP = {
     "axis": "lower(fund_name) LIKE 'axis%'",
     "abakkus": "lower(fund_name) LIKE 'abakkus%'",
     "abacus": "lower(fund_name) LIKE 'abakkus%'",
+    "helios": "lower(fund_name) LIKE 'helios%'",
 }
 
 # Per-category fund_name / AMFI-category membership rules and the ETF symbols

--- a/tests/test_helios_importer.py
+++ b/tests/test_helios_importer.py
@@ -1,0 +1,172 @@
+"""
+tests/test_helios_importer.py
+──────────────────────────────
+Unit tests for Helios Mutual Fund holdings importer (HeliosImporter).
+
+All tests are offline — HTTP calls and database calls are mocked.
+
+Run:
+    pytest tests/test_helios_importer.py -v
+"""
+
+import io
+from datetime import date
+from unittest.mock import MagicMock, patch
+import pandas as pd
+import pytest
+
+from src.data_importer.amc_holdings.factory import create_importer, REGISTRY
+from src.data_importer.amc_holdings.importers.helios import (
+    HeliosImporter,
+    SCHEME_MAP,
+    _parse_disclosure_date,
+    _normalise_fund_identity,
+)
+
+
+class TestHeliosCatalogue:
+    def test_registered_in_factory(self):
+        """Verify 'helios' is registered in factory."""
+        assert "helios" in REGISTRY
+        assert REGISTRY["helios"] == HeliosImporter
+
+    def test_factory_instantiation(self):
+        """Verify create_importer('helios') returns a HeliosImporter instance."""
+        imp = create_importer("helios", full_reimport=True)
+        assert isinstance(imp, HeliosImporter)
+        assert imp.full_reimport is True
+
+    def test_scheme_map_coverage(self):
+        """Verify key Helios schemes are present in SCHEME_MAP."""
+        assert "HSCF" in SCHEME_MAP
+        assert "HFCF" in SCHEME_MAP
+        assert "HMCF" in SCHEME_MAP
+        assert "HLMCF" in SCHEME_MAP
+        assert "HBAF" in SCHEME_MAP
+        assert "HFSF" in SCHEME_MAP
+        assert "HARF" in SCHEME_MAP
+        assert "HOF" in SCHEME_MAP
+
+        assert SCHEME_MAP["HSCF"] == ("HELIOS_SMALL_CAP", "Helios Small Cap Fund")
+        assert SCHEME_MAP["HFCF"] == ("HELIOS_FLEXI_CAP", "Helios Flexi Cap Fund")
+        assert SCHEME_MAP["HMCF"] == ("HELIOS_MID_CAP", "Helios Mid Cap Fund")
+
+
+class TestHeliosDateParsing:
+    def test_parse_disclosure_date_formats(self):
+        assert _parse_disclosure_date("July 31, 2026", "helios-small-cap-fund-monthly-portfolio-as-on-31st-july-2026.xlsx") == date(2026, 7, 31)
+        assert _parse_disclosure_date("August 31, 2025", "Helios-Overnight-Fund-Monthly-Portfolio-as-on-31st-August-2025.xlsx") == date(2025, 8, 31)
+        assert _parse_disclosure_date("March 31, 2026", "Helios-Arbitrage-Fund-Monthly-Portfolio-as-on-31st-March-2026.xlsx") == date(2026, 3, 31)
+        assert _parse_disclosure_date("June 30, 2026", "Helios-Flexi-Cap-Fund-Monthly-Portfolio-as-on-30th-June-2026.xlsx") == date(2026, 6, 30)
+        assert _parse_disclosure_date("January 31, 2026", "Helios-Small-Cap-Fund-Monthly-Portfolio-as-on-31st-January-2026.xlsx") == date(2026, 1, 31)
+
+
+class TestHeliosNormalisation:
+    def test_normalise_fund_identity(self):
+        code, name = _normalise_fund_identity("HSCF")
+        assert code == "HELIOS_SMALL_CAP"
+        assert name == "Helios Small Cap Fund"
+
+        code, name = _normalise_fund_identity("HFCF")
+        assert code == "HELIOS_FLEXI_CAP"
+        assert name == "Helios Flexi Cap Fund"
+
+        code, name = _normalise_fund_identity("Sheet1", "helios-small-cap-fund-monthly-portfolio.xlsx")
+        assert code == "HELIOS_SMALL_CAP"
+        assert name == "Helios Small Cap Fund"
+
+        code, name = _normalise_fund_identity("NEW_FUND", "")
+        assert code == "HELIOS_NEW_FUND"
+
+
+class TestHeliosImporterParams:
+    def test_default_params(self):
+        importer = HeliosImporter()
+        assert importer.full_reimport is False
+        assert importer.fund_name() == "Helios Mutual Fund"
+        assert importer.table_name() == "market_data.mf_holdings"
+        assert importer.watermark_source() == "mf_holdings"
+
+
+class TestHeliosParsing:
+    def test_parse_source_mock_excel(self):
+        """Test parsing an in-memory Excel workbook for Helios."""
+        data = [
+            ["", "", "", "", "", "", "", "", "", "", ""],
+            ["", "", "Helios Mutual Fund", "", "", "", "", "", "", "", ""],
+            ["", "", "SCHEME NAME :", "Helios Small Cap Fund", "", "", "", "", "", "", ""],
+            ["", "", "PORTFOLIO STATEMENT AS ON :", "2026-07-31 00:00:00", "", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", "", "", "", ""],
+            ["", "", "Name of the Instrument / Issuer", "ISIN", "Rating / Industry^", "Quantity", "Market value\n(Rs. in Lakhs)", "% to AUM", "YTM %", "YTC % ##", "Notes & Symbols"],
+            ["", "", "EQUITY & EQUITY RELATED", "", "", "", "", "", "", "", ""],
+            ["", "", "Listed/awaiting listing on Stock Exchanges", "", "", "", "", "", "", "", ""],
+            ["", "102744.0", "Shadowfax Technologies Ltd.", "INE12UN01015", "Transport Services", "1495211", "3631.87", "2.50", "", "", ""],
+            ["", "101345.0", "CarTrade Tech Ltd.", "INE290S01011", "Retailing", "112080", "3048.13", "2.09", "", "", ""],
+            ["", "999999.0", "Outlier Holding", "INE123A01010", "Other", "1000", "500000.0", "75.0", "", "", ""],  # >50% guard rail
+        ]
+        df = pd.DataFrame(data)
+        out = io.BytesIO()
+        with pd.ExcelWriter(out, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="HSCF", header=False, index=False)
+        excel_bytes = out.getvalue()
+
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = excel_bytes
+        mock_http.get.return_value = mock_resp
+
+        importer = HeliosImporter()
+        source = (date(2026, 7, 31), "helios-small-cap-fund-monthly-portfolio-as-on-31st-july-2026.xlsx", "https://example.com/hscf.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        # 3 rows total, 1 skipped (>50%) -> 2 rows
+        assert len(rows) == 2
+
+        r0 = rows[0]
+        assert r0["scheme_code"] == "HELIOS_SMALL_CAP"
+        assert r0["fund_name"] == "Helios Small Cap Fund"
+        assert r0["as_of_month"] == date(2026, 7, 31)
+        assert r0["isin"] == "INE12UN01015"
+        assert r0["security_name"] == "Shadowfax Technologies Ltd."
+        assert r0["asset_type"] == "equity"
+        assert r0["market_value_cr"] == 36.3187  # 3631.87 / 100
+        assert r0["pct_of_nav"] == 2.50
+
+        r1 = rows[1]
+        assert r1["isin"] == "INE290S01011"
+        assert r1["market_value_cr"] == 30.4813
+        assert r1["pct_of_nav"] == 2.09
+
+        watermarks = importer.watermark_rows(rows)
+        assert watermarks == [("HELIOS_MONTHLY", date(2026, 7, 31))]
+
+    def test_fractional_pct_scaling(self):
+        """Verify decimal fractions (e.g. 0.0250) get scaled by 100 to 2.50%."""
+        data = [
+            ["", "", "", "", "", "", "", "", "", "", ""],
+            ["", "", "Helios Mutual Fund", "", "", "", "", "", "", "", ""],
+            ["", "", "SCHEME NAME :", "Helios Small Cap Fund", "", "", "", "", "", "", ""],
+            ["", "", "PORTFOLIO STATEMENT AS ON :", "2026-07-31 00:00:00", "", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", "", "", "", ""],
+            ["", "", "Name of the Instrument / Issuer", "ISIN", "Rating / Industry^", "Quantity", "Market value (Rs. in Lakhs)", "% to AUM", "", "", ""],
+            ["", "102744.0", "Ather Energy Ltd.", "INE0LEZ01016", "Automobiles", "234615", "2956.85", "0.0203", "", "", ""],
+            ["", "100200.0", "Page Industries Ltd.", "INE761H01022", "Textiles & Apparels", "6953", "2807.27", "0.0193", "", "", ""],
+        ]
+        df = pd.DataFrame(data)
+        out = io.BytesIO()
+        with pd.ExcelWriter(out, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="HSCF", header=False, index=False)
+        excel_bytes = out.getvalue()
+
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = excel_bytes
+        mock_http.get.return_value = mock_resp
+
+        importer = HeliosImporter()
+        source = (date(2026, 7, 31), "helios-small-cap.xlsx", "https://example.com/hscf.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        assert len(rows) == 2
+        assert rows[0]["pct_of_nav"] == 2.03
+        assert rows[1]["pct_of_nav"] == 1.93


### PR DESCRIPTION
## Summary

- Implements `HeliosImporter` in `src/data_importer/amc_holdings/importers/helios.py` with dynamic disclosure discovery from https://www.heliosmf.in/downloads and multi-engine Excel parsing (`openpyxl`/`xlrd`).
- Adds support for all 8 Helios schemes (*Helios Small Cap Fund*, *Helios Flexi Cap Fund*, *Helios Mid Cap Fund*, *Helios Large & Mid Cap Fund*, *Helios Balanced Advantage Fund*, *Helios Financial Services Fund*, *Helios Arbitrage Fund*, *Helios Overnight Fund*).
- Handles browser `Accept` headers to prevent HTTP 406 blocks, dynamic header detection, Lakhs-to-Crores conversion, and percentage scaling.
- Registers `helios` in factory `REGISTRY`, canonical fetcher, main CLI import options, and freshness auditing.
- Adds Helios AMC alias support in `src/scripts/portfolio/smallcap_pattern_analyzer.py`.
- Adds standalone CLI entry points and compat shims under `src/data_importer/helios_holdings/` and `src/scripts/helios/`.
- Adds comprehensive unit test suite in `tests/test_helios_importer.py`.

## Verification
- `pytest tests/test_helios_importer.py` passed (8/8).
- All AMC tests `pytest tests/test_dsp_importer.py tests/test_hdfc_importer.py tests/test_kotak_importer.py tests/test_abakkus_importer.py tests/test_helios_importer.py` passed (36/36).
- Live ingestion into ClickHouse: 6,849 rows inserted across 34 monthly disclosure periods.
- Pattern analyzer tested: `smallcap_pattern_analyzer.py --category small --amc helios`.