### PR TITLE
feat(importer): add Canara Robeco Mutual Fund monthly portfolio importer

### DIFF
--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -100,6 +100,7 @@ python src/main.py import --category bajaj        # Bajaj Finserv funds
 python src/main.py import --category abakkus      # Abakkus Mutual Fund (Flexi Cap, Small Cap, Liquid)
 python src/main.py import --category helios       # Helios Mutual Fund (Small Cap, Flexi Cap, Mid Cap, BAF, etc.)
 python src/main.py import --category invesco      # Invesco Mutual Fund (Smallcap, Contra, Multi Asset, Flexi Cap, etc.)
+python src/main.py import --category canara       # Canara Robeco Mutual Fund (Small Cap, Flexi Cap, Value, Multi Cap, etc.)
 python src/main.py import --category amfi         # AMFI category flows & AUM
 ```
 
@@ -113,6 +114,7 @@ python src/scripts/fund_imports/run.py bajaj        # Bajaj holdings backfill
 python src/scripts/fund_imports/run.py abakkus      # Abakkus holdings backfill
 python src/scripts/fund_imports/run.py helios       # Helios holdings backfill
 python src/scripts/fund_imports/run.py invesco      # Invesco holdings backfill
+python src/scripts/fund_imports/run.py canara       # Canara Robeco holdings backfill
 python src/scripts/fund_imports/run.py amfi         # AMFI category-wise net flows
 python src/scripts/fund_imports/run.py all          # Run all registered AMC importers
 ```

--- a/src/data_importer/amc_holdings/factory.py
+++ b/src/data_importer/amc_holdings/factory.py
@@ -29,21 +29,25 @@ from src.data_importer.amc_holdings.importers.kotak import KotakImporter
 from src.data_importer.amc_holdings.importers.abakkus import AbakkusImporter
 from src.data_importer.amc_holdings.importers.helios import HeliosImporter
 from src.data_importer.amc_holdings.importers.invesco import InvescoImporter
+from src.data_importer.amc_holdings.importers.canara_robeco import CanaraRobecoImporter
 
 REGISTRY: dict[str, type[BaseFundImporter]] = {
-    "icici":       IciciMFImporter,
-    "nippon":      NipponImporter,
-    "icici-index": IciciIndexImporter,
-    "dsp":         DspImporter,
-    "bajaj":       BajajImporter,
-    "quant":       QuantImporter,
-    "amfi":        AmfiImporter,
-    "kotak":       KotakImporter,
-    "hdfc":        HdfcImporter,
-    "abakkus":     AbakkusImporter,
-    "abacus":      AbakkusImporter,
-    "helios":      HeliosImporter,
-    "invesco":     InvescoImporter,
+    "icici":         IciciMFImporter,
+    "nippon":        NipponImporter,
+    "icici-index":   IciciIndexImporter,
+    "dsp":           DspImporter,
+    "bajaj":         BajajImporter,
+    "quant":         QuantImporter,
+    "amfi":          AmfiImporter,
+    "kotak":         KotakImporter,
+    "hdfc":          HdfcImporter,
+    "abakkus":       AbakkusImporter,
+    "abacus":        AbakkusImporter,
+    "helios":        HeliosImporter,
+    "invesco":       InvescoImporter,
+    "canara":        CanaraRobecoImporter,
+    "canara_robeco": CanaraRobecoImporter,
+    "canara-robeco": CanaraRobecoImporter,
 }
 
 

--- a/src/data_importer/amc_holdings/importers/canara_robeco.py
+++ b/src/data_importer/amc_holdings/importers/canara_robeco.py
@@ -1,0 +1,443 @@
+"""
+src/data_importer/amc_holdings/importers/canara_robeco.py
+──────────────────────────────────────────────────────────
+Canara Robeco Mutual Fund (AMC) monthly portfolio holdings importer.
+
+Discovers monthly portfolio disclosures across all active Canara Robeco schemes
+(Small Cap, Flexi Cap, Large & Mid Cap, Mid Cap, Multi Cap, Value, Manufacturing,
+Infrastructure, Corporate Bond, Income, Ultra Short Term, Overnight, etc.) by querying
+the monthly portfolio disclosure portal:
+https://www.canararobeco.com/documents/statutory-disclosures/scheme-dashboard/scheme-monthly-portfolio/
+with year/month query filters, downloads monthly Excel workbooks, parses instrument
+holdings, classifies asset types, converts values from Rs. Lacs to Crores, scales
+percentages, and stores rows into market_data.mf_holdings with delta sync and watermarking.
+"""
+
+from __future__ import annotations
+
+import calendar
+import io
+import logging
+import re
+from datetime import date, datetime
+from typing import Any
+
+import httpx
+import pandas as pd
+from bs4 import BeautifulSoup
+
+from src.data_importer.amc_holdings.base import (
+    COMMON_HEADERS,
+    BaseFundImporter,
+    classify_asset,
+)
+
+logger = logging.getLogger(__name__)
+
+DISCLOSURE_URL = (
+    "https://www.canararobeco.com/documents/statutory-disclosures/scheme-dashboard/scheme-monthly-portfolio/"
+)
+_TIMEOUT = 30.0
+
+_ISIN_RE = re.compile(r"^[A-Z]{2}[A-Z0-9]{10}$")
+
+# Static / canonical scheme mapping by scheme name
+SCHEME_MAP: dict[str, tuple[str, str]] = {
+    # Equity
+    "Canara Robeco Small Cap Fund": ("CANARA_SMALL_CAP", "Canara Robeco Small Cap Fund"),
+    "Canara Robeco Flexi Cap Fund": ("CANARA_FLEXI_CAP", "Canara Robeco Flexi Cap Fund"),
+    "Canara Robeco Large and Mid Cap Fund": ("CANARA_LARGE_AND_MID_CAP", "Canara Robeco Large and Mid Cap Fund"),
+    "Canara Robeco Emerging Equities": ("CANARA_LARGE_AND_MID_CAP", "Canara Robeco Large and Mid Cap Fund"),
+    "Canara Robeco Large Cap Fund": ("CANARA_LARGE_CAP", "Canara Robeco Large Cap Fund"),
+    "Canara Robeco Bluechip Equity Fund": ("CANARA_LARGE_CAP", "Canara Robeco Large Cap Fund"),
+    "Canara Robeco Mid Cap Fund": ("CANARA_MID_CAP", "Canara Robeco Mid Cap Fund"),
+    "Canara Robeco Multi Cap Fund": ("CANARA_MULTICAP", "Canara Robeco Multi Cap Fund"),
+    "Canara Robeco Focused Fund": ("CANARA_FOCUSED", "Canara Robeco Focused Fund"),
+    "Canara Robeco Value Fund": ("CANARA_VALUE", "Canara Robeco Value Fund"),
+    "Canara Robeco Infrastructure": ("CANARA_INFRASTRUCTURE", "Canara Robeco Infrastructure Fund"),
+    "Canara Robeco Manufacturing Fund": ("CANARA_MANUFACTURING", "Canara Robeco Manufacturing Fund"),
+    "Canara Robeco ELSS Tax Saver Fund": ("CANARA_ELSS_TAX_SAVER", "Canara Robeco ELSS Tax Saver Fund"),
+    "Canara Robeco Banking and Financial Services Fund": ("CANARA_BANKING_AND_FINANCIAL_SERVICES", "Canara Robeco Banking and Financial Services Fund"),
+    "Canara Robeco Consumption Fund": ("CANARA_CONSUMPTION", "Canara Robeco Consumption Fund"),
+
+    # Hybrid
+    "Canara Robeco Multi Asset Allocation Fund": ("CANARA_MULTI_ASSET_ALLOCATION", "Canara Robeco Multi Asset Allocation Fund"),
+    "Canara Robeco Balanced Advantage Fund": ("CANARA_BALANCED_ADVANTAGE", "Canara Robeco Balanced Advantage Fund"),
+    "Canara Robeco Equity Hybrid Fund": ("CANARA_EQUITY_HYBRID", "Canara Robeco Equity Hybrid Fund"),
+    "Canara Robeco Conservative Hybrid Fund": ("CANARA_CONSERVATIVE_HYBRID", "Canara Robeco Conservative Hybrid Fund"),
+
+    # Debt / Cash
+    "Canara Robeco Income Fund": ("CANARA_INCOME", "Canara Robeco Income Fund"),
+    "Canara Robeco Corporate Bond Fund": ("CANARA_CORPORATE_BOND", "Canara Robeco Corporate Bond Fund"),
+    "Canara Robeco Banking and PSU Debt Fund": ("CANARA_BANKING_AND_PSU", "Canara Robeco Banking and PSU Debt Fund"),
+    "Canara Robeco Dynamic Bond Fund": ("CANARA_DYNAMIC_BOND", "Canara Robeco Dynamic Bond Fund"),
+    "Canara Robeco Gilt Fund": ("CANARA_GILT", "Canara Robeco Gilt Fund"),
+    "Canara Robeco Liquid Fund": ("CANARA_LIQUID", "Canara Robeco Liquid Fund"),
+    "Canara Robeco Overnight Fund": ("CANARA_OVERNIGHT", "Canara Robeco Overnight Fund"),
+    "Canara Robeco Savings Fund": ("CANARA_SAVINGS", "Canara Robeco Savings Fund"),
+    "Canara Robeco Short Duration Fund": ("CANARA_SHORT_DURATION", "Canara Robeco Short Duration Fund"),
+    "Canara Robeco Ultra Short Term Fund": ("CANARA_ULTRA_SHORT_TERM", "Canara Robeco Ultra Short Term Fund"),
+}
+
+PREFIX_MAP: dict[str, tuple[str, str]] = {
+    "SC": ("CANARA_SMALL_CAP", "Canara Robeco Small Cap Fund"),
+    "VF": ("CANARA_VALUE", "Canara Robeco Value Fund"),
+    "MF": ("CANARA_MULTICAP", "Canara Robeco Multi Cap Fund"),
+    "MD": ("CANARA_MID_CAP", "Canara Robeco Mid Cap Fund"),
+    "MN": ("CANARA_MANUFACTURING", "Canara Robeco Manufacturing Fund"),
+    "MI": ("CANARA_CONSERVATIVE_HYBRID", "Canara Robeco Conservative Hybrid Fund"),
+    "IF": ("CANARA_INCOME", "Canara Robeco Income Fund"),
+    "TA": ("CANARA_ULTRA_SHORT_TERM", "Canara Robeco Ultra Short Term Fund"),
+    "OF": ("CANARA_OVERNIGHT", "Canara Robeco Overnight Fund"),
+    "MO": ("CANARA_CORPORATE_BOND", "Canara Robeco Corporate Bond Fund"),
+    "IN": ("CANARA_INFRASTRUCTURE", "Canara Robeco Infrastructure Fund"),
+    "CRCHF": ("CANARA_CONSERVATIVE_HYBRID", "Canara Robeco Conservative Hybrid Fund"),
+}
+
+_COLUMNS = [
+    "scheme_code",
+    "fund_name",
+    "as_of_month",
+    "isin",
+    "security_name",
+    "asset_type",
+    "market_value_cr",
+    "pct_of_nav",
+    "imported_at",
+]
+
+
+def _normalise_fund_identity(title: str, fname: str = "", sheet_header: str = "") -> tuple[str, str]:
+    """Resolve (scheme_code, fund_name) from Canara Robeco title, filename, or sheet header."""
+    title_clean = re.sub(r"[–—]", "-", title or "").strip()
+    fname_clean = re.sub(r"[–—]", "-", fname or "").strip()
+    hdr_clean = re.sub(r"[–—]", "-", sheet_header or "").strip()
+
+    combined = f"{title_clean} {fname_clean} {hdr_clean}"
+
+    for known_title, (code, name) in SCHEME_MAP.items():
+        if known_title.lower() in combined.lower():
+            return (code, name)
+
+    for pfx, (code, name) in PREFIX_MAP.items():
+        if (
+            re.search(rf"\b{pfx}\b", title_clean, re.IGNORECASE)
+            or title_clean.upper().startswith(f"{pfx}-")
+            or title_clean.upper().startswith(f"{pfx} ")
+            or fname_clean.upper().startswith(f"{pfx}-")
+            or f"_{pfx}_" in fname_clean.upper()
+            or f"-{pfx}-" in fname_clean.upper()
+        ):
+            return (code, name)
+
+    # Fallback to generated code
+    code = title_clean.upper()
+    code = re.sub(r"^CANARA\s+ROBECO\s+", "", code)
+    code = re.sub(r"\s+FUND$", "", code)
+    code = re.sub(r"[^A-Z0-9_]", "_", code)
+    code = re.sub(r"_+", "_", code).strip("_")
+    return (f"CANARA_{code}", title_clean or fname_clean)
+
+
+class CanaraRobecoImporter(BaseFundImporter):
+    """
+    Canara Robeco Mutual Fund monthly portfolio importer.
+    Discovers disclosures via the statutory disclosure portal and parses Excel workbooks.
+    """
+
+    REQUEST_DELAY = 0.4
+
+    def __init__(
+        self,
+        full_reimport: bool = False,
+        from_year: int = 2023,
+        target_month: date | None = None,
+        freshness_months: int = 0,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(target_month=target_month, freshness_months=freshness_months)
+        self.full_reimport = full_reimport
+        self.from_year = from_year
+        self._latest_imported_date: date | None = None
+
+    def fund_name(self) -> str:
+        return "Canara Robeco Mutual Fund"
+
+    def table_name(self) -> str:
+        return "market_data.mf_holdings"
+
+    def column_names(self) -> list[str]:
+        return _COLUMNS
+
+    def watermark_source(self) -> str:
+        return "mf_holdings"
+
+    def fetch_sources(self) -> list[tuple[date, str, str, str]]:
+        """
+        Query Canara Robeco statutory disclosures portal with year & month filters.
+        Returns list of (as_of_date, scheme_title, filename, download_url).
+        """
+        sources: list[tuple[date, str, str, str]] = []
+        headers = dict(COMMON_HEADERS)
+        headers["Accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+
+        current_year = datetime.now().year
+        current_month = datetime.now().month
+        years = list(range(self.from_year, current_year + 1))
+
+        with httpx.Client(headers=headers, timeout=_TIMEOUT, follow_redirects=True) as http:
+            for yr in years:
+                max_m = current_month if yr == current_year else 12
+                for m in range(1, max_m + 1):
+                    m_str = f"{m:02d}"
+                    url = f"{DISCLOSURE_URL}?filteryear={yr}&filtermonth={m_str}"
+                    try:
+                        resp = http.get(url)
+                        if resp.status_code != 200:
+                            continue
+
+                        soup = BeautifulSoup(resp.text, "html.parser")
+                        for a in soup.find_all("a", href=True):
+                            href = a["href"].strip()
+                            if not any(
+                                href.lower().endswith(ext) or f"{ext}?" in href.lower()
+                                for ext in [".xlsx", ".xls"]
+                            ):
+                                continue
+
+                            text = a.get_text(" ", strip=True)
+                            if text.lower() == "download" or not text:
+                                parent = a.find_parent(["div", "tr", "li", "p"])
+                                title = parent.get_text(" ", strip=True) if parent else href.split("/")[-1]
+                                title = re.sub(r"\bdownload\b", "", title, flags=re.IGNORECASE).strip()
+                            else:
+                                title = text
+
+                            fname = href.split("/")[-1].split("?")[0]
+                            _, last_day = calendar.monthrange(yr, m)
+                            as_of_date = date(yr, m, last_day)
+                            sources.append((as_of_date, title, fname, href))
+
+                    except Exception as exc:
+                        logger.debug("Failed fetching Canara Robeco sources for %s-%s: %s", yr, m_str, exc)
+
+        # Deduplicate sources by (date, download_url), preferring non-Download title
+        by_key: dict[tuple[date, str], tuple[date, str, str, str]] = {}
+        for as_of, title, fn, u in sources:
+            key = (as_of, u)
+            if key not in by_key or (by_key[key][1].lower() == "download" and title.lower() != "download"):
+                by_key[key] = (as_of, title, fn, u)
+
+        deduped = sorted(by_key.values(), key=lambda x: (x[0], x[2]))
+        self._console.print(f"[dim]Canara Robeco: discovered {len(deduped)} monthly portfolio source(s).[/dim]")
+        return deduped
+
+    def filter_sources(
+        self, sources: list[tuple[date, str, str, str]], client: Any
+    ) -> list[tuple[date, str, str, str]]:
+        """Filter out months already imported into ClickHouse, unless full_reimport is active."""
+        if self.full_reimport:
+            return sources
+
+        last_date: date | None = None
+        try:
+            rows = client.query(
+                "SELECT max(last_date) FROM market_data.import_watermarks "
+                "WHERE source = 'mf_holdings' AND symbol = 'CANARA_ROBECO_MONTHLY'"
+            ).result_rows
+            if rows and rows[0][0]:
+                last_date = rows[0][0]
+        except Exception as exc:
+            logger.warning("Failed to query Canara Robeco watermark: %s", exc)
+
+        if last_date is None:
+            return sources
+
+        filtered = [s for s in sources if s[0] > last_date]
+        skipped = len(sources) - len(filtered)
+        if skipped:
+            self._console.print(
+                f"[dim]Delta sync: {skipped} Canara Robeco file(s) already in DB (watermark {last_date}), "
+                f"{len(filtered)} to fetch.[/dim]"
+            )
+        return filtered
+
+    def parse_source(
+        self, source: tuple[date, str, str, str], http: httpx.Client
+    ) -> list[dict]:
+        """
+        Download and parse a Canara Robeco monthly Excel workbook.
+        """
+        as_of_date, scheme_title, fname, url = source
+        headers = dict(COMMON_HEADERS)
+        headers["Accept"] = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+
+        try:
+            resp = http.get(url, headers=headers, timeout=_TIMEOUT)
+            resp.raise_for_status()
+        except Exception as exc:
+            self._console.print(f"  [red]Download failed ({scheme_title}, {url}): {exc}[/red]")
+            return []
+
+        # Load Excel workbook with engine fallback
+        xl: pd.ExcelFile | None = None
+        for engine in ("openpyxl", "xlrd"):
+            try:
+                xl = pd.ExcelFile(io.BytesIO(resp.content), engine=engine)
+                break
+            except Exception:
+                continue
+
+        if xl is None:
+            self._console.print(f"  [red]Cannot parse Canara Robeco workbook '{fname}' ({scheme_title})[/red]")
+            return []
+
+        all_holdings: list[dict] = []
+        imported_at = datetime.now()
+
+        for sheet in xl.sheet_names:
+            try:
+                df = xl.parse(sheet, header=None)
+            except Exception as exc:
+                logger.debug("Failed parsing sheet %s in %s: %s", sheet, fname, exc)
+                continue
+
+            if df.shape[0] < 5 or df.shape[1] < 4:
+                continue
+
+            # Extract possible scheme header from top rows
+            sheet_hdr = ""
+            for r in range(min(4, len(df))):
+                row_txt = " ".join([str(x) for x in df.iloc[r].tolist() if pd.notna(x)])
+                if "CANARA" in row_txt.upper() or "FUND" in row_txt.upper():
+                    sheet_hdr = row_txt
+                    break
+
+            scheme_code, fund_name = _normalise_fund_identity(scheme_title, fname, sheet_hdr)
+
+            # Locate column header row dynamically
+            header_row_idx: int | None = None
+            for r in range(min(15, len(df))):
+                r_vals = [str(x).strip().lower() for x in df.iloc[r].tolist() if pd.notna(x)]
+                if any("isin" in x for x in r_vals) and any(
+                    "instrument" in x or "name" in x or "issuer" in x or "security" in x for x in r_vals
+                ):
+                    header_row_idx = r
+                    break
+
+            if header_row_idx is None:
+                continue
+
+            headers_list = [str(x).strip() if pd.notna(x) else "" for x in df.iloc[header_row_idx].tolist()]
+
+            isin_col: int | None = None
+            name_col: int | None = None
+            ind_col: int | None = None
+            mv_col: int | None = None
+            pct_col: int | None = None
+
+            for c_idx, h in enumerate(headers_list):
+                hl = h.lower()
+                if "isin" in hl:
+                    isin_col = c_idx
+                elif "instrument" in hl or "name" in hl or "issuer" in hl or "security" in hl:
+                    if name_col is None:
+                        name_col = c_idx
+                elif "rating" in hl or "industry" in hl:
+                    ind_col = c_idx
+                elif "market value" in hl or "market/fair" in hl or "market" in hl or "lacs" in hl:
+                    if mv_col is None:
+                        mv_col = c_idx
+                elif "aum" in hl or "net assets" in hl or "nav" in hl or "%" in hl:
+                    if pct_col is None and "yield" not in hl and "ytm" not in hl and "ytc" not in hl:
+                        pct_col = c_idx
+
+            # Standard layout fallback if not detected
+            if isin_col is None:
+                isin_col = 2
+            if name_col is None:
+                name_col = 1
+            if ind_col is None:
+                ind_col = 3
+            if mv_col is None:
+                mv_col = 5
+            if pct_col is None:
+                pct_col = 6
+
+            sheet_raw_rows: list[tuple[str, str, str, float, float]] = []
+            for r_idx in range(header_row_idx + 1, len(df)):
+                row = df.iloc[r_idx].tolist()
+                if len(row) <= max([c for c in (isin_col, name_col, ind_col, mv_col, pct_col) if c is not None]):
+                    continue
+
+                isin_val = str(row[isin_col]).strip() if isin_col is not None else ""
+                if not _ISIN_RE.match(isin_val):
+                    continue
+
+                name_val = str(row[name_col]).strip() if name_col is not None and pd.notna(row[name_col]) else ""
+                ind_val = str(row[ind_col]).strip() if ind_col is not None and pd.notna(row[ind_col]) else ""
+
+                try:
+                    mv_raw = float(row[mv_col]) if mv_col is not None else 0.0
+                except (TypeError, ValueError):
+                    mv_raw = 0.0
+
+                try:
+                    pct_raw = float(row[pct_col]) if pct_col is not None else 0.0
+                except (TypeError, ValueError):
+                    pct_raw = 0.0
+
+                sheet_raw_rows.append((isin_val, name_val, ind_val, mv_raw, pct_raw))
+
+            if not sheet_raw_rows:
+                continue
+
+            # Check percentage scaling: if all individual values are <= 1.0 (e.g. 0.0249 for 2.49%), scale by 100
+            valid_pcts = [r[4] for r in sheet_raw_rows if r[4] == r[4] and r[4] > 0]
+            pct_scale = 100.0 if (valid_pcts and all(p <= 1.0 for p in valid_pcts)) else 1.0
+
+            sheet_holdings: list[dict] = []
+            for isin_val, name_val, ind_val, mv_raw, pct_raw in sheet_raw_rows:
+                pct_val = round(pct_raw * pct_scale, 4)
+                if pct_val > 50.0:
+                    logger.warning(
+                        "Skipping anomalous row '%s' (%s, %s): pct_of_nav=%.2f%% > 50%%",
+                        name_val,
+                        scheme_code,
+                        as_of_date,
+                        pct_val,
+                    )
+                    continue
+
+                sheet_holdings.append({
+                    "scheme_code": scheme_code,
+                    "fund_name": fund_name,
+                    "as_of_month": as_of_date,
+                    "isin": isin_val,
+                    "security_name": name_val,
+                    "asset_type": classify_asset(name_val, ind_val),
+                    "market_value_cr": round(mv_raw / 100.0, 4),  # Rs Lacs -> Rs Cr
+                    "pct_of_nav": pct_val,
+                    "imported_at": imported_at,
+                })
+
+            if sheet_holdings:
+                pct_total = sum(h["pct_of_nav"] for h in sheet_holdings)
+                color = "green" if pct_total <= 105.0 else "yellow"
+                self._console.print(
+                    f"  [{color}]{fund_name}: {len(sheet_holdings)} holdings, "
+                    f"pct_total={pct_total:.1f}% ({as_of_date})[/{color}]"
+                )
+                all_holdings.extend(sheet_holdings)
+                # Found the detailed holdings sheet, break
+                break
+
+        if self._latest_imported_date is None or as_of_date > self._latest_imported_date:
+            self._latest_imported_date = as_of_date
+
+        return all_holdings
+
+    def watermark_rows(self, all_rows: list[dict]) -> list[tuple[str, date]]:
+        if self._latest_imported_date:
+            return [("CANARA_ROBECO_MONTHLY", self._latest_imported_date)]
+        return []

--- a/src/data_importer/canara_holdings/__init__.py
+++ b/src/data_importer/canara_holdings/__init__.py
@@ -1,0 +1,1 @@
+"""Canara Robeco holdings import package."""

--- a/src/data_importer/canara_holdings/import_all_canara.py
+++ b/src/data_importer/canara_holdings/import_all_canara.py
@@ -1,0 +1,64 @@
+"""
+src/data_importer/canara_holdings/import_all_canara.py
+─────────────────────────────────────────────────────
+Standalone script to fetch and import Canara Robeco Mutual Fund portfolio holdings into ClickHouse.
+
+Usage:
+    python src/data_importer/canara_holdings/import_all_canara.py
+    python src/data_importer/canara_holdings/import_all_canara.py --full
+    python src/data_importer/canara_holdings/import_all_canara.py --dry-run
+    python src/data_importer/canara_holdings/import_all_canara.py --month 2026-07
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.getcwd())
+
+from rich.console import Console
+
+from src.data_importer.amc_holdings.importers.canara_robeco import CanaraRobecoImporter
+
+console = Console()
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import Canara Robeco Mutual Fund monthly portfolio holdings")
+    parser.add_argument("--full", action="store_true", help="Ignore watermarks and re-import all historical files")
+    parser.add_argument("--dry-run", action="store_true", help="Download and parse files without writing to ClickHouse")
+    parser.add_argument("--month", type=str, default="", help="Specific month to import (YYYY-MM, e.g. 2026-07)")
+    parser.add_argument("--fresh", type=int, default=0, help="Re-import the N most recent months")
+    parser.add_argument("--year", type=int, default=2023, help="Earliest year to consider (default: 2023)")
+    args = parser.parse_args()
+
+    target_month = None
+    if args.month:
+        try:
+            target_month = datetime.strptime(args.month, "%Y-%m").date()
+        except ValueError:
+            console.print(f"[red]Invalid month format: {args.month}. Expected YYYY-MM.[/red]")
+            sys.exit(1)
+
+    console.print(
+        f"[bold blue]Starting Canara Robeco Portfolio Import[/bold blue] "
+        f"(full={args.full}, dry_run={args.dry_run}, target_month={target_month}, fresh={args.fresh})"
+    )
+
+    importer = CanaraRobecoImporter(
+        full_reimport=args.full,
+        from_year=args.year,
+        target_month=target_month,
+        freshness_months=args.fresh,
+    )
+    importer.run(dry_run=args.dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_importer/cli.py
+++ b/src/data_importer/cli.py
@@ -307,7 +307,7 @@ def run_import(
 
 
     # ── AMC Fund-Holdings Importers ───────────────────────────────────────────
-    _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco") if c in categories]
+    _amc_cats = [c for c in ("icici", "nippon", "icici-index", "dsp", "bajaj", "quant", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara") if c in categories]
     if _amc_cats:
         from src.data_importer.fetchers.amc_holdings_fetcher import fetch_amc_holdings
 

--- a/src/data_importer/fetchers/amc_holdings_fetcher.py
+++ b/src/data_importer/fetchers/amc_holdings_fetcher.py
@@ -25,7 +25,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Valid values for the `amc` argument — mirrors factory.REGISTRY keys.
-AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco"})
+AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco"})
 
 
 def fetch_amc_holdings(
@@ -56,7 +56,7 @@ def fetch_amc_holdings(
     from src.data_importer.amc_holdings.factory import create_importer
 
     kwargs: dict = {}
-    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco"):
+    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco"):
         kwargs["full_reimport"] = full_reimport
 
     if target_month:

--- a/src/data_importer/maintenance/audit_freshness.py
+++ b/src/data_importer/maintenance/audit_freshness.py
@@ -155,7 +155,7 @@ def audit_freshness():
             elif import_name == "inav": import_name = "inav"
             elif import_name == "indian_macro": import_name = "indian_macro"
             elif import_name == "fii_dii": import_name = "fii_dii"
-            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus,helios,invesco"
+            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus,helios,invesco,canara"
             stale_categories.append(import_name)
 
         table.add_row(cat, tbl_name, str(max_date), status)

--- a/src/main.py
+++ b/src/main.py
@@ -939,7 +939,7 @@ def import_data(
             "cot, cb_reserves, etf_aum, mf_holdings, fii_dii, amfi_flows, "
             "earnings, insider, valuation, "
             "world_bank, imf_weo, indian_macro, indian_macro_indicators, "
-            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, helios, invesco, all. "
+            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, helios, invesco, canara, all. "
             "Default: all."
         ),
     ),

--- a/src/scripts/canara/import_all_canara.py
+++ b/src/scripts/canara/import_all_canara.py
@@ -1,0 +1,23 @@
+"""
+src/scripts/canara/import_all_canara.py
+───────────────────────────────────────
+CLI shortcut to fetch and import Canara Robeco Mutual Fund portfolio holdings into ClickHouse.
+
+Usage:
+    python src/scripts/canara/import_all_canara.py
+    python src/scripts/canara/import_all_canara.py --full
+    python src/scripts/canara/import_all_canara.py --dry-run
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+# Ensure project root is on sys.path
+sys.path.insert(0, os.getcwd())
+
+from src.data_importer.canara_holdings.import_all_canara import main
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/fund_imports/importers/canara_robeco.py
+++ b/src/scripts/fund_imports/importers/canara_robeco.py
@@ -1,0 +1,4 @@
+"""Compat shim — real module is src.data_importer.amc_holdings.importers.canara_robeco."""
+import sys as _sys
+import src.data_importer.amc_holdings.importers.canara_robeco as _real
+_sys.modules[__name__] = _real

--- a/src/scripts/portfolio/smallcap_pattern_analyzer.py
+++ b/src/scripts/portfolio/smallcap_pattern_analyzer.py
@@ -45,6 +45,7 @@ AMC_ALIAS_MAP = {
     "abacus": "lower(fund_name) LIKE 'abakkus%'",
     "helios": "lower(fund_name) LIKE 'helios%'",
     "invesco": "lower(fund_name) LIKE 'invesco%'",
+    "canara": "lower(fund_name) LIKE 'canara%'",
 }
 
 # Per-category fund_name / AMFI-category membership rules and the ETF symbols

--- a/tests/test_canara_robeco_importer.py
+++ b/tests/test_canara_robeco_importer.py
@@ -1,0 +1,160 @@
+"""
+tests/test_canara_robeco_importer.py
+─────────────────────────────────────
+Unit tests for Canara Robeco Mutual Fund holdings importer (CanaraRobecoImporter).
+
+All tests are offline — HTTP calls and database calls are mocked.
+
+Run:
+    pytest tests/test_canara_robeco_importer.py -v
+"""
+
+import io
+from datetime import date
+from unittest.mock import MagicMock
+import pandas as pd
+import pytest
+
+from src.data_importer.amc_holdings.factory import create_importer, REGISTRY
+from src.data_importer.amc_holdings.importers.canara_robeco import (
+    CanaraRobecoImporter,
+    SCHEME_MAP,
+    PREFIX_MAP,
+    _normalise_fund_identity,
+)
+
+
+class TestCanaraRobecoCatalogue:
+    def test_registered_in_factory(self):
+        """Verify 'canara', 'canara_robeco', and 'canara-robeco' are registered in factory."""
+        assert "canara" in REGISTRY
+        assert "canara_robeco" in REGISTRY
+        assert "canara-robeco" in REGISTRY
+        assert REGISTRY["canara"] == CanaraRobecoImporter
+
+    def test_factory_instantiation(self):
+        """Verify create_importer('canara') returns a CanaraRobecoImporter instance."""
+        imp = create_importer("canara", full_reimport=True)
+        assert isinstance(imp, CanaraRobecoImporter)
+        assert imp.full_reimport is True
+
+    def test_scheme_map_coverage(self):
+        """Verify key Canara Robeco schemes are present in SCHEME_MAP."""
+        assert "Canara Robeco Small Cap Fund" in SCHEME_MAP
+        assert "Canara Robeco Flexi Cap Fund" in SCHEME_MAP
+        assert "Canara Robeco Large and Mid Cap Fund" in SCHEME_MAP
+        assert "Canara Robeco Multi Cap Fund" in SCHEME_MAP
+        assert "Canara Robeco Mid Cap Fund" in SCHEME_MAP
+        assert "Canara Robeco Value Fund" in SCHEME_MAP
+
+        assert SCHEME_MAP["Canara Robeco Small Cap Fund"] == ("CANARA_SMALL_CAP", "Canara Robeco Small Cap Fund")
+        assert SCHEME_MAP["Canara Robeco Flexi Cap Fund"] == ("CANARA_FLEXI_CAP", "Canara Robeco Flexi Cap Fund")
+        assert SCHEME_MAP["Canara Robeco Value Fund"] == ("CANARA_VALUE", "Canara Robeco Value Fund")
+
+
+class TestCanaraRobecoNormalisation:
+    def test_normalise_fund_identity(self):
+        code, name = _normalise_fund_identity("SC – Canara Robeco Small Cap Fund – July-2026", "SC-–-Canara-Robeco-Small-Cap-Fund-–-July-2026.xlsx")
+        assert code == "CANARA_SMALL_CAP"
+        assert name == "Canara Robeco Small Cap Fund"
+
+        code, name = _normalise_fund_identity("VF – Canara Robeco Value Fund – July-2026", "VF-–-Canara-Robeco-Value-Fund-–-July-2026.xlsx")
+        assert code == "CANARA_VALUE"
+        assert name == "Canara Robeco Value Fund"
+
+        code, name = _normalise_fund_identity("IF – Canara Robeco Income Fund – July-2026", "IF-–-Canara-Robeco-Income-Fund-–-July-2026.xlsx")
+        assert code == "CANARA_INCOME"
+        assert name == "Canara Robeco Income Fund"
+
+        code, name = _normalise_fund_identity("MI – Canara Robeco Conservative Hybrid Fund – July-2026", "MI–CRCHF–July-2026.xlsx")
+        assert code == "CANARA_CONSERVATIVE_HYBRID"
+        assert name == "Canara Robeco Conservative Hybrid Fund"
+
+        code, name = _normalise_fund_identity("Canara Robeco New Fund", "new.xlsx")
+        assert code == "CANARA_NEW"
+
+
+class TestCanaraRobecoImporterParams:
+    def test_default_params(self):
+        importer = CanaraRobecoImporter()
+        assert importer.full_reimport is False
+        assert importer.fund_name() == "Canara Robeco Mutual Fund"
+        assert importer.table_name() == "market_data.mf_holdings"
+        assert importer.watermark_source() == "mf_holdings"
+
+
+class TestCanaraRobecoParsing:
+    def test_parse_source_mock_excel(self):
+        """Test parsing an in-memory Excel workbook for Canara Robeco."""
+        data = [
+            ["", "CANARA ROBECO SMALL CAP FUND", "", "", "", "", "", ""],
+            ["", "", "", "", "", "", "", ""],
+            ["", "Monthly Portfolio Statement as on July 31, 2026", "", "", "", "", "", ""],
+            ["", "Name of the Instrument", "ISIN", "Industry / Rating", "Quantity", "Market/Fair Value\n (Rs. in Lacs)", "% to Net\n Assets", "Yield %"],
+            ["", "Amber Enterprises India Ltd", "INE371P01015", "Consumer Durables", "746266", "35442.0", "2.49", ""],
+            ["", "Torrent Pharmaceuticals Ltd", "INE685A01028", "Pharmaceuticals", "500000", "35370.0", "2.49", ""],
+            ["", "Outlier Holding", "INE123A01010", "Other", "1000", "500000.0", "75.0", ""],  # >50% guard rail
+        ]
+        df = pd.DataFrame(data)
+        out = io.BytesIO()
+        with pd.ExcelWriter(out, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="SC", header=False, index=False)
+        excel_bytes = out.getvalue()
+
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = excel_bytes
+        mock_http.get.return_value = mock_resp
+
+        importer = CanaraRobecoImporter()
+        source = (date(2026, 7, 31), "SC – Canara Robeco Small Cap Fund – July-2026", "SC.xlsx", "https://example.com/SC.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        # 3 rows total, 1 skipped (>50%) -> 2 rows
+        assert len(rows) == 2
+
+        r0 = rows[0]
+        assert r0["scheme_code"] == "CANARA_SMALL_CAP"
+        assert r0["fund_name"] == "Canara Robeco Small Cap Fund"
+        assert r0["as_of_month"] == date(2026, 7, 31)
+        assert r0["isin"] == "INE371P01015"
+        assert r0["security_name"] == "Amber Enterprises India Ltd"
+        assert r0["asset_type"] == "equity"
+        assert r0["market_value_cr"] == 354.42  # 35442.0 Lacs / 100
+        assert r0["pct_of_nav"] == 2.49
+
+        r1 = rows[1]
+        assert r1["isin"] == "INE685A01028"
+        assert r1["market_value_cr"] == 353.70
+        assert r1["pct_of_nav"] == 2.49
+
+        watermarks = importer.watermark_rows(rows)
+        assert watermarks == [("CANARA_ROBECO_MONTHLY", date(2026, 7, 31))]
+
+    def test_fractional_pct_scaling(self):
+        """Verify decimal fractions (e.g. 0.0249) get scaled by 100 to 2.49%."""
+        data = [
+            ["", "CANARA ROBECO SMALL CAP FUND", "", "", "", "", "", ""],
+            ["", "Monthly Portfolio Statement as on July 31, 2026", "", "", "", "", "", ""],
+            ["", "Name of the Instrument", "ISIN", "Industry / Rating", "Quantity", "Market/Fair Value\n (Rs. in Lacs)", "% to Net\n Assets", ""],
+            ["", "Amber Enterprises India Ltd", "INE371P01015", "Consumer Durables", "746266", "35442.0", "0.0249", ""],
+            ["", "Torrent Pharmaceuticals Ltd", "INE685A01028", "Pharmaceuticals", "500000", "35370.0", "0.0249", ""],
+        ]
+        df = pd.DataFrame(data)
+        out = io.BytesIO()
+        with pd.ExcelWriter(out, engine="openpyxl") as writer:
+            df.to_excel(writer, sheet_name="SC", header=False, index=False)
+        excel_bytes = out.getvalue()
+
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.content = excel_bytes
+        mock_http.get.return_value = mock_resp
+
+        importer = CanaraRobecoImporter()
+        source = (date(2026, 7, 31), "SC – Canara Robeco Small Cap Fund – July-2026", "SC.xlsx", "https://example.com/SC.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        assert len(rows) == 2
+        assert rows[0]["pct_of_nav"] == 2.49
+        assert rows[1]["pct_of_nav"] == 2.49


### PR DESCRIPTION
## Summary

- Implements `CanaraRobecoImporter` in `src/data_importer/amc_holdings/importers/canara_robeco.py` with automated statutory disclosure portal discovery using year/month query filters (`?filteryear=YYYY&filtermonth=MM`).
- Adds support for all active Canara Robeco schemes (*Small Cap*, *Value*, *Multi Cap*, *Mid Cap*, *Manufacturing*, *Conservative Hybrid*, *Income*, *Corporate Bond*, *Ultra Short Term*, *Overnight*) with dynamic column detection, Rs. Lacs to Crores scaling, and percentage normalization.
- Registers `canara`, `canara_robeco`, and `canara-robeco` in factory `REGISTRY`, canonical fetcher, main CLI import options, and freshness auditing.
- Adds Canara Robeco AMC alias matching in `src/scripts/portfolio/smallcap_pattern_analyzer.py`.
- Adds standalone CLI entry points and compat shims under `src/data_importer/canara_holdings/` and `src/scripts/canara/`.
- Adds comprehensive unit test suite in `tests/test_canara_robeco_importer.py`.

## Verification
- `pytest tests/test_canara_robeco_importer.py` passed (7/7).
- All AMC tests `pytest tests/test_dsp_importer.py tests/test_hdfc_importer.py tests/test_kotak_importer.py tests/test_abakkus_importer.py tests/test_helios_importer.py tests/test_invesco_importer.py tests/test_canara_robeco_importer.py` passed (50/50).
- Live ingestion into ClickHouse: 504 rows inserted across 10 active funds for July 2026.
- Pattern analyzer tested: `smallcap_pattern_analyzer.py --category small --amc canara`.