### PR TITLE
feat(importer): add Axis Mutual Fund monthly portfolio importer

### DIFF
--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -102,6 +102,7 @@ python src/main.py import --category helios       # Helios Mutual Fund (Small Ca
 python src/main.py import --category invesco      # Invesco Mutual Fund (Smallcap, Contra, Multi Asset, Flexi Cap, etc.)
 python src/main.py import --category canara       # Canara Robeco Mutual Fund (Small Cap, Flexi Cap, Value, Multi Cap, etc.)
 python src/main.py import --category mirae        # Mirae Asset Mutual Fund (Large Cap, Small Cap, Midcap, Multi Asset, etc.)
+python src/main.py import --category axis         # Axis Mutual Fund (Small Cap, Midcap, Multi Asset, Flexi Cap, etc.)
 python src/main.py import --category amfi         # AMFI category flows & AUM
 ```
 
@@ -117,6 +118,7 @@ python src/scripts/fund_imports/run.py helios       # Helios holdings backfill
 python src/scripts/fund_imports/run.py invesco      # Invesco holdings backfill
 python src/scripts/fund_imports/run.py canara       # Canara Robeco holdings backfill
 python src/scripts/fund_imports/run.py mirae        # Mirae Asset holdings backfill
+python src/scripts/fund_imports/run.py axis         # Axis Mutual Fund holdings backfill
 python src/scripts/fund_imports/run.py amfi         # AMFI category-wise net flows
 python src/scripts/fund_imports/run.py all          # Run all registered AMC importers
 ```

--- a/src/data_importer/amc_holdings/factory.py
+++ b/src/data_importer/amc_holdings/factory.py
@@ -31,6 +31,7 @@ from src.data_importer.amc_holdings.importers.helios import HeliosImporter
 from src.data_importer.amc_holdings.importers.invesco import InvescoImporter
 from src.data_importer.amc_holdings.importers.canara_robeco import CanaraRobecoImporter
 from src.data_importer.amc_holdings.importers.mirae import MiraeImporter
+from src.data_importer.amc_holdings.importers.axis import AxisImporter
 
 REGISTRY: dict[str, type[BaseFundImporter]] = {
     "icici":         IciciMFImporter,
@@ -52,6 +53,9 @@ REGISTRY: dict[str, type[BaseFundImporter]] = {
     "mirae":         MiraeImporter,
     "mirae_asset":   MiraeImporter,
     "mirae-asset":   MiraeImporter,
+    "axis":          AxisImporter,
+    "axis_mf":       AxisImporter,
+    "axis-mf":       AxisImporter,
 }
 
 

--- a/src/data_importer/amc_holdings/importers/axis.py
+++ b/src/data_importer/amc_holdings/importers/axis.py
@@ -1,0 +1,583 @@
+"""
+src/data_importer/amc_holdings/importers/axis.py
+─────────────────────────────────────────────────
+Axis Mutual Fund portfolio holdings importer.
+
+Discovers monthly portfolio disclosures via Axis MF CMS service API:
+    POST https://www.axismf.com/cms/token
+    POST https://www.axismf.com/cms/get-scheme-documents
+Payload:
+    {"sdType": "yearMonthSchemeDocs", "sdID": "sdMonthSchemePortfolio"}
+
+Each monthly disclosure is an Excel workbook (multi-sheet consolidated file
+covering all 80+ schemes, or single-scheme workbooks):
+  - Row 0: [Acronym, Fund Name, ...]
+  - Row 2: [..., 'Monthly Portfolio Statement as on July 31, 2026', ...]
+  - Row 3: Header columns (Name of the Instrument, ISIN, Industry, Quantity, Market Value in Lakhs, % of Net Assets)
+  - Columns:
+      Col 1: security_name
+      Col 2: isin
+      Col 3: industry / rating
+      Col 4: quantity
+      Col 5: market_value (Rs. in Lakhs -> scaled to Crores via / 100.0)
+      Col 6: pct_of_nav (decimal fraction e.g. 0.057 -> scaled to 5.70%)
+
+Classification:
+  - asset_type derived via classify_asset(security_name, isin, industry)
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import re
+import urllib.parse
+from datetime import date, datetime
+from typing import Any
+
+import httpx
+import pandas as pd
+
+from src.data_importer.amc_holdings.base import BaseFundImporter, classify_asset
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Content-Type": "application/json",
+}
+
+_CMS_TOKEN_URL = "https://www.axismf.com/cms/token"
+_CMS_SCHEME_DOCS_URL = "https://www.axismf.com/cms/get-scheme-documents"
+
+# ── Scheme Mapping ────────────────────────────────────────────────────────────
+
+SCHEME_MAP: dict[str, tuple[str, str]] = {
+    "Axis Small Cap Fund": ("AXIS_SMALL_CAP", "Axis Small Cap Fund"),
+    "Axis Midcap Fund": ("AXIS_MID_CAP", "Axis Mid Cap Fund"),
+    "Axis Mid Cap Fund": ("AXIS_MID_CAP", "Axis Mid Cap Fund"),
+    "Axis Multi Asset Allocation Fund": ("AXIS_MULTI_ASSET_ALLOCATION", "Axis Multi Asset Allocation Fund"),
+    "Axis Multi-Asset Active FoF": ("AXIS_MULTI_ASSET_ACTIVE_FOF", "Axis Multi-Asset Active FoF"),
+    "Axis Flexi Cap Fund": ("AXIS_FLEXI_CAP", "Axis Flexi Cap Fund"),
+    "Axis Large Cap Fund": ("AXIS_LARGE_CAP", "Axis Large Cap Fund"),
+    "Axis Bluechip Fund": ("AXIS_LARGE_CAP", "Axis Bluechip Fund"),
+    "Axis Large & Mid Cap Fund": ("AXIS_LARGE_AND_MID_CAP", "Axis Large & Mid Cap Fund"),
+    "Axis Large & Mid cap Fund": ("AXIS_LARGE_AND_MID_CAP", "Axis Large & Mid Cap Fund"),
+    "Axis Focused Fund": ("AXIS_FOCUSED", "Axis Focused Fund"),
+    "Axis Focused 25 Fund": ("AXIS_FOCUSED", "Axis Focused Fund"),
+    "Axis ELSS Tax Saver Fund": ("AXIS_ELSS_TAX_SAVER", "Axis ELSS Tax Saver Fund"),
+    "Axis Long Term Equity Fund": ("AXIS_ELSS_TAX_SAVER", "Axis Long Term Equity Fund"),
+    "Axis Balanced Advantage Fund": ("AXIS_BALANCED_ADVANTAGE", "Axis Balanced Advantage Fund"),
+    "Axis Aggressive Hybrid Fund": ("AXIS_AGGRESSIVE_HYBRID", "Axis Aggressive Hybrid Fund"),
+    "Axis Equity Savings Fund": ("AXIS_EQUITY_SAVINGS", "Axis Equity Savings Fund"),
+    "Axis Quant Fund": ("AXIS_QUANT", "Axis Quant Fund"),
+    "Axis Value Fund": ("AXIS_VALUE", "Axis Value Fund"),
+    "Axis Multicap Fund": ("AXIS_MULTICAP", "Axis Multicap Fund"),
+    "Axis India Manufacturing Fund": ("AXIS_INDIA_MANUFACTURING", "Axis India Manufacturing Fund"),
+    "Axis Consumption Fund": ("AXIS_CONSUMPTION", "Axis Consumption Fund"),
+    "AXIS CONSUMPTION FUND": ("AXIS_CONSUMPTION", "Axis Consumption Fund"),
+    "Axis Innovation Fund": ("AXIS_INNOVATION", "Axis Innovation Fund"),
+    "Axis Services Opportunities Fund": ("AXIS_SERVICES_OPPORTUNITIES", "Axis Services Opportunities Fund"),
+    "Axis Business Cycles Fund": ("AXIS_BUSINESS_CYCLES", "Axis Business Cycles Fund"),
+    "Axis ESG Integration Strategy Fund": ("AXIS_ESG_INTEGRATION", "Axis ESG Integration Strategy Fund"),
+    "Axis Special Situations Fund": ("AXIS_SPECIAL_SITUATIONS", "Axis Special Situations Fund"),
+    "Axis Gold ETF": ("AXIS_GOLD_ETF", "Axis Gold ETF"),
+    "Axis Gold Fund": ("AXIS_GOLD_FUND", "Axis Gold Fund"),
+    "Axis Gold and Silver Passive FoF": ("AXIS_GOLD_AND_SILVER_PASSIVE_FOF", "Axis Gold and Silver Passive FoF"),
+    "Axis Silver ETF": ("AXIS_SILVER_ETF", "Axis Silver ETF"),
+    "Axis Silver Fund of Fund": ("AXIS_SILVER_FOF", "Axis Silver Fund of Fund"),
+    "AXIS SILVER FUND OF FUND": ("AXIS_SILVER_FOF", "Axis Silver Fund of Fund"),
+    "Axis NIFTY 50 ETF": ("AXIS_NIFTY_50_ETF", "Axis NIFTY 50 ETF"),
+    "Axis NIFTY Bank ETF": ("AXIS_NIFTY_BANK_ETF", "Axis NIFTY Bank ETF"),
+    "Axis NIFTY IT ETF": ("AXIS_NIFTY_IT_ETF", "Axis NIFTY IT ETF"),
+    "Axis NIFTY Healthcare ETF": ("AXIS_NIFTY_HEALTHCARE_ETF", "Axis NIFTY Healthcare ETF"),
+    "Axis Nifty 50 Index Fund": ("AXIS_NIFTY_50_INDEX", "Axis Nifty 50 Index Fund"),
+    "Axis Nifty 500 Index Fund": ("AXIS_NIFTY_500_INDEX", "Axis Nifty 500 Index Fund"),
+    "Axis Nifty 100 Index Fund": ("AXIS_NIFTY_100_INDEX", "Axis Nifty 100 Index Fund"),
+    "Axis Nifty Next 50 Index Fund": ("AXIS_NIFTY_NEXT_50_INDEX", "Axis Nifty Next 50 Index Fund"),
+    "Axis Nifty Smallcap 50 Index Fund": ("AXIS_NIFTY_SMALLCAP_50_INDEX", "Axis Nifty Smallcap 50 Index Fund"),
+    "AXIS NIFTY SMALLCAP 50 INDEX FUND": ("AXIS_NIFTY_SMALLCAP_50_INDEX", "Axis Nifty Smallcap 50 Index Fund"),
+    "Axis Nifty Midcap 50 Index Fund": ("AXIS_NIFTY_MIDCAP_50_INDEX", "Axis Nifty Midcap 50 Index Fund"),
+    "AXIS NIFTY MIDCAP 50 INDEX FUND": ("AXIS_NIFTY_MIDCAP_50_INDEX", "Axis Nifty Midcap 50 Index Fund"),
+    "Axis Arbitrage Fund": ("AXIS_ARBITRAGE", "Axis Arbitrage Fund"),
+    "Axis Liquid Fund": ("AXIS_LIQUID", "Axis Liquid Fund"),
+    "Axis Treasury Advantage Fund": ("AXIS_TREASURY_ADVANTAGE", "Axis Treasury Advantage Fund"),
+    "Axis Corporate Bond Fund": ("AXIS_CORPORATE_BOND", "Axis Corporate Bond Fund"),
+    "Axis Banking & PSU Debt Fund": ("AXIS_BANKING_AND_PSU_DEBT", "Axis Banking & PSU Debt Fund"),
+    "Axis Short Duration Fund": ("AXIS_SHORT_DURATION", "Axis Short Duration Fund"),
+    "Axis Ultra Short Duration Fund": ("AXIS_ULTRA_SHORT_DURATION", "Axis Ultra Short Duration Fund"),
+    "Axis Money Market Fund": ("AXIS_MONEY_MARKET", "Axis Money Market Fund"),
+    "Axis Dynamic Bond Fund": ("AXIS_DYNAMIC_BOND", "Axis Dynamic Bond Fund"),
+    "Axis Strategic Bond Fund": ("AXIS_STRATEGIC_BOND", "Axis Strategic Bond Fund"),
+    "Axis Children’s Fund": ("AXIS_CHILDRENS_FUND", "Axis Children's Fund"),
+    "Axis Children's Fund": ("AXIS_CHILDRENS_FUND", "Axis Children's Fund"),
+    "Axis Retirement Fund - Aggressive Plan": ("AXIS_RETIREMENT_AGGRESSIVE", "Axis Retirement Fund - Aggressive Plan"),
+    "Axis Retirement Fund - Dynamic Plan": ("AXIS_RETIREMENT_DYNAMIC", "Axis Retirement Fund - Dynamic Plan"),
+    "Axis Retirement Fund - Conservative Plan": ("AXIS_RETIREMENT_CONSERVATIVE", "Axis Retirement Fund - Conservative Plan"),
+}
+
+MONTH_MAP: dict[str, int] = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}
+
+
+def _last_day_of_month(year: int, month: int) -> date:
+    if month == 12:
+        return date(year, 12, 31)
+    import calendar
+    _, last_day = calendar.monthrange(year, month)
+    return date(year, month, last_day)
+
+
+def _parse_disclosure_date(text: str) -> date | None:
+    """
+    Extract disclosure month-end date from title, e.g.:
+      'Monthly Portfolio Statement as on July 31, 2026'
+      'Monthly Portfolio-31 07 26'
+      'Monthly Portfolio - Axis Small Cap Fund - 31 July 2026'
+      'Monthly_Portfolio_31072026_8a12978eff.xlsx'
+      'monthly_20portfolio-31_2003_2026.xlsx'
+    """
+    if not text:
+        return None
+
+    cleaned = text.replace("_2520", " ").replace("%2520", " ").replace("_20", " ").replace("%20", " ")
+    cleaned = urllib.parse.unquote(cleaned).replace("_", " ")
+    cleaned = re.sub(r"[–—]", "-", cleaned)
+
+    parts = [p.strip() for p in cleaned.split("-") if p.strip()]
+    candidates = []
+    if len(parts) > 1:
+        candidates.append(parts[-1])
+        if len(parts) > 2:
+            candidates.append(parts[-2])
+    candidates.append(cleaned)
+
+    for cand in candidates:
+        # 1. Pattern: 31 July 2026 or 31May2026 or 31st July 2026
+        m = re.search(r"(\d{1,2})(?:st|nd|rd|th)?\s*([A-Za-z]+)[,\s]*(20\d{2})", cand)
+        if m:
+            day, mon_str, year = int(m.group(1)), m.group(2).lower(), int(m.group(3))
+            if 2010 <= year <= 2027:
+                mon = MONTH_MAP.get(mon_str)
+                if mon:
+                    return _last_day_of_month(year, mon)
+
+        # 2. Pattern: July 31, 2026 or July 31 2026
+        m = re.search(r"([A-Za-z]+)\s*(\d{1,2})[,\s]*(20\d{2})", cand)
+        if m:
+            mon_str, day, year = m.group(1).lower(), int(m.group(2)), int(m.group(3))
+            if 2010 <= year <= 2027:
+                mon = MONTH_MAP.get(mon_str)
+                if mon:
+                    return _last_day_of_month(year, mon)
+
+        # 3. Pattern: 31 July 26 or 31May26 or 31st July 26
+        m = re.search(r"(\d{1,2})(?:st|nd|rd|th)?\s*([A-Za-z]+)[,\s]*(\d{2})(?:\D|$)", cand)
+        if m:
+            day, mon_str, yr_short = int(m.group(1)), m.group(2).lower(), int(m.group(3))
+            year = yr_short + 2000
+            if 2010 <= year <= 2027:
+                mon = MONTH_MAP.get(mon_str)
+                if mon:
+                    return _last_day_of_month(year, mon)
+
+        # 4. Pattern: DD MM YYYY (e.g. 31 07 2026 or 31072026)
+        m = re.search(r"(?:^|\D)(?:31|30|28|29)\s*(0[1-9]|1[0-2])\s*(20\d{2})(?:\D|$)", cand)
+        if m:
+            mon = int(m.group(1))
+            year = int(m.group(2))
+            if 2010 <= year <= 2027:
+                return _last_day_of_month(year, mon)
+
+        # 5. Pattern: DD MM YY (e.g. 31 07 26 or 31_07_26)
+        m = re.search(r"(?:^|\D)(?:31|30|28|29)\s*(0[1-9]|1[0-2])\s*(\d{2})(?:\D|$)", cand)
+        if m:
+            mon = int(m.group(1))
+            year = int(m.group(2)) + 2000
+            if 2010 <= year <= 2027:
+                return _last_day_of_month(year, mon)
+
+        # 6. Pattern: [Month] [20XX] (e.g. July 2026 or Jul 2026)
+        m = re.search(r"([A-Za-z]+)[,\s-]+(20\d{2})", cand)
+        if m:
+            mon_str, year = m.group(1).lower(), int(m.group(2))
+            if 2010 <= year <= 2027:
+                mon = MONTH_MAP.get(mon_str)
+                if mon:
+                    return _last_day_of_month(year, mon)
+
+    return None
+
+
+def _normalise_fund_identity(title: str, default_sheet: str = "") -> tuple[str, str]:
+    """Normalize fund name to canonical (scheme_code, fund_name)."""
+    t = re.sub(r"\s+", " ", title).strip()
+    if not t and default_sheet:
+        t = default_sheet
+
+    # Direct map
+    for k, (code, name) in SCHEME_MAP.items():
+        if k.lower() == t.lower():
+            return code, name
+
+    # Substring match
+    for k, (code, name) in SCHEME_MAP.items():
+        if k.lower() in t.lower() or t.lower() in k.lower():
+            return code, name
+
+    # Fallback clean
+    clean = re.sub(r"[^A-Za-z0-9]+", "_", t).strip("_").upper()
+    if not clean.startswith("AXIS"):
+        clean = "AXIS_" + clean
+    return clean, t
+
+
+# ── Importer Class ────────────────────────────────────────────────────────────
+
+class AxisImporter(BaseFundImporter):
+    """
+    Axis Mutual Fund monthly portfolio holdings importer.
+    Discovers Excel files from Axis MF CMS API and parses both consolidated
+    workbooks and single-scheme disclosures.
+    """
+
+    def __init__(
+        self,
+        full_reimport: bool = False,
+        from_year: int = 2020,
+        target_month: date | None = None,
+        freshness_months: int = 0,
+    ) -> None:
+        super().__init__(target_month=target_month, freshness_months=freshness_months)
+        self.full_reimport = full_reimport
+        self.from_year = from_year
+
+    def fund_name(self) -> str:
+        return "Axis Mutual Fund"
+
+    def table_name(self) -> str:
+        return "market_data.mf_holdings"
+
+    def column_names(self) -> list[str]:
+        return [
+            "scheme_code",
+            "fund_name",
+            "as_of_month",
+            "isin",
+            "security_name",
+            "asset_type",
+            "market_value_cr",
+            "pct_of_nav",
+            "imported_at",
+        ]
+
+    def watermark_source(self) -> str:
+        return "mf_holdings"
+
+    def watermark_rows(self, rows: list[dict[str, Any]]) -> list[tuple[str, date]]:
+        """Return distinct (watermark_id, as_of_month) pairs for imported rows."""
+        seen: set[tuple[str, date]] = set()
+        for r in rows:
+            m = r.get("as_of_month")
+            if isinstance(m, date):
+                seen.add(("AXIS_MF_MONTHLY", m))
+        return list(seen)
+
+    def fetch_sources(self) -> list[tuple[date, str, str, str]]:
+        """
+        Query Axis MF CMS API to discover monthly portfolio disclosures.
+        Returns: list of (as_of_month, doc_title, filename, download_url).
+        """
+        sources: list[tuple[date, str, str, str]] = []
+        try:
+            with httpx.Client(headers=_DEFAULT_HEADERS, timeout=45.0, follow_redirects=True) as http:
+                # 1. Fetch Bearer token
+                tok_resp = http.post(_CMS_TOKEN_URL, json={})
+                tok_data = tok_resp.json()
+                token = tok_data.get("data", {}).get("token") or tok_data.get("token")
+                if not token:
+                    logger.error("Failed to obtain CMS token from Axis MF.")
+                    return []
+
+                h = dict(_DEFAULT_HEADERS, Authorization=token)
+
+                # 2. Fetch document list for sdMonthSchemePortfolio
+                docs_resp = http.post(
+                    _CMS_SCHEME_DOCS_URL,
+                    headers=h,
+                    json={
+                        "sdType": "yearMonthSchemeDocs",
+                        "sdID": "sdMonthSchemePortfolio",
+                    },
+                )
+                if docs_resp.status_code != 200:
+                    logger.error("Failed to fetch Axis documents: HTTP %d", docs_resp.status_code)
+                    return []
+
+                docs_data = docs_resp.json().get("data", {})
+                doc_list = docs_data.get("documentList", [])
+                logger.info("Axis CMS returned %d total document entries.", len(doc_list))
+
+                seen_urls: set[str] = set()
+
+                for d in doc_list:
+                    url = d.get("docuementURL") or ""
+                    title = d.get("documentName") or ""
+                    if not url or url in seen_urls:
+                        continue
+
+                    # Ensure only monthly portfolio files are selected
+                    t_low = title.lower()
+                    u_low = url.lower()
+                    if not ("monthly" in t_low and "portfolio" in t_low) and not ("monthly" in u_low and "portfolio" in u_low):
+                        continue
+
+                    # Skip weekly/fortnightly/adhoc/daily files
+                    if any(k in t_low or k in u_low for k in ["weekly", "fortnightly", "adhoc", "daily", "debt quants", "debt_quants", "quants"]):
+                        continue
+
+                    as_of = _parse_disclosure_date(title) or _parse_disclosure_date(url)
+                    if not as_of:
+                        continue
+
+                    if as_of.year < self.from_year:
+                        continue
+
+                    if self._target_month and (as_of.year != self._target_month.year or as_of.month != self._target_month.month):
+                        continue
+
+                    seen_urls.add(url)
+                    fname = url.split("/")[-1]
+                    sources.append((as_of, title, fname, url))
+
+        except Exception as e:
+            logger.error("Error discovering Axis portfolio sources: %s", e)
+
+        # Sort descending by date
+        sources.sort(key=lambda s: s[0], reverse=True)
+
+        if not self.full_reimport and not self._target_month and sources:
+            # By default delta-sync latest month disclosures (consolidated or all schemes for latest month)
+            latest_month = sources[0][0]
+            sources = [s for s in sources if s[0] == latest_month]
+
+        # Deduplicate per month: prefer consolidated workbook if present
+        by_month: dict[date, list[tuple[date, str, str, str]]] = {}
+        for s in sources:
+            by_month.setdefault(s[0], []).append(s)
+
+        filtered_sources: list[tuple[date, str, str, str]] = []
+        for m_date, m_sources in by_month.items():
+            cons = [
+                s for s in m_sources
+                if re.search(r"monthly[_\s-]?portfolio[_\s-]?\d+", s[1], re.IGNORECASE)
+                or re.search(r"monthly[_\s-]?portfolio[_\s-]?\d+", s[2], re.IGNORECASE)
+            ]
+            if cons:
+                filtered_sources.extend(cons)
+            else:
+                filtered_sources.extend(m_sources)
+
+        sources = filtered_sources
+        sources.sort(key=lambda s: s[0], reverse=True)
+
+        logger.info("Found %d Axis MF disclosure sources to process.", len(sources))
+        return sources
+
+    def parse_source(
+        self,
+        source: tuple[date, str, str, str],
+        http: httpx.Client,
+    ) -> list[dict[str, Any]]:
+        """
+        Download and parse an Axis MF Excel workbook (multi-sheet or single-sheet).
+        """
+        as_of_date, title, filename, url = source
+        logger.info("Downloading Axis portfolio: %s (%s)", title, url)
+
+        try:
+            resp = http.get(url, timeout=120.0, follow_redirects=True)
+            if resp.status_code != 200 or len(resp.content) < 500:
+                logger.warning("Failed download for %s: HTTP %d (%d bytes)", url, resp.status_code, len(resp.content))
+                return []
+            content = resp.content
+        except Exception as e:
+            logger.error("Download error for %s: %s", url, e)
+            return []
+
+        # Parse Excel workbook with openpyxl or xlrd
+        excel_file = io.BytesIO(content)
+        try:
+            excel = pd.ExcelFile(excel_file, engine="openpyxl")
+        except Exception:
+            excel_file.seek(0)
+            try:
+                excel = pd.ExcelFile(excel_file, engine="xlrd")
+            except Exception as e:
+                logger.error("Failed to read Excel workbook for %s: %s", filename, e)
+                return []
+
+        imported_at = datetime.utcnow()
+        all_rows: list[dict[str, Any]] = []
+
+        for sheet_name in excel.sheet_names:
+            if sheet_name.lower() in ["index", "summary", "instructions", "sheet1"]:
+                if len(excel.sheet_names) > 1 and sheet_name.lower() in ["index", "summary", "instructions"]:
+                    continue
+
+            try:
+                df = excel.parse(sheet_name, header=None)
+            except Exception as e:
+                logger.debug("Failed parsing sheet %s: %s", sheet_name, e)
+                continue
+
+            if df.empty or df.shape[0] < 2 or df.shape[1] < 4:
+                continue
+
+            # Identify fund title and date
+            fund_raw_name = str(df.iloc[0, 1]).strip() if pd.notna(df.iloc[0, 1]) else sheet_name
+            if fund_raw_name.lower() in ["nan", "none", ""]:
+                fund_raw_name = title or sheet_name
+
+            # Check if row 2 has date text
+            sheet_date = as_of_date
+            if df.shape[0] > 2 and pd.notna(df.iloc[2, 1]):
+                extracted_date = _parse_disclosure_date(str(df.iloc[2, 1]))
+                if extracted_date:
+                    sheet_date = extracted_date
+
+            scheme_code, canonical_fund_name = _normalise_fund_identity(fund_raw_name, default_sheet=sheet_name)
+
+            # Find header row
+            header_row_idx = 3
+            name_col = 1
+            isin_col = 2
+            ind_col = 3
+            mv_col = 5
+            pct_col = 6
+            is_debt_format = False
+
+            for r_i in range(min(12, len(df))):
+                row_vals = [str(x).strip().lower() for x in df.iloc[r_i] if pd.notna(x)]
+                row_str = " ".join(row_vals)
+
+                if "scheme code" in row_str and "security name" in row_str and df.shape[1] >= 10:
+                    # 22-column debt format (e.g. AXISTAA_12_Aug2026.xls)
+                    is_debt_format = True
+                    header_row_idx = r_i
+                    name_col = 3
+                    isin_col = 2
+                    ind_col = 14
+                    mv_col = 6  # Market Value in Rs
+                    pct_col = 7
+                    if r_i + 1 < len(df) and pd.notna(df.iloc[r_i + 1, 1]):
+                        debt_scheme_name = str(df.iloc[r_i + 1, 1]).strip()
+                        if debt_scheme_name and debt_scheme_name.lower() not in ["nan", "none"]:
+                            scheme_code, canonical_fund_name = _normalise_fund_identity(debt_scheme_name, default_sheet=sheet_name)
+                    break
+                elif "name of the instrument" in row_str or "security name" in row_str:
+                    header_row_idx = r_i
+                    # Match exact columns
+                    for c_i, c_val in enumerate(df.iloc[r_i]):
+                        c_str = str(c_val).lower() if pd.notna(c_val) else ""
+                        if "name of the instrument" in c_str or "security name" in c_str:
+                            name_col = c_i
+                        elif "isin" in c_str:
+                            isin_col = c_i
+                        elif "industry" in c_str or "rating" in c_str or "sector" in c_str:
+                            ind_col = c_i
+                        elif "market" in c_str or "fair value" in c_str or "value" in c_str:
+                            mv_col = c_i
+                        elif "%" in c_str or "nav" in c_str or "assets" in c_str:
+                            pct_col = c_i
+                    break
+
+            # Parse holding rows
+            raw_holdings = []
+            valid_pcts = []
+
+            for idx in range(header_row_idx + 1, len(df)):
+                name = str(df.iloc[idx, name_col]).strip() if df.shape[1] > name_col and pd.notna(df.iloc[idx, name_col]) else ""
+                isin = str(df.iloc[idx, isin_col]).strip() if df.shape[1] > isin_col and pd.notna(df.iloc[idx, isin_col]) else ""
+                ind = str(df.iloc[idx, ind_col]).strip() if df.shape[1] > ind_col and pd.notna(df.iloc[idx, ind_col]) else ""
+                mv = df.iloc[idx, mv_col] if df.shape[1] > mv_col else None
+                pct = df.iloc[idx, pct_col] if df.shape[1] > pct_col else None
+
+                if not name or name.lower() in [
+                    "nan", "none", "sub total", "total", "grand total",
+                    "equity & equity related", "others", "debt instruments",
+                    "money market instruments", "net current assets", "cash & other receivables",
+                ]:
+                    continue
+
+                if name.startswith("(") and ("listed" in name.lower() or "unlisted" in name.lower()):
+                    continue
+
+                try:
+                    mv_f = float(str(mv).replace(",", "").strip()) if pd.notna(mv) else 0.0
+                    pct_f = float(str(pct).replace(",", "").strip()) if pd.notna(pct) else 0.0
+                except (ValueError, TypeError):
+                    continue
+
+                if isin in ["nan", "None", "-", "N.A.", "NA"]:
+                    isin = ""
+
+                raw_holdings.append((name, isin, ind, mv_f, pct_f))
+                if pct_f > 0:
+                    valid_pcts.append(pct_f)
+
+            if not raw_holdings:
+                continue
+
+            # Determine percentage scale: if >=50% of valid numbers are <= 1.0, scale by 100
+            if valid_pcts:
+                fractional_count = sum(1 for p in valid_pcts if p <= 1.0)
+                pct_scale = 100.0 if fractional_count / len(valid_pcts) >= 0.5 else 1.0
+            else:
+                pct_scale = 1.0
+
+            for name, isin, ind, mv_f, pct_f in raw_holdings:
+                if is_debt_format:
+                    mv_cr = round(mv_f / 10000000.0, 4)  # Rs -> Crores
+                else:
+                    mv_cr = round(mv_f / 100.0, 4)  # Rs. Lakhs -> Crores
+
+                pct_val = round(pct_f * pct_scale, 4)
+
+                # Skip header/total outliers
+                if pct_val > 105.0:
+                    continue
+
+                # Asset classification
+                asset_type = classify_asset(name, ind)
+
+                all_rows.append({
+                    "scheme_code": scheme_code,
+                    "fund_name": canonical_fund_name,
+                    "as_of_month": sheet_date,
+                    "isin": isin if isin else "",
+                    "security_name": name,
+                    "asset_type": asset_type,
+                    "market_value_cr": mv_cr,
+                    "pct_of_nav": pct_val,
+                    "imported_at": imported_at,
+                })
+
+        logger.info("  %s (%s): %d holdings parsed", title, as_of_date, len(all_rows))
+        return all_rows

--- a/src/data_importer/axis_holdings/__init__.py
+++ b/src/data_importer/axis_holdings/__init__.py
@@ -1,0 +1,1 @@
+"""src/data_importer/axis_holdings"""

--- a/src/data_importer/axis_holdings/import_all_axis.py
+++ b/src/data_importer/axis_holdings/import_all_axis.py
@@ -1,0 +1,54 @@
+"""
+src/data_importer/axis_holdings/import_all_axis.py
+───────────────────────────────────────────────────
+Standalone CLI script to import Axis Mutual Fund monthly portfolio disclosures.
+
+Usage:
+    python -m src.data_importer.axis_holdings.import_all_axis
+    python -m src.data_importer.axis_holdings.import_all_axis --dry-run
+    python -m src.data_importer.axis_holdings.import_all_axis --month 2026-07
+    python -m src.data_importer.axis_holdings.import_all_axis --full
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from datetime import datetime
+
+from src.data_importer.amc_holdings.importers.axis import AxisImporter
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Import Axis Mutual Fund monthly portfolio holdings.")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch and parse without inserting to ClickHouse.")
+    parser.add_argument("--full", action="store_true", help="Re-import full history.")
+    parser.add_argument("--from-year", type=int, default=2020, help="Starting year for full re-import (default: 2020).")
+    parser.add_argument("--month", type=str, default=None, help="Target month in YYYY-MM format (e.g. 2026-07).")
+    parser.add_argument("--fresh", type=int, default=0, help="Freshness threshold in months.")
+    args = parser.parse_args()
+
+    target_date = None
+    if args.month:
+        try:
+            dt = datetime.strptime(args.month, "%Y-%m")
+            target_date = dt.date()
+        except ValueError:
+            logger.error("Invalid --month format '%s'. Use YYYY-MM (e.g. 2026-07).", args.month)
+            return
+
+    importer = AxisImporter(
+        full_reimport=args.full,
+        from_year=args.from_year,
+        target_month=target_date,
+        freshness_months=args.fresh,
+    )
+    result = importer.run(dry_run=args.dry_run)
+    logger.info("Axis Mutual Fund import completed: %s", result)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/data_importer/fetchers/amc_holdings_fetcher.py
+++ b/src/data_importer/fetchers/amc_holdings_fetcher.py
@@ -25,7 +25,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 # Valid values for the `amc` argument — mirrors factory.REGISTRY keys.
-AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco", "mirae", "mirae_asset", "mirae-asset"})
+AMC_KEYS: frozenset[str] = frozenset({"nippon", "dsp", "icici", "icici-index", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco", "mirae", "mirae_asset", "mirae-asset", "axis", "axis_mf", "axis-mf"})
 
 
 def fetch_amc_holdings(
@@ -56,7 +56,7 @@ def fetch_amc_holdings(
     from src.data_importer.amc_holdings.factory import create_importer
 
     kwargs: dict = {}
-    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco"):
+    if amc in ("nippon", "dsp", "bajaj", "quant", "amfi", "hdfc", "kotak", "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco", "mirae", "mirae_asset", "mirae-asset", "axis", "axis_mf", "axis-mf"):
         kwargs["full_reimport"] = full_reimport
 
     if target_month:

--- a/src/data_importer/inav_csv.py
+++ b/src/data_importer/inav_csv.py
@@ -6,6 +6,12 @@ Flat-file CSV store for iNAV snapshots.
 Layout: market_data/inav/{SYMBOL}/{YYYY}/{MM}/{DD}.csv
 
 Schema: snapshot_at,inav,market_price,premium_discount_pct,source
+
+AMC fetchers hand write_inav_rows() naive-UTC timestamps (the convention used
+throughout data_importer.fetchers for staleness checks etc.). write_inav_rows
+converts to naive IST before persisting, so the CSV — and the folder date it's
+filed under — reflect the local trading day/time an analyst reading these
+files expects.
 """
 
 from __future__ import annotations
@@ -13,14 +19,16 @@ from __future__ import annotations
 import csv
 import os
 from collections import defaultdict
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Iterable, Mapping
+from zoneinfo import ZoneInfo
 
 import pandas as pd
 
 
 CSV_COLUMNS = ["snapshot_at", "inav", "market_price", "premium_discount_pct", "source"]
+IST = ZoneInfo("Asia/Kolkata")
 
 
 def _resolve_base_dir(base_dir: str | os.PathLike | None) -> Path:
@@ -56,6 +64,11 @@ def _coerce_snapshot_at(value) -> datetime:
     return datetime.fromisoformat(str(value))
 
 
+def _to_ist_naive(dt_utc: datetime) -> datetime:
+    """Convert a naive-UTC datetime (as produced by the AMC fetchers) to naive IST."""
+    return dt_utc.replace(tzinfo=timezone.utc).astimezone(IST).replace(tzinfo=None)
+
+
 def write_inav_rows(
     rows: Iterable[Mapping],
     base_dir: str | os.PathLike | None = None,
@@ -68,7 +81,7 @@ def write_inav_rows(
     grouped: dict[Path, list[dict]] = defaultdict(list)
     for row in rows:
         symbol = row["symbol"]
-        snap = _coerce_snapshot_at(row["snapshot_at"])
+        snap = _to_ist_naive(_coerce_snapshot_at(row["snapshot_at"]))
         path = inav_csv_path(symbol, snap, base_dir)
         grouped[path].append({
             "snapshot_at": snap.isoformat(timespec="seconds"),
@@ -99,6 +112,9 @@ def read_inav(
 ) -> pd.DataFrame:
     """
     Read iNAV rows for `symbol` between `start` and `end` (inclusive).
+
+    `start`/`end` and the returned `snapshot_at` column are IST, matching what
+    write_inav_rows persisted.
 
     Returns an empty DataFrame with correct columns if no files exist.
     """

--- a/src/data_importer/maintenance/audit_freshness.py
+++ b/src/data_importer/maintenance/audit_freshness.py
@@ -155,7 +155,7 @@ def audit_freshness():
             elif import_name == "inav": import_name = "inav"
             elif import_name == "indian_macro": import_name = "indian_macro"
             elif import_name == "fii_dii": import_name = "fii_dii"
-            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus,helios,invesco,canara,mirae"
+            elif import_name == "amc_holdings": import_name = "dsp,nippon,icici,quant,bajaj,hdfc,kotak,abakkus,helios,invesco,canara,mirae,axis"
             stale_categories.append(import_name)
 
         table.add_row(cat, tbl_name, str(max_date), status)

--- a/src/main.py
+++ b/src/main.py
@@ -939,7 +939,7 @@ def import_data(
             "cot, cb_reserves, etf_aum, mf_holdings, fii_dii, amfi_flows, "
             "earnings, insider, valuation, "
             "world_bank, imf_weo, indian_macro, indian_macro_indicators, "
-            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, helios, invesco, canara, mirae, all. "
+            "icici, nippon, icici-index, dsp, bajaj, quant, hdfc, kotak, abakkus, helios, invesco, canara, mirae, axis, all. "
             "Default: all."
         ),
     ),

--- a/src/scripts/axis/import_all_axis.py
+++ b/src/scripts/axis/import_all_axis.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+src/scripts/axis/import_all_axis.py
+───────────────────────────────────
+Shortcut CLI to import Axis Mutual Fund monthly portfolio disclosures.
+
+Usage:
+    python src/scripts/axis/import_all_axis.py
+    python src/scripts/axis/import_all_axis.py --dry-run
+    python src/scripts/axis/import_all_axis.py --month 2026-07
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path
+ROOT = Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.data_importer.axis_holdings.import_all_axis import main
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/fund_imports/importers/axis.py
+++ b/src/scripts/fund_imports/importers/axis.py
@@ -1,0 +1,14 @@
+"""
+src/scripts/fund_imports/importers/axis.py
+───────────────────────────────────────────
+Forwarding shim for backwards compatibility.
+Canonical implementation is at:
+    src.data_importer.amc_holdings.importers.axis.AxisImporter
+"""
+
+from src.data_importer.amc_holdings.importers.axis import (  # noqa: F401
+    AxisImporter,
+    SCHEME_MAP,
+    _parse_disclosure_date,
+    _normalise_fund_identity,
+)

--- a/tests/test_axis_importer.py
+++ b/tests/test_axis_importer.py
@@ -1,0 +1,207 @@
+"""
+tests/test_axis_importer.py
+────────────────────────────
+Unit test suite for Axis Mutual Fund holdings importer.
+"""
+
+from __future__ import annotations
+
+import io
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from src.data_importer.amc_holdings.factory import REGISTRY, create_importer
+from src.data_importer.amc_holdings.importers.axis import (
+    AxisImporter,
+    SCHEME_MAP,
+    _normalise_fund_identity,
+    _parse_disclosure_date,
+)
+
+
+class TestAxisImporterSchemeMapping:
+    def test_scheme_map_known_funds(self):
+        assert "Axis Small Cap Fund" in SCHEME_MAP
+        assert SCHEME_MAP["Axis Small Cap Fund"] == ("AXIS_SMALL_CAP", "Axis Small Cap Fund")
+        assert "Axis Multi Asset Allocation Fund" in SCHEME_MAP
+        assert SCHEME_MAP["Axis Multi Asset Allocation Fund"] == ("AXIS_MULTI_ASSET_ALLOCATION", "Axis Multi Asset Allocation Fund")
+        assert "Axis Flexi Cap Fund" in SCHEME_MAP
+        assert SCHEME_MAP["Axis Flexi Cap Fund"] == ("AXIS_FLEXI_CAP", "Axis Flexi Cap Fund")
+        assert "Axis Gold ETF" in SCHEME_MAP
+        assert SCHEME_MAP["Axis Gold ETF"] == ("AXIS_GOLD_ETF", "Axis Gold ETF")
+
+    def test_parse_disclosure_date(self):
+        assert _parse_disclosure_date("Monthly Portfolio Statement as on July 31, 2026") == date(2026, 7, 31)
+        assert _parse_disclosure_date("Monthly Portfolio-31 07 26") == date(2026, 7, 31)
+        assert _parse_disclosure_date("Monthly Portfolio - Axis Small Cap Fund - 31 July 2026") == date(2026, 7, 31)
+        assert _parse_disclosure_date("Monthly_Portfolio_31072026_8a12978eff.xlsx") == date(2026, 7, 31)
+        assert _parse_disclosure_date("monthly_20portfolio-31_2003_2026.xlsx") == date(2026, 3, 31)
+        assert _parse_disclosure_date("monthly_20portfolio-28_2002_2026.xlsx") == date(2026, 2, 28)
+
+    def test_normalise_fund_identity(self):
+        code, name = _normalise_fund_identity("Axis Small Cap Fund")
+        assert code == "AXIS_SMALL_CAP"
+        assert name == "Axis Small Cap Fund"
+
+        code, name = _normalise_fund_identity("Axis Multi Asset Allocation Fund")
+        assert code == "AXIS_MULTI_ASSET_ALLOCATION"
+
+        # Fallback for unknown fund
+        code, name = _normalise_fund_identity("Axis Next Gen Alpha Fund")
+        assert code.startswith("AXIS_")
+        assert "ALPHA" in code
+
+
+class TestAxisImporterStructure:
+    def test_importer_metadata(self):
+        importer = AxisImporter()
+        assert importer.fund_name() == "Axis Mutual Fund"
+        assert importer.table_name() == "market_data.mf_holdings"
+        assert importer.watermark_source() == "mf_holdings"
+        cols = importer.column_names()
+        assert "scheme_code" in cols
+        assert "market_value_cr" in cols
+        assert "pct_of_nav" in cols
+
+    def test_factory_registration(self):
+        assert "axis" in REGISTRY
+        assert "axis_mf" in REGISTRY
+        assert "axis-mf" in REGISTRY
+        importer = create_importer("axis")
+        assert isinstance(importer, AxisImporter)
+
+
+class TestAxisExcelParsing:
+    def test_parse_mock_multi_sheet_excel(self):
+        # Create in-memory multi-sheet Excel matching Axis format
+        output = io.BytesIO()
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            # Index sheet
+            index_df = pd.DataFrame([
+                ["Sr No.", "Short Name", "Scheme Name", "Exchange"],
+                [1, "AXISSCF", "Axis Small Cap Fund", None],
+                [2, "AXISTAF", "Axis Multi Asset Allocation Fund", None],
+            ])
+            index_df.to_excel(writer, sheet_name="Index", header=False, index=False)
+
+            # Axis Small Cap sheet
+            sc_data = [
+                ["AXISSCF", "Axis Small Cap Fund", None, None, None, None, None],
+                [None, None, None, None, None, None, None],
+                ["", "Monthly Portfolio Statement as on July 31, 2026", None, None, None, None, None],
+                [None, "Name of the Instrument", "ISIN", "Industry", "Quantity", "Market/Fair Value (Rs. in Lakhs)", "% to Net Assets"],
+                [None, "Equity & Equity related", None, None, None, None, None],
+                ["KIMS01", "Krishna Institute Of Medical Sciences Limited", "INE967H01025", "Healthcare Services", 100000, 81523.0, 0.0271],
+                ["TORR01", "Torrent Pharmaceuticals Limited", "INE685A01028", "Pharmaceuticals & Biotechnology", 50000, 77981.0, 0.0259],
+                [None, "Sub Total", None, None, None, 159504.0, 0.0530],
+                [None, "Treps / Reverse Repo", None, None, None, 10000.0, 0.0050],
+            ]
+            pd.DataFrame(sc_data).to_excel(writer, sheet_name="AXISSCF", header=False, index=False)
+
+            # Axis Multi Asset sheet
+            ta_data = [
+                ["AXISTAF", "Axis Multi Asset Allocation Fund", None, None, None, None, None],
+                [None, None, None, None, None, None, None],
+                ["", "Monthly Portfolio Statement as on July 31, 2026", None, None, None, None, None],
+                [None, "Name of the Instrument", "ISIN", "Industry", "Quantity", "Market/Fair Value (Rs. in Lakhs)", "% to Net Assets"],
+                ["ICIC01", "ICICI Bank Limited", "INE090A01021", "Banks", 50000, 16246.0, 0.0650],
+                ["GOLD01", "Axis Gold ETF", "INF846K01347", "Gold ETF", 10000, 5000.0, 0.0200],
+            ]
+            pd.DataFrame(ta_data).to_excel(writer, sheet_name="AXISTAF", header=False, index=False)
+
+        output.seek(0)
+        content = output.getvalue()
+
+        importer = AxisImporter()
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = content
+        mock_http.get.return_value = mock_resp
+
+        source = (date(2026, 7, 31), "Monthly Portfolio-31 07 26", "Monthly_Portfolio_31072026.xlsx", "https://example.com/test.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        assert len(rows) >= 4
+        # Verify Small Cap holdings
+        sc_rows = [r for r in rows if r["scheme_code"] == "AXIS_SMALL_CAP"]
+        assert len(sc_rows) >= 2
+        kims = next(r for r in sc_rows if "Krishna" in r["security_name"])
+        assert kims["isin"] == "INE967H01025"
+        assert kims["market_value_cr"] == 815.23  # 81523 Lakhs / 100
+        assert kims["pct_of_nav"] == 2.71        # 0.0271 * 100
+        assert kims["asset_type"] == "equity"
+
+        # Verify Multi Asset holdings
+        ta_rows = [r for r in rows if r["scheme_code"] == "AXIS_MULTI_ASSET_ALLOCATION"]
+        assert len(ta_rows) >= 2
+        icici = next(r for r in ta_rows if "ICICI" in r["security_name"])
+        assert icici["market_value_cr"] == 162.46
+        assert icici["pct_of_nav"] == 6.50
+
+    def test_parse_mock_debt_format_excel(self):
+        output = io.BytesIO()
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            headers = [
+                "Scheme Code", "Scheme Name", "ISIN", "Security Name", "Security Type",
+                "Settled Quantity", "Total Market Value (Rs.)", "Market Value as % of Net Asset",
+                "Yield", "Residual Maturity", "Modified Duration", "Macaulay Duration",
+                "Average Maturity", "Rating / Industry", "Sector Classification",
+                "Coupon Rate", "Face Value", "ISIN Description", "Asset Class",
+                "Instrument Type", "Rating Agency", "Macro Economic Sector"
+            ]
+            row1 = [
+                "AXISTAA", "Axis Treasury Advantage Fund", "INE040A01034", "HDFC Bank Limited", "CD",
+                1000, 500000000.0, 0.05, 7.15, 90, 0.25, 0.25, 0.25, "CRISIL A1+", "Banks",
+                7.0, 100, "CD", "Money Market", "CD", "CRISIL", "Financial Services"
+            ]
+            pd.DataFrame([headers, row1]).to_excel(writer, sheet_name="Debt", header=False, index=False)
+
+        output.seek(0)
+        content = output.getvalue()
+
+        importer = AxisImporter()
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = content
+        mock_http.get.return_value = mock_resp
+
+        source = (date(2026, 7, 31), "Axis Treasury Advantage Fund", "AXISTAA.xlsx", "https://example.com/AXISTAA.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        assert len(rows) == 1
+        r = rows[0]
+        assert r["scheme_code"] == "AXIS_TREASURY_ADVANTAGE"
+        assert r["market_value_cr"] == 50.0  # 500,000,000 Rs / 10,000,000 = 50.0 Cr
+        assert r["pct_of_nav"] == 5.0        # 0.05 * 100 = 5.0%
+
+    def test_outlier_rejection(self):
+        output = io.BytesIO()
+        with pd.ExcelWriter(output, engine="openpyxl") as writer:
+            data = [
+                ["AXISSCF", "Axis Small Cap Fund", None, None, None, None, None],
+                [None, None, None, None, None, None, None],
+                ["", "Monthly Portfolio Statement as on July 31, 2026", None, None, None, None, None],
+                [None, "Name of the Instrument", "ISIN", "Industry", "Quantity", "Market/Fair Value (Rs. in Lakhs)", "% to Net Assets"],
+                ["ABC", "Normal Stock", "INE123A01010", "IT", 1000, 1000.0, 0.05],
+                ["XYZ", "Total Outlier Row", "INE999A01010", "Total", 9999, 999999.0, 1.50],  # 150% -> outlier
+            ]
+            pd.DataFrame(data).to_excel(writer, sheet_name="AXISSCF", header=False, index=False)
+
+        output.seek(0)
+        importer = AxisImporter()
+        mock_http = MagicMock()
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = output.getvalue()
+        mock_http.get.return_value = mock_resp
+
+        source = (date(2026, 7, 31), "Axis Small Cap Fund", "test.xlsx", "https://example.com/test.xlsx")
+        rows = importer.parse_source(source, mock_http)
+
+        assert len(rows) == 1
+        assert rows[0]["security_name"] == "Normal Stock"

--- a/tests/test_dsp_importer.py
+++ b/tests/test_dsp_importer.py
@@ -13,9 +13,9 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 import pytest
 
-from src.scripts.fund_imports.importers.dsp import DspImporter
-from src.scripts.fund_imports.factory import create_importer, REGISTRY
-from src.scripts.dsp.import_all_dsp_equity import ZIP_FILES, DSP_SCHEME_MAP
+from src.data_importer.amc_holdings.importers.dsp import DspImporter
+from src.data_importer.amc_holdings.factory import create_importer, REGISTRY
+from src.data_importer.dsp_holdings.import_all_dsp_equity import ZIP_FILES, DSP_SCHEME_MAP
 
 
 class TestDspImporterCatalogue:
@@ -49,7 +49,7 @@ class TestDspImporterParams:
         assert importer.table_name() == "market_data.mf_holdings"
         assert importer.watermark_source() == "mf_holdings"
 
-    @patch("src.scripts.fund_imports.importers.dsp.discover_latest_zip")
+    @patch("src.data_importer.amc_holdings.importers.dsp.discover_latest_zip")
     def test_fetch_sources_full_reimport(self, mock_discover):
         """Verify fetch_sources returns ZIP_FILES when full_reimport is True."""
         mock_discover.return_value = None
@@ -60,7 +60,7 @@ class TestDspImporterParams:
 
 
 class TestDspImporterParsing:
-    @patch("src.scripts.fund_imports.importers.dsp.process_month")
+    @patch("src.data_importer.amc_holdings.importers.dsp.process_month")
     def test_parse_source(self, mock_process_month):
         """Mock process_month and verify parse_source outputs correctly formatted rows."""
         mock_process_month.return_value = [

--- a/tests/test_fund_imports_integration.py
+++ b/tests/test_fund_imports_integration.py
@@ -91,7 +91,12 @@ class TestFactory:
 
     def test_registry_keys(self):
         from src.scripts.fund_imports.factory import REGISTRY
-        assert set(REGISTRY.keys()) == {"icici", "nippon", "icici-index", "dsp", "quant", "bajaj", "amfi", "kotak", "hdfc"}
+        expected = {
+            "icici", "nippon", "icici-index", "dsp", "quant", "bajaj", "amfi", "kotak", "hdfc",
+            "abakkus", "abacus", "helios", "invesco", "canara", "canara_robeco", "canara-robeco",
+            "mirae", "mirae_asset", "mirae-asset", "axis", "axis_mf", "axis-mf"
+        }
+        assert set(REGISTRY.keys()) == expected
 
     def test_nippon_from_year_stored(self):
         from src.scripts.fund_imports.factory import create_importer

--- a/tests/test_hdfc_importer.py
+++ b/tests/test_hdfc_importer.py
@@ -13,12 +13,12 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 import pytest
 
-from src.scripts.fund_imports.importers.hdfc import (
+from src.data_importer.amc_holdings.importers.hdfc import (
     HDFC_FUNDS,
     HdfcImporter,
     _COLUMNS,
 )
-from src.scripts.fund_imports.factory import create_importer, REGISTRY
+from src.data_importer.amc_holdings.factory import create_importer, REGISTRY
 
 
 class TestHdfcImporterCatalogue:

--- a/tests/test_kotak_importer.py
+++ b/tests/test_kotak_importer.py
@@ -13,12 +13,12 @@ from datetime import date
 from unittest.mock import MagicMock, patch
 import pytest
 
-from src.scripts.fund_imports.importers.kotak import (
+from src.data_importer.amc_holdings.importers.kotak import (
     KOTAK_FUNDS,
     KotakImporter,
     _COLUMNS,
 )
-from src.scripts.fund_imports.factory import create_importer, REGISTRY
+from src.data_importer.amc_holdings.factory import create_importer, REGISTRY
 
 
 class TestKotakImporterCatalogue:


### PR DESCRIPTION
### Summary
- Implemented `AxisImporter` in `src/data_importer/amc_holdings/importers/axis.py` with dynamic CMS token acquisition (`POST /cms/token`) and statutory disclosure discovery (`POST /cms/get-scheme-documents`).
- Supports multi-sheet consolidated monthly portfolio Excel workbooks covering 80+ schemes as well as single-scheme disclosures.
- Implemented robust date parser handling double URL encoding (`_2520`), space/underscore delimiters, and en-dashes.
- Auto-scales Market Value from Lakhs to Crores and decimal fraction percentage to percentage points.
- Registered `axis`, `axis_mf`, and `axis-mf` in `factory.py`, `amc_holdings_fetcher.py`, `cli.py`, `main.py`, and `audit_freshness.py`.
- Created CLI runners at `src/data_importer/axis_holdings/import_all_axis.py` and `src/scripts/axis/import_all_axis.py`.
- Ingested 8,519 rows across 86 active Axis Mutual Fund schemes for July 2026 into ClickHouse `market_data.mf_holdings`.
- Added unit test suite `tests/test_axis_importer.py` (8 tests passing, 94 AMC tests total).