### PR TITLE
fix: keep whale scan latest snapshots per fund

### DIFF
--- a/src/scripts/portfolio/whale_accumulation_scanner.py
+++ b/src/scripts/portfolio/whale_accumulation_scanner.py
@@ -308,36 +308,48 @@ def run_whale_scan(
 
     df_raw["as_of_month"] = pd.to_datetime(df_raw["as_of_month"])
 
-    # ── 3. Identify latest and comparison month (by calendar month) ──────────
-    # Different AMCs snapshot on different calendar days (1st, 15th, month-end),
-    # so comparing by *exact* as_of_month date starves the scan of cross-AMC
-    # breadth whenever one family's snapshot date happens to be globally latest
-    # (e.g. only BAJAJ_FINSERV_* funds report on the 15th while every other AMC
-    # reports on the 1st/month-end — the exact-date max used to resolve to a
-    # date where only one AMC group had any data at all).  Bucket to calendar
-    # month instead so every AMC's most recent snapshot in that month counts.
-    df_raw["report_month"] = df_raw["as_of_month"].values.astype("datetime64[M]")
-    all_report_months = sorted(df_raw["report_month"].unique())
-    latest_report_month = all_report_months[-1]
-    target_prev = pd.Timestamp(latest_report_month) - pd.DateOffset(months=lookback_months)
-    prev_report_month = min(all_report_months, key=lambda m: abs((pd.Timestamp(m) - target_prev).days))
+    # ── 3. Identify each fund's own latest & comparison snapshot ─────────────
+    # Different AMCs' importers stamp their monthly disclosure with different
+    # as_of_month conventions — some snapshot on the 1st/15th/month-end of a
+    # given month, others stamp the FOLLOWING month's 1st for what is really
+    # the prior month's month-end data. A single shared "latest calendar month"
+    # bucket (a prior version of this fix) only fixed same-month day drift —
+    # it still silently drops every AMC whose latest row happens to land in an
+    # earlier *calendar month* than another AMC's (observed live: HDFC/ICICI/
+    # KOTAK's latest row was dated the 1st of the next month while all 12 other
+    # AMCs' latest row was dated the last day of the prior month — one day
+    # apart in reality, but a different report_month bucket, so only
+    # HDFC/ICICI/KOTAK ever appeared in "latest" and no other AMC could ever
+    # reach num_amcs >= min_amcs). Resolve "latest" and "comparison"
+    # independently PER FUND instead, so every AMC's own most recent snapshot
+    # always counts regardless of how far ahead/behind another AMC's is.
+    def _latest_per_fund(df: pd.DataFrame) -> pd.DataFrame:
+        """Each fund's own most recent as_of_month — ALL securities from that
+        date (guards against rare double-imports/backfills landing on the same
+        date collapsing to a single row)."""
+        max_dates = df.groupby("fund_name")["as_of_month"].transform("max")
+        return df[df["as_of_month"] == max_dates].copy()
 
-    def _latest_per_fund(df: pd.DataFrame, report_month) -> pd.DataFrame:
-        """Within a calendar month, keep each fund's most recent snapshot DATE
-        (guards against rare double-imports/backfills landing in the same month) —
-        ALL securities from that date, not a single collapsed row. (A prior
-        `groupby(...).idxmax()` + `.loc[idx]` here silently kept only one
-        arbitrary security per fund per month, discarding the rest of that
-        fund's holdings from the scan entirely.)"""
-        sub = df[df["report_month"] == report_month]
-        max_dates = sub.groupby("fund_name")["as_of_month"].transform("max")
-        return sub[sub["as_of_month"] == max_dates].copy()
+    def _comparison_per_fund(df: pd.DataFrame, own_latest: "pd.Series") -> pd.DataFrame:
+        """For each fund, the snapshot closest to (that fund's own latest date
+        minus lookback_months) — independent of any other fund's timeline."""
+        parts = []
+        for fund_name, grp in df.groupby("fund_name"):
+            latest_date = own_latest.get(fund_name)
+            if latest_date is None:
+                continue
+            target = latest_date - pd.DateOffset(months=lookback_months)
+            dates = grp["as_of_month"].unique()
+            closest = min(dates, key=lambda d: abs((pd.Timestamp(d) - target).days))
+            parts.append(grp[grp["as_of_month"] == closest])
+        return pd.concat(parts) if parts else df.iloc[0:0].copy()
 
-    df_latest = _latest_per_fund(df_raw, latest_report_month)
-    df_prev   = _latest_per_fund(df_raw, prev_report_month)
+    df_latest = _latest_per_fund(df_raw)
+    fund_latest_dates = df_latest.groupby("fund_name")["as_of_month"].first()
+    df_prev = _comparison_per_fund(df_raw, fund_latest_dates)
 
-    latest_month = pd.Timestamp(latest_report_month)
-    prev_month   = pd.Timestamp(prev_report_month)
+    latest_month = df_latest["as_of_month"].max()
+    prev_month   = df_prev["as_of_month"].max()
 
     # ── 4. Aggregate per security_name × amc_group per month ─────────────────
     def _agg(df: pd.DataFrame) -> pd.DataFrame:

--- a/tests/test_whale_accumulation_scanner.py
+++ b/tests/test_whale_accumulation_scanner.py
@@ -150,6 +150,48 @@ class TestWhaleAccumulationScan(unittest.TestCase):
         self.assertIsInstance(reliance["opportunity_score"], float)
 
 
+class TestPerFundDateResolution(unittest.TestCase):
+    """
+    Regression coverage for a real bug found QA'ing against live ClickHouse
+    data: a shared calendar-month bucket (report_month) excluded every AMC
+    whose latest snapshot landed in an earlier calendar month than another
+    AMC's — even when the two dates were only a day apart (e.g. one AMC's
+    importer stamps the 1st of the next month for what is really the prior
+    month's month-end disclosure, while another AMC's importer stamps the
+    actual month-end date). run_whale_scan must resolve "latest" and
+    "comparison" independently per fund so this drift can't silently exclude
+    an AMC from the scan entirely.
+    """
+
+    @patch(f"{MODULE}.query_df", side_effect=lambda sql, *a, **k: (
+        pd.DataFrame() if "amfi_category_flows" in sql else pd.DataFrame(
+            [
+                # HDFC's importer stamps the 1st of the *next* month for
+                # July's month-end disclosure; KOTAK's importer stamps the
+                # actual month-end date. Same real-world disclosure cycle,
+                # different calendar-month bucket under naive bucketing.
+                ("HDFC_FLEXI_CAP",  "2026-08-01", "Reliance Industries Ltd.", 2.5, 130.0, RELIANCE_ISIN),
+                ("HDFC_FLEXI_CAP",  "2026-05-01", "Reliance Industries Ltd.", 2.0, 100.0, RELIANCE_ISIN),
+                ("KOTAK_FLEXI_CAP", "2026-07-31", "Reliance Industries Ltd.", 2.0, 90.0,  RELIANCE_ISIN),
+                ("KOTAK_FLEXI_CAP", "2026-04-30", "Reliance Industries Ltd.", 1.5, 60.0,  RELIANCE_ISIN),
+            ],
+            columns=["fund_name", "as_of_month", "security_name", "pct_of_nav", "market_value_cr", "isin"],
+        ).assign(asset_type="equity")
+    ))
+    @patch("yfinance.download")
+    def test_amcs_a_calendar_day_apart_still_both_count(self, mock_yf_download, mock_query_df):
+        results = run_whale_scan(amc="all", lookback_months=3, min_amcs=2)
+
+        self.assertNotIn("error", results)
+        acc_by_name = {r["security_name"]: r for r in results["top_accumulators"]}
+        self.assertIn("Reliance Industries Ltd.", acc_by_name)
+        reliance = acc_by_name["Reliance Industries Ltd."]
+        # Both HDFC (Aug-1-dated) and KOTAK (Jul-31-dated) must count, even
+        # though a naive calendar-month bucket would keep only HDFC's.
+        self.assertEqual(reliance["num_amcs"], 2)
+        self.assertEqual(set(reliance["amcs"]), {"HDFC", "KOTAK"})
+
+
 class TestAmcGroupingAndFilters(unittest.TestCase):
     """
     Direct unit coverage for the three pure helper functions that a stale,


### PR DESCRIPTION
QA follow-up: resolves the per-fund latest/comparison snapshot bug in whale accumulation scanning and adds regression coverage for the calendar-boundary case.