### PR TITLE
docs: sync fund NAV tool guidance + fix stale architecture docs; track INDIGRID

### DIFF
--- a/.agents/skills/mf-tracker/SKILL.md
+++ b/.agents/skills/mf-tracker/SKILL.md
@@ -306,6 +306,19 @@ python src/scripts/portfolio/fund_mom_returns.py --scheme <SCHEME_CODE>
 | **DSP Value** | `148595` | Value |
 | **DSP Healthcare** | `145454` | Pharma / Healthcare |
 
+### Any Fund by Name (not just DSP)
+
+Don't know the scheme code? Search by name first — works for any AMC/fund, not just the DSP table above:
+```bash
+python src/scripts/portfolio/fund_mom_returns.py --search "<fund name>"   # lists matching scheme codes (e.g. Direct vs Regular Plan), then pick one
+python src/scripts/portfolio/fund_mom_returns.py --scheme <CODE> --months <N>
+```
+Agent tool: `run_fund_mom_returns(scheme_code, search_query, months=12)` (`src/tools/runners.py`).
+
+**NAV is always fetched live from mfapi.in** — no ClickHouse import step exists or is needed for actively-managed AMC schemes (only a fixed ETF/index watchlist gets imported into `market_data.mf_nav`, see `MF_SCHEME_CODES` in `src/data_importer/registry.py`).
+
+**Expense ratio is NOT available** from this tool or anywhere else in the codebase — mfapi.in's scheme metadata only has `fund_house`/`scheme_type`/`scheme_category`/`scheme_code`/`scheme_name`/ISINs. Don't invent a number from training knowledge; say it's unavailable (see `docs/CLAUDE.md` grounding rules).
+
 ---
 
 ## 🔍 6. DSP Active-Fund Conviction Signal (Single-Name Research)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ python src/scripts/goldbees_report.py                              # Pre-baked G
 python src/scripts/portfolio/smallcap_pattern_analyzer.py --amc all  # Multi-AMC Small Cap accumulation & conviction analyzer
 python src/scripts/portfolio/run_stock_quant_workflow.py BAJFINANCE  # Stock ASCII chart, anomalies & MF holdings
 python src/scripts/portfolio/fund_mom_returns.py --scheme 152056   # MoM NAV returns
+python src/scripts/portfolio/fund_mom_returns.py --search "<name>"  # resolve scheme code by fund name (any AMC)
 
 python src/scripts/market/whale_tracker.py                         # All 7 multi-asset funds
 python src/scripts/dsp/import_all_dsp_equity.py                    # DSP holdings import
@@ -78,6 +79,11 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary single-nam
 
 ### 7. No Web Search Mandate
 - **NEVER use web search (`search_web` or web search tools)**. Rely strictly on local codebase, ClickHouse database, Python/SQL tools, and direct tool outputs.
+
+### 8. Fund NAV Lookup & Expense Ratio
+- For "what's fund X's scheme code / NAV returns" questions, use `src/scripts/portfolio/fund_mom_returns.py` directly: `--search "<name>"` resolves the AMFI scheme code (any AMC, not just DSP), `--scheme <CODE> --months N` computes MoM returns.
+- NAV is fetched **live** from mfapi.in every run — no ClickHouse import exists or is needed for actively-managed AMC schemes (only a fixed ETF/index watchlist is imported into `market_data.mf_nav`).
+- **Expense ratio is not available anywhere** — mfapi.in's scheme metadata has no such field, and nothing in this codebase tracks TER. Do not substitute a number from training knowledge (see Rule 1) — state it's unavailable.
 
 ---
 

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -262,6 +262,15 @@ SELECT ... FROM market_data.mf_holdings FINAL WHERE ...
 **Never use** `weight_pct` or `name` — those columns do not exist.
 Coverage: 62 DSP funds Sep 2023–Mar 2026; Top 10 funds back to Jun 2022.
 
+### Fund NAV Returns & Expense Ratio
+For "what's fund X's scheme code / NAV returns" questions, use
+`src/scripts/portfolio/fund_mom_returns.py` directly instead of re-discovering it:
+- `--search "<fund name>"` resolves the AMFI scheme code (works for any AMC, not just DSP)
+- `--scheme <CODE> --months N` computes MoM returns
+- NAV is fetched **live** from mfapi.in every run — no ClickHouse import exists or is needed for actively-managed AMC schemes (only a fixed ETF/index watchlist is imported into `market_data.mf_nav`)
+
+**Expense ratio is not available anywhere** — mfapi.in's scheme metadata has no such field, and nothing in this codebase (ClickHouse, importers, factsheet scrapers) tracks TER. Do not substitute a number from training knowledge (see Number Sources rule above) — state it's unavailable and offer to scrape an AMC factsheet/SID as a one-off if the user needs it.
+
 ### Token-Efficient Exploration
 When investigating a bug or exploring unfamiliar code, default to the narrowest
 query/read that answers the specific question, and push open-ended investigation
@@ -296,6 +305,6 @@ conclusion lands back in the main session — not the raw exploration output.
   - `fund_imports/` — Factory-pattern AMC importers; run via `python src/scripts/fund_imports/run.py <icici|nippon|icici-index|all> [--dry-run] [--test]`. `base.py` has the `BaseFundImporter` ABC; `importers/` has one class per AMC; `factory.py` has `create_importer(name)`.
   - `etf/` — ETF comparison, CAGR validation, risk analysis
   - `ml/` — ML prediction backfill and evaluation
-  - `portfolio/` — portfolio tracking, health checks, opportunity scan, parallel stock import (`import_stocks_parallel.py`)
-  - `market/` — macro themes, FII/DII, metals, sentiment, whale tracker
+  - `portfolio/` — portfolio tracking, health checks, opportunity scan, parallel stock import (`import_stocks_parallel.py`); cross-AMC whale accumulation scanner (`whale_accumulation_scanner.py` — consensus_score + optional RSI/drawdown/volume-surge technical confirmation); concentration risk/HHI, crowding & contrarian signal, fund overlap matrix, portfolio X-ray, rolling returns, SIP backtester
+  - `market/` — macro themes, FII/DII, metals, sentiment, per-fund whale/theme tracker (`whale_tracker.py`)
   - `db/` — ClickHouse backup, restore, sanity checks, and data quality repairs (`fix_bad_data.py`)

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -207,11 +207,11 @@ class _SubAgent:
 
 ### MFSubAgent
 
-- **Purpose:** Indian mutual-fund analysis — holdings, NAV returns, cross-fund consensus, whale tracking
-- **Tools (~12):** `run_multi_asset_holdings_mom_yoy`, `run_multi_asset_consensus`, `run_whale_tracker`, `run_dsp_multi_asset_comparison`, `run_fund_mom_returns`, `run_dsp_multi_asset_importer`, `run_nippon_importer`, `get_mf_holdings_for_stock`, `plot_fund_holdings_chart`, `plot_price_chart`, `query_clickhouse_db`, `publish_consolidated_pdf`
+- **Purpose:** Indian mutual-fund analysis — holdings, NAV returns, cross-fund consensus, whale tracking (both the per-fund theme tracker AND the full-universe cross-AMC accumulation scanner)
+- **Tools (~23):** `run_multi_asset_holdings_mom_yoy`, `run_multi_asset_consensus`, `run_whale_tracker`, `run_dsp_multi_asset_comparison`, `run_fund_mom_returns`, `run_dsp_multi_asset_importer`, `run_nippon_importer`, `run_icici_importer`, `run_all_multi_asset_importers`, `scan_whale_accumulation`, `get_whale_consensus`, `get_mf_holdings_for_stock`, `find_funds_holding`, `find_similar_funds`, `search_mf_exposure`, `plot_fund_holdings_chart`, `plot_price_chart`, `query_clickhouse_db`, `describe_db_table`, `list_db_tables`, `sample_db_table`, `search_db_metadata`, `get_stock_news`, `publish_consolidated_pdf`
 - **Recursion limit:** 30
-- **Routing keywords:** "mutual fund", "DSP multi asset", "cross-fund consensus", "which funds hold", "NAV return", "holding pattern"
-- **Fallback:** keyword-routed — `consensus/pattern` → `run_multi_asset_consensus`; `mom/yoy/changes` → `run_multi_asset_holdings_mom_yoy`; `which funds hold` → `get_mf_holdings_for_stock`; `whale/theme` → `run_whale_tracker`; `nav return` → `run_fund_mom_returns`
+- **Routing keywords:** "mutual fund", "DSP multi asset", "cross-fund consensus", "which funds hold", "NAV return", "holding pattern", "institutional accumulation", "which consensus buys are technically attractive"
+- **Fallback:** keyword-routed — `consensus/accumulation/institutions buying` → `scan_whale_accumulation` (checked before the theme branch below since both can match "whale"; `technical/rsi/breakout/oversold/drawdown` in the query sets `with_technicals=True`); `mom/yoy/changes` → `run_multi_asset_holdings_mom_yoy`; `which funds hold` → `get_mf_holdings_for_stock`; `whale/theme/thematic` → `run_whale_tracker`; `nav return` → `run_fund_mom_returns`
 
 ### NewsSubAgent
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -134,6 +134,16 @@ src/
     trend_predictor.py    LightGBM 5-day predictor + joblib model cache
     anomaly.py            Composite anomaly (MAD-Z + GARCH + Isolation Forest + PELT CPD + corp action suppression)
   models/                 Pydantic data schemas
+  scripts/                Standalone domain scripts — `python src/scripts/<subdir>/<name>.py`
+    dsp/                  DSP AMC import, analysis, backtests
+    fund_imports/         Factory-pattern AMC importers (BaseFundImporter ABC + per-AMC classes)
+    etf/                  ETF comparison, CAGR validation, risk analysis
+    ml/                   ML prediction backfill and evaluation
+    portfolio/            Portfolio tracking/health, concentration-HHI, crowding-contrarian, fund
+                          overlap matrix, portfolio X-ray, rolling returns, SIP backtester,
+                          cross-AMC whale accumulation scanner (+ optional technical confirmation)
+    market/               Macro themes, FII/DII, metals, sentiment, per-fund whale/theme tracker
+    db/                   ClickHouse backup, restore, sanity checks, data quality repairs
   tools/                  @tool wrappers + standalone signal functions
     skills_tools.py       General-purpose tools (query, import, iNAV, deep-dive) + SKILLS_TOOLS list
     runners.py            Thin shell-command runners (run_goldbees_pipeline, run_macro_scanner, …)
@@ -280,6 +290,8 @@ Most tools are standalone functions returning a dict/DataFrame — no DB writes,
 | **Get Corporate Actions** | `market/equity.py` | NSE corporate actions (splits/bonuses/demergers/rights/dividends) → upserts to `corporate_actions` table → history table |
 | **Chart Tools** | `chart_tools.py` | plotext terminal charts — price (🔴 GARCH anomaly markers + 🏦 corporate action markers, session-cached), signal scores, GARCH vol, MACD |
 | **Zerodha MCP Tools** | `zerodha_mcp_tools.py` | Holdings, positions, orders via Zerodha Kite MCP |
+| **Scan Whale Accumulation** | `whale_tools.py` | Cross-AMC consensus scan (`consensus_score = num_amcs × avg_delta_pp`), zero-to-hero fresh entries, optional RSI/drawdown/volume-surge technical confirmation + blended opportunity_score |
+| **Get Whale Consensus** | `whale_tools.py` | Single-stock lookup — which AMCs hold it, MoM delta, months-held conviction tenure |
 
 ### Quant Scorecard Pillars (`quant_scorecard.py`)
 
@@ -421,23 +433,24 @@ Adding a 7th pillar: subclass `SignalSource`, implement `collect(repo)`, append 
 
 Covers 18 core ETFs. Output optionally written to `signal_composite` table via `--save`.
 
-> **Planned 7th pillar — DSP Smart Money (pending):** MoM delta of DSP Multi Asset gold/equity allocation (`mf_holdings` table) as a contrarian tactical signal. Source: `scripts/dsp_quant_strategy_analyzer.py`. GSR correlation R=0.68 identified as primary driver of DSP allocation shifts.
+> **Planned 7th pillar — DSP Smart Money (pending):** MoM delta of DSP Multi Asset gold/equity allocation (`mf_holdings` table) as a contrarian tactical signal. Source: `src/scripts/dsp/dsp_quant_strategy_analyzer.py`. GSR correlation R=0.68 identified as primary driver of DSP allocation shifts.
 
 ---
 
-## Scripts (`scripts/`)
+## Scripts (`src/scripts/`)
 
-Standalone scripts that run analyses against the live database and print Rich console output.
+Standalone scripts that run analyses against the live database and print Rich console output, organised by domain under `src/scripts/<subdir>/`. Run from the project root: `python src/scripts/<subdir>/<name>.py` (moved out of a top-level `scripts/` dir, which now holds only cron/shell wrappers).
 
-| Script | Purpose |
-|---|---|
-| `metals_quant_scorecard.py` | Run Gold + Silver quant scorecards side-by-side |
-| `opportunity_scan.py` | Cross-asset DB scan — momentum, drawdown, RSI, iNAV, flows → ranked opportunity table |
-| `gold_quant_scorecard.py` | Gold-only 4-pillar scorecard (GOLDBEES) |
-| `fii_pattern_check.py` | FII historical buying/selling pattern analysis |
-| `import_dsp_history.py` | One-time ETL backfill: 31-month DSP Multi Asset holdings (Sep 2023–Mar 2026) from DSP website ZIPs into `mf_holdings`; writes watermark on completion |
-| `dsp_quant_strategy_analyzer.py` | Reverse-engineer DSP's trading rules by correlating monthly allocation deltas against Mosaic quant signals (DXY, COT, iNAV, GSR, ML). Identifies GSR as primary tactical lever (R=0.68). |
-| `whale_tracker.py` | Large FII/DII flow detection and alerts |
+| Subdir | Key scripts | Purpose |
+|---|---|---|
+| `market/` | `metals_quant_scorecard.py`, `gold_quant_scorecard.py`, `fii_pattern_check.py`, `whale_tracker.py`, `macro_theme_agent.py` | Gold+Silver / gold-only quant scorecards, FII historical pattern analysis, per-fund theme/archetype tracker (gold/silver/nuclear/infra + AMC archetype scorecard — NOT FII/DII flow), macro theme scanner |
+| `portfolio/` | `opportunity_scan.py`, `whale_accumulation_scanner.py`, `dsp_opportunity_scanner.py`, `smallcap_pattern_analyzer.py`, `multi_asset_consensus.py`, `concentration_risk.py`, `crowding_contrarian.py`, `fund_overlap_matrix.py`, `portfolio_xray.py`, `rolling_returns.py`, `sip_backtester.py` | Cross-asset opportunity scan; cross-AMC whale consensus scan (`consensus_score` + optional RSI/drawdown/volume-surge confirmation); DSP conviction+technical scanner; small/mid-cap cross-ownership; multi-asset smart-money overlap; HHI concentration; crowding/contrarian signal; fund overlap matrix; portfolio X-ray; rolling returns; SIP backtesting |
+| `dsp/` | `import_dsp_history.py`, `dsp_quant_strategy_analyzer.py`, `backtest_dsp_strategies.py` | One-time ETL backfill (31-month DSP Multi Asset holdings, Sep 2023–Mar 2026); reverse-engineers DSP's trading rules by correlating allocation deltas against Mosaic quant signals (GSR primary lever, R=0.68); strategy backtests |
+| `fund_imports/` | `run.py`, `factory.py`, `importers/*.py` | Factory-pattern AMC importers (`BaseFundImporter` ABC + one class per AMC) |
+| `etf/` | `validate_etf_cagr.py`, `yoy_etf_comparison.py`, `run_all_etf_risk.py` | ETF comparison, CAGR validation, risk analysis |
+| `db/` | `fix_bad_data.py` | ClickHouse backup, restore, sanity checks, data quality repairs |
+
+`goldbees_report.py` (pre-baked GOLDBEES signal, ~2s) lives directly under `src/scripts/`.
 
 ---
 

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -11,6 +11,7 @@ All data sources used by Mosaic Fund Agent are free unless noted.
 | Currency exchange rates (FX) | Yahoo Finance | Free, daily OHLC for USDINR, USDCNY, USDAED, USDSAR, USDKWD. Used in macro and anomaly models |
 | ETF iNAV — live | NSE API | Free, 15-second refresh (9:15 AM – 3:30 PM IST) |
 | ETF iNAV — historic / NAV | MFAPI.in (AMFI official) | Free |
+| MF scheme lookup by name / NAV MoM returns (any AMC) | MFAPI.in (AMFI official) | Free; use `src/scripts/portfolio/fund_mom_returns.py --search "<name>"` then `--scheme <code>`; fetched live, no ClickHouse import step exists for actively-managed schemes. **No expense ratio field** — not available from this source or tracked anywhere else in the codebase. |
 | COMEX spot prices | gold-api.com | Free with API key |
 | COMEX previous close | Yahoo Finance futures | Free |
 

--- a/docs/gemini-prompts.md
+++ b/docs/gemini-prompts.md
@@ -695,3 +695,24 @@ Step 3 — Answer these questions from the data:
   DSP_MULTI_ASSET the safer choice for long-term allocation analysis?
 - Recommended choice for a conservative multi-asset investor and why.
 ```
+
+### 25. Fund Lookup by Name — Resolve Scheme Code & Compute Returns
+
+For any fund (not just DSP/pre-known scheme codes) — resolve its AMFI scheme code by name, then compute NAV returns.
+
+```
+I don't know the scheme code for "Abakkus Small Cap Fund". Resolve it and compute returns:
+
+Step 1 — Search for matching scheme codes (may list both Direct and Regular Plan):
+  python src/scripts/portfolio/fund_mom_returns.py --search "Abakkus Small Cap Fund"
+
+Step 2 — Compute MoM returns for the Direct Plan-Growth code found above:
+  python src/scripts/portfolio/fund_mom_returns.py --scheme <CODE> --months 24
+
+Report: period return, best/worst month, average MoM return, positive vs negative month count.
+
+Note: NAV is fetched live from mfapi.in — no ClickHouse import is needed or possible for this
+fund (only a fixed ETF/index watchlist is imported into market_data.mf_nav). Expense ratio is
+NOT available from mfapi.in or anywhere else in this codebase — don't estimate it, state it's
+unavailable if asked.
+```

--- a/src/data_importer/registry.py
+++ b/src/data_importer/registry.py
@@ -79,6 +79,7 @@ STOCKS: list[tuple[str, str]] = [
     ("CHOLAFIN",    "CHOLAFIN.NS"),      # Cholamandalam Investment & Finance (Murugappa)
     ("ALKYLAMINE",  "ALKYLAMINE.NS"),    # Alkyl Amines Chemicals — specialty amines
     ("BECTORFOOD",  "BECTORFOOD.NS"),    # Mrs. Bectors Food Specialities Limited
+    ("INDIGRID",    "INDIGRID.NS"),      # IndiGrid Infrastructure Trust — InvIT, power transmission assets
 ]
 
 ETFS: list[tuple[str, str]] = [


### PR DESCRIPTION
## Summary
- Adds `fund_mom_returns.py --search`/`--scheme` guidance and the expense-ratio-unavailable caveat consistently across `docs/CLAUDE.md`, `AGENTS.md`, `docs/gemini-prompts.md`, `.agents/skills/mf-tracker/SKILL.md`, and `docs/data-sources.md`
- Fixes `docs/architecture.md`: Directory Map was missing `src/scripts/` entirely; the "## Scripts" section described a defunct root-level `scripts/` dir (real scripts moved to `src/scripts/<domain>/` a while ago) — rewritten to match reality, including the whale accumulation scanner and new portfolio tools
- Fixes `docs/agent-architecture.md`: MFSubAgent tool list said "~12 tools", was missing 11 real ones (incl. `scan_whale_accumulation`/`get_whale_consensus`)
- Adds `INDIGRID` (IndiGrid Infrastructure Trust) to the `STOCKS` registry for standard OHLCV import coverage

## Test plan
- [x] Docs-only + one registry-list addition — no runtime logic changed
- [x] Verified `INDIGRID` resolves via `src.data_importer.registry.STOCKS` (63 tracked symbols)