### PR TITLE
feat(importer): add NSE daily delivery-position fetcher

### DIFF
--- a/src/data_importer/cli.py
+++ b/src/data_importer/cli.py
@@ -135,7 +135,7 @@ def run_import(
         if c in {"stocks", "us_stocks", "etfs", "commodities", "indices",
                  "nse_indices", "nse_eod", "indian_macro", "fx_rates",
                  "cot", "cb_reserves", "etf_aum", "mf", "fii_dii",
-                 "world_bank", "imf_weo", "amfi_flows"}
+                 "world_bank", "imf_weo", "amfi_flows", "nse_delivery"}
     ]
     for category in registry_categories:
         fetcher = get_registry().get(category)

--- a/src/data_importer/clickhouse.py
+++ b/src/data_importer/clickhouse.py
@@ -217,6 +217,31 @@ PARTITION BY toYYYYMM(trade_date)
 ORDER BY (symbol, trade_date)
 """
 
+_DDL_NSE_DELIVERY = """
+CREATE TABLE IF NOT EXISTS market_data.nse_delivery (
+    trade_date    Date,
+    symbol        String,
+    series        LowCardinality(String) DEFAULT 'EQ',
+    prev_close    Float64,
+    open_price    Float64,
+    high_price    Float64,
+    low_price     Float64,
+    last_price    Float64,
+    close_price   Float64,
+    avg_price     Float64,
+    ttl_trd_qty   UInt64,
+    turnover_lacs Float64,
+    no_of_trades  UInt64,
+    deliv_qty     Nullable(UInt64),   -- NULL where NSE doesn't publish delivery (e.g. some debt series)
+    deliv_per     Nullable(Float64),  -- NULL, not 0 — distinguishes "not published" from "0% delivered"
+    source        LowCardinality(String) DEFAULT 'nse',
+    imported_at   DateTime DEFAULT now()
+)
+ENGINE = ReplacingMergeTree(imported_at)
+PARTITION BY toYYYYMM(trade_date)
+ORDER BY (symbol, trade_date, series)
+"""
+
 _DDL_INAV_SNAPSHOTS = """
 CREATE TABLE IF NOT EXISTS market_data.inav_snapshots (
     symbol                String,
@@ -763,7 +788,7 @@ class ClickHouseImporter:
         for ddl in (
             _DDL_DATABASE, _DDL_DAILY_PRICES, _DDL_MF_NAV, _DDL_WATERMARKS,
             _DDL_INAV_SNAPSHOTS, _DDL_COT_GOLD, _DDL_CB_GOLD_RESERVES, _DDL_ETF_AUM,
-            _DDL_FX_RATES, _DDL_ML_PREDICTIONS, _DDL_MF_HOLDINGS, _DDL_FII_DII_FLOWS,
+            _DDL_FX_RATES, _DDL_NSE_DELIVERY, _DDL_ML_PREDICTIONS, _DDL_MF_HOLDINGS, _DDL_FII_DII_FLOWS,
             _DDL_FII_DII_MONTHLY, _DDL_FII_DII_FNO_DAILY, _DDL_NEWS_ARTICLES,
             _DDL_SIGNAL_COMPOSITE, _DDL_WEIGHT_CHECKPOINTS, _DDL_PIPELINE_MANIFEST,
             _DDL_STOCK_EARNINGS, _DDL_STOCK_INSIDER, _DDL_STOCK_VALUATION,
@@ -1449,6 +1474,33 @@ class ClickHouseImporter:
         )
         from src.db.market_vector import vectorize_fx_rates
         vectorize_fx_rates(rows)
+        return len(rows)
+
+    # ── Bulk insert: nse_delivery ──────────────────────────────────────────
+
+    def insert_nse_delivery(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        dry_run: bool = False,
+    ) -> int:
+        """Insert NSE daily delivery-position rows. Returns row count."""
+        if not rows:
+            return 0
+        if dry_run:
+            return len(rows)
+        cols = [
+            "trade_date", "symbol", "series", "prev_close", "open_price",
+            "high_price", "low_price", "last_price", "close_price", "avg_price",
+            "ttl_trd_qty", "turnover_lacs", "no_of_trades", "deliv_qty",
+            "deliv_per", "source",
+        ]
+        self._client.insert(
+            "market_data.nse_delivery",
+            [[r.get(c) for c in cols] for r in rows],
+            column_names=cols,
+            settings={"max_partitions_per_insert_block": 300},
+        )
         return len(rows)
 
     # ── Bulk insert: fii_dii_flows ────────────────────────────────────────────

--- a/src/data_importer/fetchers/adapters.py
+++ b/src/data_importer/fetchers/adapters.py
@@ -405,6 +405,33 @@ class FIIDIIFetcher(Fetcher):
         return max(r["trade_date"] for r in rows)
 
 
+# ── NSE Delivery Position (bulk bhavcopy, all symbols) ───────────────────────
+
+class NseDeliveryFetcher(Fetcher):
+    """
+    Daily delivery quantity / % delivery-to-traded for every NSE-listed
+    security, from NSE's bulk bhavcopy (one file/day covers the whole market,
+    not a per-symbol fetch like STOCKS/ETFS).
+    """
+
+    source_name  = "nse_delivery"
+    symbol_key   = "MARKET"
+    description  = "NSE daily delivery position (all symbols, bhavcopy)"
+    overlap_days = 3
+    first_run_lookback_days = 1095  # 3 years — matches verified NSE archive depth
+
+    def fetch(self, from_date: date, to_date: date, *, source: str | None = None) -> list[dict[str, Any]]:
+        try:
+            from src.data_importer.fetchers.nse_delivery_fetcher import fetch_nse_delivery
+            return fetch_nse_delivery(from_date, to_date)
+        except Exception as exc:
+            log.warning("%s fetch failed: %s", self, exc)
+            return []
+
+    def insert(self, rows: list[dict], ch) -> int:
+        return ch.insert_nse_delivery(rows)
+
+
 # ── FX Rates (USD pairs via Yahoo Finance) ───────────────────────────────────
 
 class FXRatesFetcher(Fetcher):
@@ -826,6 +853,7 @@ def _build_registry() -> dict[str, Fetcher]:
     registry["mf"]      = MFNavFetcher(MF_SCHEME_CODES)
     registry["fii_dii"] = FIIDIIFetcher()
     registry["fx_rates"] = FXRatesFetcher()
+    registry["nse_delivery"] = NseDeliveryFetcher()
     registry["cot"]     = COTGoldFetcher()
     registry["cb_reserves"] = CbReservesFetcher()
     registry["etf_aum"]     = EtfAumFetcher()

--- a/src/data_importer/fetchers/nse_delivery_fetcher.py
+++ b/src/data_importer/fetchers/nse_delivery_fetcher.py
@@ -1,0 +1,150 @@
+"""
+src/data_importer/fetchers/nse_delivery_fetcher.py
+────────────────────────────────────────────────────
+Fetches NSE's daily "Security-wise Delivery Position" report — delivery
+quantity and % delivery-to-traded-quantity for every listed security — the
+standard Indian-market proxy for institutional-vs-speculative volume (intraday
+/ algo volume doesn't result in a delivery, so a high delivery % on a volume
+spike is the classic "quiet accumulation" signature).
+
+Endpoint (bulk daily bhavcopy, ALL symbols in one file):
+    https://archives.nseindia.com/products/content/sec_bhavdata_full_{DDMMYYYY}.csv
+
+Unlike www.nseindia.com's JSON APIs (see nse_corporate_actions_fetcher.py),
+archives.nseindia.com does NOT require session warming / HTTP2 / bot-detection
+headers — verified live: a plain httpx GET with a standard User-Agent returns
+200 with real CSV data.
+
+The file's own DATE1 column is the authoritative trade date — NOT the DDMMYYYY
+in the URL. On weekends/holidays NSE keeps serving the last trading day's file
+under the current date's URL rather than 404ing, so the URL date and DATE1 can
+diverge; duplicate (symbol, trade_date, series) rows across two URL attempts
+are harmless (ReplacingMergeTree dedupes on insert).
+
+Column quirks (verified live, 2026-08-16):
+    - Header/values have leading spaces (" SYMBOL", " DELIV_PER", ...) — must
+      strip.
+    - DELIV_QTY / DELIV_PER are "-" for some non-equity series (debt/G-Secs) —
+      parsed as None (SQL NULL), not 0, so "not published" is distinguishable
+      from "0% delivered".
+
+Output schema (for market_data.nse_delivery):
+    trade_date, symbol, series, prev_close, open_price, high_price, low_price,
+    last_price, close_price, avg_price, ttl_trd_qty, turnover_lacs,
+    no_of_trades, deliv_qty, deliv_per, source="nse"
+"""
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from io import StringIO
+from typing import Any
+
+import httpx
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_BHAVCOPY_URL = "https://archives.nseindia.com/products/content/sec_bhavdata_full_{ddmmyyyy}.csv"
+_HEADERS = {"User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"}
+_TIMEOUT = 20
+
+_INT_COLS = {"ttl_trd_qty": "TTL_TRD_QNTY", "no_of_trades": "NO_OF_TRADES"}
+_FLOAT_COLS = {
+    "prev_close":    "PREV_CLOSE",
+    "open_price":    "OPEN_PRICE",
+    "high_price":    "HIGH_PRICE",
+    "low_price":     "LOW_PRICE",
+    "last_price":    "LAST_PRICE",
+    "close_price":   "CLOSE_PRICE",
+    "avg_price":     "AVG_PRICE",
+    "turnover_lacs": "TURNOVER_LACS",
+}
+
+
+def _parse_nullable_number(value: str, cast) -> Any:
+    """NSE stamps '-' for delivery fields on series where it isn't published
+    (e.g. debt/G-Secs) — that must become NULL, not 0, so callers can tell
+    'not published' apart from a genuine 0% delivery day."""
+    text = str(value).strip()
+    if not text or text == "-":
+        return None
+    try:
+        return cast(text)
+    except ValueError:
+        return None
+
+
+def _fetch_one_day(client: httpx.Client, day: date) -> list[dict[str, Any]]:
+    url = _BHAVCOPY_URL.format(ddmmyyyy=day.strftime("%d%m%Y"))
+    try:
+        resp = client.get(url, timeout=_TIMEOUT)
+    except Exception as exc:
+        logger.debug("NSE bhavcopy request failed for %s: %s", day, exc)
+        return []
+
+    if resp.status_code != 200 or not resp.content:
+        logger.debug("NSE bhavcopy unavailable for %s (status=%s) — skipping", day, resp.status_code)
+        return []
+
+    try:
+        df = pd.read_csv(StringIO(resp.content.decode("utf-8", errors="replace")))
+    except Exception as exc:
+        logger.warning("NSE bhavcopy CSV parse failed for %s: %s", day, exc)
+        return []
+
+    df.columns = [c.strip() for c in df.columns]
+    if "SYMBOL" not in df.columns or "DATE1" not in df.columns:
+        logger.warning("NSE bhavcopy for %s missing expected columns: %s", day, list(df.columns))
+        return []
+
+    rows: list[dict[str, Any]] = []
+    for _, r in df.iterrows():
+        trade_date_str = str(r["DATE1"]).strip()
+        try:
+            trade_date = pd.to_datetime(trade_date_str, format="%d-%b-%Y").date()
+        except ValueError:
+            continue
+
+        row: dict[str, Any] = {
+            "trade_date": trade_date,
+            "symbol":     str(r["SYMBOL"]).strip(),
+            "series":     str(r.get("SERIES", "EQ")).strip() or "EQ",
+            "source":     "nse",
+        }
+        for out_key, csv_col in _FLOAT_COLS.items():
+            row[out_key] = _parse_nullable_number(r.get(csv_col, "-"), float) or 0.0
+        for out_key, csv_col in _INT_COLS.items():
+            row[out_key] = int(_parse_nullable_number(r.get(csv_col, "-"), float) or 0)
+        row["deliv_qty"] = _parse_nullable_number(r.get("DELIV_QTY", "-"), lambda v: int(float(v)))
+        row["deliv_per"] = _parse_nullable_number(r.get("DELIV_PER", "-"), float)
+        rows.append(row)
+
+    return rows
+
+
+def fetch_nse_delivery(from_date: date, to_date: date) -> list[dict[str, Any]]:
+    """
+    Fetch NSE's daily delivery-position bhavcopy for every calendar day in
+    [from_date, to_date] (inclusive). Weekends/holidays return no data for
+    that URL and are silently skipped — never raises.
+    """
+    rows: list[dict[str, Any]] = []
+    seen_dates: set[date] = set()
+
+    with httpx.Client(headers=_HEADERS, follow_redirects=True, timeout=_TIMEOUT) as client:
+        day = from_date
+        while day <= to_date:
+            day_rows = _fetch_one_day(client, day)
+            for r in day_rows:
+                if r["trade_date"] not in seen_dates:
+                    rows.append(r)
+            if day_rows:
+                seen_dates.add(day_rows[0]["trade_date"])
+            day += timedelta(days=1)
+
+    logger.info(
+        "NSE delivery: %d rows fetched across %d trading day(s) (%s→%s)",
+        len(rows), len(seen_dates), from_date, to_date,
+    )
+    return rows

--- a/tests/test_nse_delivery_fetcher.py
+++ b/tests/test_nse_delivery_fetcher.py
@@ -1,0 +1,69 @@
+"""
+tests/test_nse_delivery_fetcher.py
+───────────────────────────
+Unit tests for the NSE delivery-position (bhavcopy) fetcher.
+"""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+from src.data_importer.fetchers.nse_delivery_fetcher import fetch_nse_delivery
+
+_SAMPLE_CSV = (
+    "SYMBOL, SERIES, DATE1, PREV_CLOSE, OPEN_PRICE, HIGH_PRICE, LOW_PRICE, "
+    "LAST_PRICE, CLOSE_PRICE, AVG_PRICE, TTL_TRD_QNTY, TURNOVER_LACS, "
+    "NO_OF_TRADES, DELIV_QTY, DELIV_PER\n"
+    "20MICRONS, EQ, 14-Aug-2026, 189.07, 190.01, 190.99, 187.22, 188.00, "
+    "188.53, 188.70, 68386, 129.04, 1783, 36394, 53.22\n"
+    "3IINFOLTD, BE, 14-Aug-2026, 26.93, 26.80, 27.50, 25.59, 27.00, "
+    "26.95, 26.16, 734406, 192.11, 1547, -, -\n"
+)
+
+
+def _mock_response(status_code=200, content=_SAMPLE_CSV.encode("utf-8")):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.content = content
+    return resp
+
+
+class TestFetchNseDelivery:
+
+    @patch("httpx.Client.get")
+    def test_parses_csv_including_null_delivery(self, mock_get):
+        mock_get.return_value = _mock_response()
+
+        rows = fetch_nse_delivery(date(2026, 8, 14), date(2026, 8, 14))
+
+        assert len(rows) == 2
+        by_symbol = {r["symbol"]: r for r in rows}
+
+        eq_row = by_symbol["20MICRONS"]
+        assert eq_row["trade_date"] == date(2026, 8, 14)
+        assert eq_row["series"] == "EQ"
+        assert eq_row["deliv_qty"] == 36394
+        assert eq_row["deliv_per"] == 53.22
+        assert eq_row["source"] == "nse"
+
+        # "-" delivery fields must become None (SQL NULL), not 0 — distinguishes
+        # "NSE doesn't publish delivery for this series" from "0% delivered".
+        be_row = by_symbol["3IINFOLTD"]
+        assert be_row["deliv_qty"] is None
+        assert be_row["deliv_per"] is None
+
+    @patch("httpx.Client.get")
+    def test_skips_unavailable_days_without_raising(self, mock_get):
+        # Simulates a weekend/holiday where NSE has no file for that date.
+        mock_get.return_value = _mock_response(status_code=404, content=b"")
+
+        rows = fetch_nse_delivery(date(2026, 8, 15), date(2026, 8, 16))
+
+        assert rows == []
+
+    @patch("httpx.Client.get")
+    def test_get_raises_is_handled_gracefully(self, mock_get):
+        mock_get.side_effect = Exception("network down")
+
+        rows = fetch_nse_delivery(date(2026, 8, 14), date(2026, 8, 14))
+
+        assert rows == []


### PR DESCRIPTION
## Summary

Phase 1 of an ML institutional-accumulation-detection project (feasibility discussed separately) — adds NSE daily delivery-position data, the standard Indian-market proxy for institutional-vs-speculative volume (intraday/algo volume never results in a delivery, so a delivery-% spike alongside a volume spike is the classic "quiet accumulation" signature).

- New `market_data.nse_delivery` table, populated from NSE's daily bhavcopy CSV (`archives.nseindia.com/products/content/sec_bhavdata_full_*.csv`)
- `src/data_importer/fetchers/nse_delivery_fetcher.py`: no session-warming needed (verified live — unlike `www.nseindia.com`, the archives domain isn't behind the same bot detection); parses `DATE1` as the authoritative trade date, not the URL's date suffix (can be stale on weekends); maps `"-"` delivery sentinels to `NULL` (not 0) so "not published" (e.g. debt/G-Sec series) is distinguishable from "0% delivered"
- Registered as the `nse_delivery` import category (`NseDeliveryFetcher` adapter, market-level watermark, 3-year first-run lookback)
- Bulk/block deals were investigated but both endpoints returned 503 live — not included, flagged as a possible future follow-up
- Feature engineering, label construction, and model training are explicitly out of scope for this PR — deferred until enough backfilled history exists to validate against

## Test plan

- [x] `pytest tests/test_nse_delivery_fetcher.py -v` — 3 tests pass (CSV parsing incl. NULL-sentinel handling, weekend/holiday skip, network-failure handling)
- [x] Verified live against real NSE data: correct row counts, correct `DELIV_QTY`/`DELIV_PER` values, correct NULL handling for non-equity series
- [x] Verified insert path lands correctly in ClickHouse
- [x] Verified watermark/incremental-resume: a re-run with an existing watermark only re-fetches `watermark - overlap_days` forward, not the full history
- [x] Backfilled 1 month (68,984 rows, 21 trading days, 2026-07-17 → 2026-08-14) per user request; full 3-year backfill deferred to a later run