### PR TITLE
feat(qdrant): switch all Qdrant clients to gRPC transport

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -411,6 +411,9 @@ class Settings(BaseSettings):
     # [NON-SENSITIVE] Qdrant port (default 6333)
     qdrant_port: int = Field(default=6333, description="Qdrant port")
 
+    # [NON-SENSITIVE] Qdrant gRPC port (default 6334) — used when prefer_grpc=True
+    qdrant_grpc_port: int = Field(default=6334, description="Qdrant gRPC port")
+
     # ── Indian Market Constants ───────────────────────────────────────────────
 
     # [NON-SENSITIVE] Yahoo Finance suffix for NSE-listed stocks

--- a/src/data_importer/maintenance/audit_freshness.py
+++ b/src/data_importer/maintenance/audit_freshness.py
@@ -180,7 +180,8 @@ def audit_qdrant_freshness(console):
         import os
         host = os.environ.get("QDRANT_HOST", "localhost")
         port = int(os.environ.get("QDRANT_PORT", "6333"))
-        qc = QdrantClient(url=f"http://{host}:{port}", timeout=10)
+        grpc_port = int(os.environ.get("QDRANT_GRPC_PORT", "6334"))
+        qc = QdrantClient(host=host, port=port, grpc_port=grpc_port, prefer_grpc=True, timeout=10)
         # Quick connectivity check
         qc.get_collections()
     except Exception:

--- a/src/db/anomaly_vector.py
+++ b/src/db/anomaly_vector.py
@@ -82,7 +82,8 @@ def _get_client() -> Any:
 
             host = os.environ.get("QDRANT_HOST") or getattr(settings, "qdrant_host", "localhost")
             port = int(os.environ.get("QDRANT_PORT") or getattr(settings, "qdrant_port", 6333))
-            _client = QdrantClient(url=f"http://{host}:{port}", timeout=15.0)
+            grpc_port = int(os.environ.get("QDRANT_GRPC_PORT") or getattr(settings, "qdrant_grpc_port", 6334))
+            _client = QdrantClient(host=host, port=port, grpc_port=grpc_port, prefer_grpc=True, timeout=15.0)
             log.debug("AnomalyVector: Qdrant client at %s:%s", host, port)
         except Exception as e:
             log.debug("AnomalyVector: Qdrant init failed: %s", e)

--- a/src/db/db_metadata_rag.py
+++ b/src/db/db_metadata_rag.py
@@ -36,7 +36,8 @@ def get_qdrant_client() -> Optional[QdrantClient]:
             from config.settings import settings
             host = os.environ.get("QDRANT_HOST") or getattr(settings, "qdrant_host", "localhost")
             port = int(os.environ.get("QDRANT_PORT") or getattr(settings, "qdrant_port", 6333))
-            _qdrant_client = QdrantClient(url=f"http://{host}:{port}", timeout=10.0)
+            grpc_port = int(os.environ.get("QDRANT_GRPC_PORT") or getattr(settings, "qdrant_grpc_port", 6334))
+            _qdrant_client = QdrantClient(host=host, port=port, grpc_port=grpc_port, prefer_grpc=True, timeout=10.0)
         except Exception as e:
             log.debug("Failed to initialize QdrantClient for metadata: %s", e)
             _qdrant_client = None

--- a/src/db/market_vector.py
+++ b/src/db/market_vector.py
@@ -73,7 +73,8 @@ def _get_client() -> Any:
 
             host = os.environ.get("QDRANT_HOST") or getattr(settings, "qdrant_host", "localhost")
             port = int(os.environ.get("QDRANT_PORT") or getattr(settings, "qdrant_port", 6333))
-            _client = QdrantClient(url=f"http://{host}:{port}", timeout=15.0)
+            grpc_port = int(os.environ.get("QDRANT_GRPC_PORT") or getattr(settings, "qdrant_grpc_port", 6334))
+            _client = QdrantClient(host=host, port=port, grpc_port=grpc_port, prefer_grpc=True, timeout=15.0)
             log.debug("MarketVector: Qdrant client connected at %s:%s", host, port)
         except Exception as e:
             log.debug("MarketVector: Qdrant client init failed: %s", e)

--- a/src/db/mf_vector.py
+++ b/src/db/mf_vector.py
@@ -85,7 +85,8 @@ def _get_client() -> Any:
             from config.settings import settings
             host = os.environ.get("QDRANT_HOST") or getattr(settings, "qdrant_host", "localhost")
             port = int(os.environ.get("QDRANT_PORT") or getattr(settings, "qdrant_port", 6333))
-            _client = QdrantClient(url=f"http://{host}:{port}", timeout=15.0)
+            grpc_port = int(os.environ.get("QDRANT_GRPC_PORT") or getattr(settings, "qdrant_grpc_port", 6334))
+            _client = QdrantClient(host=host, port=port, grpc_port=grpc_port, prefer_grpc=True, timeout=15.0)
             log.debug("MFVector: Qdrant client at %s:%s", host, port)
         except Exception as e:
             log.debug("MFVector: Qdrant init failed: %s", e)

--- a/src/ml/correlation/news_rag.py
+++ b/src/ml/correlation/news_rag.py
@@ -53,7 +53,8 @@ def get_qdrant_client() -> Optional[QdrantClient]:
             from config.settings import settings
             host = os.environ.get("QDRANT_HOST") or getattr(settings, "qdrant_host", "localhost")
             port = int(os.environ.get("QDRANT_PORT") or getattr(settings, "qdrant_port", 6333))
-            _qdrant_client = QdrantClient(url=f"http://{host}:{port}", timeout=10.0)
+            grpc_port = int(os.environ.get("QDRANT_GRPC_PORT") or getattr(settings, "qdrant_grpc_port", 6334))
+            _qdrant_client = QdrantClient(host=host, port=port, grpc_port=grpc_port, prefer_grpc=True, timeout=10.0)
         except Exception as e:
             log.debug("Failed to initialize QdrantClient: %s", e)
             _qdrant_client = None


### PR DESCRIPTION
## Summary
- All 6 Qdrant client instantiations (`anomaly_vector`, `market_vector`, `mf_vector`, `db_metadata_rag`, `news_rag`, `audit_freshness`) now connect via gRPC (`prefer_grpc=True`) instead of HTTP REST.
- Adds `qdrant_grpc_port` setting (default `6334`), overridable via `QDRANT_GRPC_PORT` env var — mirrors the existing `QDRANT_HOST`/`QDRANT_PORT` pattern.
- No new dependencies: `grpcio` already ships with `qdrant-client`, and docker-compose already exposes `6334:6334` on the qdrant service.

## Why
gRPC's protobuf framing has lower overhead than JSON/HTTP for vector upserts and search, which is Qdrant's own recommended interface for performance-sensitive workloads.

## Test plan
- [x] `py_compile` on all 7 changed files
- [x] Live smoke test: `market_vector`'s client connected via gRPC to the running Qdrant instance and listed all 7 collections