### PR TITLE
feat(quant): dynamic regime weighting, GJR-GARCH asymmetry & news calendar chunking

### DIFF
--- a/src/agents/signal_aggregator.py
+++ b/src/agents/signal_aggregator.py
@@ -19,7 +19,7 @@ log = logging.getLogger(__name__)
 # SIGNAL_ETFS is now owned by signal_sources to avoid circular imports.
 from src.agents.signal_sources import SIGNAL_ETFS  # noqa: E402
 
-# ── Weights for each pillar ───────────────────────────────────────────────────
+# ── Weights for each pillar (Baseline) ────────────────────────────────────────
 
 WEIGHTS = {
     "macro":     0.20,
@@ -29,11 +29,43 @@ WEIGHTS = {
     "ml":        0.20,
     "anomaly":   0.10,
 }
-# Weights sum to 1.00.  Valuation, ML, and Anomaly are prioritised over Flow
-# because FII/DII net-flow is a single scalar applied uniformly to equity vs.
-# haven buckets — it currently adds zero cross-ETF ranking power when the
-# 5-day net is flat.  When per-ETF AUM flow data is added, Flow weight can
-# be revisited.
+
+# ── Dynamic Regime-Adaptive Weights (Bayesian Calibration) ────────────────────
+# In dislocation/breakout regimes, static mean-reverting valuation and short-term
+# ML models decay, while Macro and Anomaly/Precedent signals carry higher SNR.
+# In persistent trend regimes, ML directional momentum and institutional Flows lead.
+REGIME_WEIGHTS: dict[str, dict[str, float]] = {
+    "Volatile Breakout": {
+        "macro": 0.28, "anomaly": 0.18, "sentiment": 0.14, "valuation": 0.16, "ml": 0.14, "flow": 0.10,
+    },
+    "Panic": {
+        "macro": 0.30, "anomaly": 0.20, "sentiment": 0.15, "valuation": 0.15, "ml": 0.10, "flow": 0.10,
+    },
+    "Flash Crash (Contrarian BUY)": {
+        "macro": 0.25, "anomaly": 0.25, "valuation": 0.20, "sentiment": 0.10, "ml": 0.10, "flow": 0.10,
+    },
+    "🔀 Regime Shift (Change Point)": {
+        "macro": 0.25, "anomaly": 0.20, "sentiment": 0.15, "valuation": 0.15, "ml": 0.15, "flow": 0.10,
+    },
+    "Strong Trend (HODL)": {
+        "ml": 0.25, "macro": 0.20, "flow": 0.15, "sentiment": 0.15, "valuation": 0.15, "anomaly": 0.10,
+    },
+    "Normal": {
+        "valuation": 0.25, "ml": 0.20, "macro": 0.20, "sentiment": 0.15, "flow": 0.10, "anomaly": 0.10,
+    },
+}
+
+
+def _get_regime_weights(flag: str) -> dict[str, float]:
+    """Retrieve dynamically calibrated pillar weights based on the active market regime."""
+    if flag in REGIME_WEIGHTS:
+        return REGIME_WEIGHTS[flag]
+    flag_lower = flag.lower()
+    for key, weights_dict in REGIME_WEIGHTS.items():
+        if key.lower() in flag_lower:
+            return weights_dict
+    return WEIGHTS
+
 
 # ── Anomaly regime → numeric score ───────────────────────────────────────────
 # Regime labels from the GARCH+IF+PELT anomaly pipeline are mapped to 0-100
@@ -91,25 +123,22 @@ def _anomaly_to_score(flag: str) -> float:
     return 50.0  # unknown → neutral
 
 
-def _build_breakdown(scores: dict[str, float]) -> str:
+def _build_breakdown(scores: dict[str, float], active_weights: dict[str, float] | None = None) -> str:
     """
     Build a human-readable, auditable per-pillar breakdown.
 
     Each line shows the pillar, its effective weight, its raw 0–100 score,
     and its *weighted contribution* (score × weight).  The sum of contributions
     equals the composite score.
-
-    Example output:
-        Macro=75 ×0.20=+15.0 | Sent.=40 ×0.15=+6.0 | Val.=60 ×0.25=+15.0
-        Flow=55 ×0.10=+5.5 | ML=52 ×0.20=+10.4 | Anom.=70 ×0.10=+7.0
     """
+    w_map = active_weights if active_weights is not None else WEIGHTS
     parts = []
     for label, key in [
         ("Macro", "macro"), ("Sent.", "sentiment"), ("Val.", "valuation"),
         ("Flow", "flow"), ("ML", "ml"), ("Anom.", "anomaly"),
     ]:
         raw = scores[key]
-        w = WEIGHTS[key]
+        w = w_map[key]
         parts.append(f"{label}={raw:.0f} ×{w:.2f}={raw * w:+.1f}")
 
     # Split into two lines of 3 for readability
@@ -122,31 +151,31 @@ def _compute_composite(
 ) -> list[ETFSignal]:
     """Compute weighted composite score and action for each ETF.
 
-    All six pillars (including anomaly) are weighted numerically.
-    The anomaly regime label is converted to a 0–100 score via
-    ANOMALY_REGIME_SCORES and participates in the weighted sum.
-    Weights sum to 1.00 — no extra allocation hacks.
+    All six pillars (including anomaly) are weighted dynamically based
+    on the underlying regime. Weights sum to 1.00.
     """
     signals = []
     for etf in SIGNAL_ETFS:
-        m      = macro.get(etf, 50)
-        s      = sentiment.get(etf, 50)
-        v      = valuation.get(etf, 50)
-        f      = flow.get(etf, 50)
-        ml_s   = ml.get(etf, 50)
-        a_flag = anomaly.get(etf, "Normal")
+        m       = macro.get(etf, 50)
+        s       = sentiment.get(etf, 50)
+        v       = valuation.get(etf, 50)
+        f       = flow.get(etf, 50)
+        ml_s    = ml.get(etf, 50)
+        a_flag  = anomaly.get(etf, "Normal")
         a_score = _anomaly_to_score(a_flag)
+
+        # Dynamic regime weights
+        eff_weights = _get_regime_weights(a_flag)
 
         # Fully weighted composite — all 6 pillars, weights sum to 1.00
         composite = (
-            m       * WEIGHTS["macro"]
-            + s     * WEIGHTS["sentiment"]
-            + v     * WEIGHTS["valuation"]
-            + f     * WEIGHTS["flow"]
-            + ml_s  * WEIGHTS["ml"]
-            + a_score * WEIGHTS["anomaly"]
+            m       * eff_weights["macro"]
+            + s     * eff_weights["sentiment"]
+            + v     * eff_weights["valuation"]
+            + f     * eff_weights["flow"]
+            + ml_s  * eff_weights["ml"]
+            + a_score * eff_weights["anomaly"]
         )
-
 
         composite = round(composite, 1)
 
@@ -167,7 +196,7 @@ def _compute_composite(
             "macro": m, "sentiment": s, "valuation": v,
             "flow": f, "ml": ml_s, "anomaly": a_score,
         }
-        breakdown = _build_breakdown(pillar_scores)
+        breakdown = _build_breakdown(pillar_scores, active_weights=eff_weights)
 
         signals.append(ETFSignal(
             etf=etf,

--- a/src/agents/signal_aggregator.py
+++ b/src/agents/signal_aggregator.py
@@ -30,10 +30,12 @@ WEIGHTS = {
     "anomaly":   0.10,
 }
 
-# ── Dynamic Regime-Adaptive Weights (Bayesian Calibration) ────────────────────
+# ── Dynamic Regime-Adaptive Weights (static lookup, hand-tuned) ──────────────
 # In dislocation/breakout regimes, static mean-reverting valuation and short-term
 # ML models decay, while Macro and Anomaly/Precedent signals carry higher SNR.
 # In persistent trend regimes, ML directional momentum and institutional Flows lead.
+# NOTE: these weight sets are fixed constants, not Bayesian-updated — there is no
+# prior/posterior or calibration procedure here, just a per-regime lookup table.
 REGIME_WEIGHTS: dict[str, dict[str, float]] = {
     "Volatile Breakout": {
         "macro": 0.28, "anomaly": 0.18, "sentiment": 0.14, "valuation": 0.16, "ml": 0.14, "flow": 0.10,
@@ -57,7 +59,7 @@ REGIME_WEIGHTS: dict[str, dict[str, float]] = {
 
 
 def _get_regime_weights(flag: str) -> dict[str, float]:
-    """Retrieve dynamically calibrated pillar weights based on the active market regime."""
+    """Look up the fixed pillar weights for the active market regime label."""
     if flag in REGIME_WEIGHTS:
         return REGIME_WEIGHTS[flag]
     flag_lower = flag.lower()

--- a/src/data_importer/tool_fetchers/news_search.py
+++ b/src/data_importer/tool_fetchers/news_search.py
@@ -143,8 +143,9 @@ def fetch_news_for_symbol(symbol: str, company_name: str = "", target_date: str 
     Returns:
         List of NewsItem models.
     """
+    import math
     import pytz
-    from datetime import datetime
+    from datetime import datetime, timedelta
     from dateutil import parser as date_parser
 
     # Resolve target_dt
@@ -185,22 +186,53 @@ def fetch_news_for_symbol(symbol: str, company_name: str = "", target_date: str 
             for c in cached[: settings.news_articles_per_stock]
         ]
 
+    tz = pytz.timezone(settings.market_timezone or "Asia/Kolkata")
+    today_dt = datetime.now(tz).date()
+
     # Calculate dynamic lookback needed to cover the target date if provided
     lookback_days = settings.news_lookback_days
     if target_dt:
-        tz = pytz.timezone(settings.market_timezone or "Asia/Kolkata")
-        today_dt = datetime.now(tz).date()
         days_diff = (today_dt - target_dt).days
         lookback_days = max(settings.news_lookback_days, days_diff + 1)
 
-    client = _make_gnews_client(lookback_days)
     query = f"{company_name} NSE stock" if company_name else f"{symbol} NSE stock"
 
-    articles = _gnews_get_news(client, query)
+    # Multi-window chunking for lookbacks > 30 days to bypass single-feed 100-item caps
+    articles: list[dict] = []
+    seen_urls: set[str] = set()
 
-    # Fallback: bare symbol query if primary returned nothing
-    if not articles:
-        articles = _gnews_get_news(client, symbol)
+    if lookback_days <= 30:
+        client = _make_gnews_client(lookback_days)
+        raw_res = _gnews_get_news(client, query) or _gnews_get_news(client, symbol)
+        for a in (raw_res or []):
+            u = a.get("url") or a.get("link") or a.get("title", "")
+            if u not in seen_urls:
+                seen_urls.add(u)
+                articles.append(a)
+    else:
+        # Sliced calendar chunking (30-day non-overlapping windows)
+        num_chunks = min(math.ceil(lookback_days / 30), 6) # max 6 months
+        for chunk_idx in range(num_chunks):
+            end_chunk = today_dt - timedelta(days=chunk_idx * 30)
+            start_chunk = max(today_dt - timedelta(days=(chunk_idx + 1) * 30), today_dt - timedelta(days=lookback_days))
+            if start_chunk >= end_chunk:
+                break
+            
+            client = GNews(
+                language="en",
+                country="IN",
+                max_results=30,
+            )
+            client.start_date = (start_chunk.year, start_chunk.month, start_chunk.day)
+            client.end_date = (end_chunk.year, end_chunk.month, end_chunk.day)
+            
+            chunk_res = _gnews_get_news(client, query) or _gnews_get_news(client, symbol)
+            for a in (chunk_res or []):
+                u = a.get("url") or a.get("link") or a.get("title", "")
+                if u not in seen_urls:
+                    seen_urls.add(u)
+                    articles.append(a)
+            time.sleep(random.uniform(0.5, 1.2)) # polite inter-chunk delay
 
     filtered_items: list[NewsItem] = []
     all_items: list[NewsItem] = []

--- a/src/data_importer/tool_fetchers/news_search.py
+++ b/src/data_importer/tool_fetchers/news_search.py
@@ -87,14 +87,27 @@ except Exception:
 
 # ── GNews Client ─────────────────────────────────────────────────────────────
 
-def _make_gnews_client(lookback_days: int) -> GNews:
-    """Create a GNews client configured for Indian English financial news with a dynamic lookback."""
-    return GNews(
+def _make_gnews_client(
+    lookback_days: int | None = None,
+    start_date: tuple[int, int, int] | None = None,
+    end_date: tuple[int, int, int] | None = None,
+) -> GNews:
+    """Create a GNews client configured for Indian English financial news.
+
+    Pass either ``lookback_days`` (relative rolling period) or both
+    ``start_date``/``end_date`` (absolute calendar window) -- not both.
+    """
+    client = GNews(
         language="en",
         country="IN",
         max_results=min(settings.news_articles_per_stock * 3, 30),
-        period=f"{lookback_days}d",
     )
+    if start_date is not None and end_date is not None:
+        client.start_date = start_date
+        client.end_date = end_date
+    else:
+        client.period = f"{lookback_days}d"
+    return client
 
 
 # ── Sentiment heuristic ───────────────────────────────────────────────────────
@@ -218,14 +231,11 @@ def fetch_news_for_symbol(symbol: str, company_name: str = "", target_date: str 
             if start_chunk >= end_chunk:
                 break
             
-            client = GNews(
-                language="en",
-                country="IN",
-                max_results=30,
+            client = _make_gnews_client(
+                start_date=(start_chunk.year, start_chunk.month, start_chunk.day),
+                end_date=(end_chunk.year, end_chunk.month, end_chunk.day),
             )
-            client.start_date = (start_chunk.year, start_chunk.month, start_chunk.day)
-            client.end_date = (end_chunk.year, end_chunk.month, end_chunk.day)
-            
+
             chunk_res = _gnews_get_news(client, query) or _gnews_get_news(client, symbol)
             for a in (chunk_res or []):
                 u = a.get("url") or a.get("link") or a.get("title", "")

--- a/src/ml/anomaly/_garch.py
+++ b/src/ml/anomaly/_garch.py
@@ -43,8 +43,14 @@ def fit_garch_residuals(
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
-        am  = arch_model(returns, vol="Garch", p=1, q=1, dist="t", rescale=False)
-        res = am.fit(disp="off", show_warning=False)
+        try:
+            # GJR-GARCH(1,1,1) with Student-t innovations to capture asymmetric downside volatility leverage
+            am  = arch_model(returns, p=1, o=1, q=1, vol="Garch", dist="t", rescale=False)
+            res = am.fit(disp="off", show_warning=False)
+        except Exception:
+            # Fallback to standard symmetric GARCH(1,1)
+            am  = arch_model(returns, vol="Garch", p=1, q=1, dist="t", rescale=False)
+            res = am.fit(disp="off", show_warning=False)
 
     # arch returns vectors aligned to the *non-NaN* log_return rows (N-1 values)
     # We need to map them back to the full df index (N rows).


### PR DESCRIPTION
## 📌 Summary of Quantitative Upgrades

This PR implements optimizations across the signal aggregation, volatility modeling, and news ingestion subsystems:

### 1. 🧠 Dynamic Regime-Adaptive Weighting (`src/agents/signal_aggregator.py`)
- Replaced static pillar weights with a **static, hand-tuned per-regime lookup table** (`REGIME_WEIGHTS`) — this is a fixed weight matrix keyed by regime label, *not* a Bayesian-calibrated model (no priors/posteriors are computed):
  - **Volatile Breakout:** Macro 28%, Anomaly/Precedent 18%, Valuation 16%, ML 14%.
  - **Panic:** Macro 30%, Anomaly/Precedent 20%, Valuation 15%, ML 10% (more aggressive than Volatile Breakout, not identical to it).
  - **Strong Trend (HODL):** ML momentum 25%, Institutional Flows 15%.
  - **Normal / Mean-Reverting:** Balanced fundamental baseline (Valuation 25%, ML 20%, Macro 20%).
- `_build_breakdown` now prints each pillar's active regime weight and its weighted point contribution for auditability.

### 2. ⚡ Asymmetric GJR-GARCH(1,1,1) Volatility Modeling (`src/ml/anomaly/_garch.py`)
- Upgraded the GARCH residual fitting engine to **GJR-GARCH(1,1,1) with Student-t innovations** (`arch_model(..., p=1, o=1, q=1, dist="t")`):
  - Incorporates asymmetric downside leverage (o=1) to model structural volatility spikes during market drawdowns.
  - Accounts for fat-tailed kurtosis in commodity and equity price spikes, with automatic fallback to symmetric GARCH(1,1) on fit failure.

### 3. 📅 Multi-Window Calendar Slicing for News (`src/data_importer/tool_fetchers/news_search.py`)
- Implemented automatic 30-day sliced calendar chunking (`start_date`/`end_date`) for lookbacks >30 days (capped at 6 chunks / 180 days) to bypass Google News's single-feed item ceiling per query.

Note: Qdrant vector write-through caching for news articles (`_cache_articles_to_qdrant`, `embed_batch`/`upsert_to_qdrant`, nomic-embed-text 768-dim) already existed in `news_search.py`/`news_rag.py` prior to this PR and is unchanged here — it is not part of this PR's diff.

---
### 🧪 Verification
- `py_compile` clean on all changed files.
- GJR-GARCH weight sums verified to equal 1.00 for all 6 regimes.
- Manual read-through of chunking logic against the >30-day lookback path.