### PR TITLE
docs: fix staleness, close gaps, add mermaid diagrams across doc set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file is read automatically by Codex when working in this project.
 
+> Kept content-identical to [GEMINI.md](GEMINI.md) (read by Gemini CLI) except for this header — if you edit one, mirror the change in the other.
+
 ## Project Overview
 
 Mosaic is an agentic quantitative research, asset-allocation, and risk-management platform for Indian and global ETF/equity markets. It integrates walk-forward machine learning predictions (LightGBM), dynamic volatility scaling (GARCH), multi-pillar signal aggregation, and institutional flow (whale) tracking.
@@ -96,7 +98,7 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary single-nam
 ## ClickHouse Schema & Documentation References
 
 - **Database:** `market_data` (ReplacingMergeTree tables; always query with `FINAL`).
-- **Core Tables:** `daily_prices`, `mf_nav`, `mf_holdings`, `fii_dii_flows`, `fii_dii_monthly`, `cot_gold`, `cb_gold_reserves`, `etf_aum`, `inav_snapshots`, `fx_rates`, `ml_predictions`, `signal_composite`, `news_articles`, `import_watermarks`, `corporate_actions`, `amfi_category_flows`, `amfi_market_cap`.
+- **Core Tables:** `daily_prices`, `mf_nav`, `mf_holdings`, `fii_dii_flows`, `fii_dii_monthly`, `cot_gold`, `cb_gold_reserves`, `etf_aum`, `inav_snapshots`, `fx_rates`, `ml_predictions`, `signal_composite`, `news_articles`, `import_watermarks`, `corporate_actions`, `amfi_category_flows`, `bulk_block_deals` (37 tables total — full list in [docs/import-schema.md](docs/import-schema.md#clickhouse-schema)).
 - **Full Architecture & Details:**
   - System & Data Pipelines: [docs/architecture.md](docs/architecture.md)
   - Agent Orchestration & Playbooks: [docs/agent-architecture.md](docs/agent-architecture.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,20 +71,26 @@ Add to `requirements.txt` when submitting a PR that introduces graph nodes.
 
 ```
 src/
-  agents/         Standalone agent scripts (portfolio, comex, news, signals)
+  agents/         LangChain/LangGraph orchestrators, sub-agents, intent router
   analyzers/      Asset and portfolio analyzers
   clients/        Zerodha Kite MCP client
-  importer/       ClickHouse ETL pipeline
-  ml/             LightGBM forecaster, GARCH anomaly detection
+  data_importer/  ClickHouse ETL pipeline (git submodule; canonical path)
+  importer/       Compat shim — re-exports src.data_importer, do not add new code here
+  db/             MarketDataRepository, connection pool, Qdrant vector writers
+  events/         EventBus, DataImportedEvent, post-import observers
+  ml/             LightGBM forecaster (trend_predictor), composite anomaly pipeline (anomaly/), OU estimator
+  models/         Pydantic domain models (Holding, Portfolio, Sentiment)
   tools/          Standalone tool functions (iNAV, COMEX, risk governor, etc.)
+  workflows/      LangGraph StateGraph pipelines (fixed-structure, low-LLM-call alternative to sub-agents)
+  scripts/        Domain-organised analysis/backfill scripts (market/, portfolio/, dsp/, fund_imports/, etf/, db/)
   ui/             Streamlit data hub
-scripts/          One-off analysis, backfill, and Zerodha account backup scripts
+scripts/          Top-level cron/shell wrappers only — the Python scripts themselves live under src/scripts/
 tests/            Unit and integration tests
 docs/             Architecture, schema, and configuration docs
 config/           Pydantic settings
 ```
 
-When adding a LangGraph graph, place it in `src/agents/` alongside the script it replaces or augments.
+When adding a LangGraph ReAct sub-agent, place it in `src/agents/sub_agents/`; for a fixed-structure pipeline that doesn't need the ReAct tool-call loop, prefer a `StateGraph` workflow in `src/workflows/` instead (see [docs/agent-architecture.md](docs/agent-architecture.md#workflows-srcworkflows)) — it's cheaper and every node is guaranteed to run.
 
 ---
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -2,6 +2,8 @@
 
 This file is read automatically by Gemini CLI when working in this project.
 
+> Kept content-identical to [AGENTS.md](AGENTS.md) (read by Codex) except for this header — if you edit one, mirror the change in the other.
+
 ## Project Overview
 
 Mosaic is an agentic quantitative research, asset-allocation, and risk-management platform for Indian and global ETF/equity markets. It integrates walk-forward machine learning predictions (LightGBM), dynamic volatility scaling (GARCH), multi-pillar signal aggregation, and institutional flow (whale) tracking.
@@ -24,6 +26,7 @@ python src/scripts/goldbees_report.py                              # Pre-baked G
 python src/scripts/portfolio/smallcap_pattern_analyzer.py --amc all  # Multi-AMC Small Cap accumulation & conviction analyzer
 python src/scripts/portfolio/run_stock_quant_workflow.py BAJFINANCE  # Stock ASCII chart, anomalies & MF holdings
 python src/scripts/portfolio/fund_mom_returns.py --scheme 152056   # MoM NAV returns
+python src/scripts/portfolio/fund_mom_returns.py --search "<name>"  # resolve scheme code by fund name (any AMC)
 
 python src/scripts/market/whale_tracker.py                         # All 7 multi-asset funds
 python src/scripts/dsp/import_all_dsp_equity.py                    # DSP holdings import
@@ -38,7 +41,7 @@ python src/scripts/db/fix_bad_data.py                              # Deduplicati
 | Declarative | `src/agents/declarative/` | Configuration-driven YAML playbooks (`config/agents/*.yaml`) & runner |
 | Analyzers | `src/analyzers/` | `asset_analyzer` (per-holding), `portfolio_analyzer` (aggregate) |
 | Tools | `src/tools/` | Pure functions returning dict/DataFrame |
-| Importer | `src/importer/` | Delta-sync pipeline: fetchers → ClickHouse |
+| Importer | `src/data_importer/` | Delta-sync pipeline: fetchers → ClickHouse |
 | DB Pool | `src/db/pool.py` | Thread-safe `CHPool` singleton (`get_pool()`) |
 | ML | `src/ml/` | LightGBM 5-day forecast (`trend_predictor`), composite anomaly (`anomaly.py`) |
 | Repository | `src/db/repository.py` | `MarketDataRepository`: typed reads, watermarks |
@@ -79,10 +82,15 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary single-nam
 ### 7. No Web Search Mandate
 - **NEVER use web search (`search_web` or web search tools)**. Rely strictly on local codebase, ClickHouse database, Python/SQL tools, and direct tool outputs.
 
-### 8. Always Use Color in Console
+### 8. Fund NAV Lookup & Expense Ratio
+- For "what's fund X's scheme code / NAV returns" questions, use `src/scripts/portfolio/fund_mom_returns.py` directly: `--search "<name>"` resolves the AMFI scheme code (any AMC, not just DSP), `--scheme <CODE> --months N` computes MoM returns.
+- NAV is fetched **live** from mfapi.in every run — no ClickHouse import exists or is needed for actively-managed AMC schemes (only a fixed ETF/index watchlist is imported into `market_data.mf_nav`).
+- **Expense ratio is not available anywhere** — mfapi.in's scheme metadata has no such field, and nothing in this codebase tracks TER. Do not substitute a number from training knowledge (see Rule 1) — state it's unavailable.
+
+### 9. Always Use Color in Console
 - ALWAYS use rich colors, ANSI escape sequences, or Rich library console styling in terminal outputs and scripts (e.g., green for gains/freshness, red for losses/anomalies, cyan/bold for headers, yellow for warnings). Ensure console reports are visually distinct and easy to read.
 
-### 9. Always Use Charts Where Possible
+### 10. Always Use Charts Where Possible
 - Whenever analyzing technical patterns, stock/ETF moves, price/volume trends, moving average setups, or anomaly regimes, ALWAYS include terminal ASCII/Unicode charts (via plotext/rich) and Mermaid diagrams alongside data tables for maximum visual clarity.
 
 ---
@@ -90,7 +98,7 @@ DSP active-fund holdings in `market_data.mf_holdings` are the primary single-nam
 ## ClickHouse Schema & Documentation References
 
 - **Database:** `market_data` (ReplacingMergeTree tables; always query with `FINAL`).
-- **Core Tables:** `daily_prices`, `mf_nav`, `mf_holdings`, `fii_dii_flows`, `fii_dii_monthly`, `cot_gold`, `cb_gold_reserves`, `etf_aum`, `inav_snapshots`, `fx_rates`, `ml_predictions`, `signal_composite`, `news_articles`, `import_watermarks`, `corporate_actions`, `amfi_category_flows`, `amfi_market_cap`.
+- **Core Tables:** `daily_prices`, `mf_nav`, `mf_holdings`, `fii_dii_flows`, `fii_dii_monthly`, `cot_gold`, `cb_gold_reserves`, `etf_aum`, `inav_snapshots`, `fx_rates`, `ml_predictions`, `signal_composite`, `news_articles`, `import_watermarks`, `corporate_actions`, `amfi_category_flows`, `bulk_block_deals` (37 tables total — full list in [docs/import-schema.md](docs/import-schema.md#clickhouse-schema)).
 - **Full Architecture & Details:**
   - System & Data Pipelines: [docs/architecture.md](docs/architecture.md)
   - Agent Orchestration & Playbooks: [docs/agent-architecture.md](docs/agent-architecture.md)

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Price: 56,595   Volume: 45,231 (baseline ~1,050)
 📰 Trump says US-Iran ceasefire is "over" after fresh strikes — Reuters
 ```
 
+> Every `mosaic ...` command shown in this README is shorthand for the real invocation — see **[Quick Start](#quick-start)** below. There's no globally-installed `mosaic` binary; run `python src/main.py <command>` (native) or `./mosaic.sh <command>` / `mosaic.bat <command>` (Docker) instead.
+
 ---
 
 ## Who is this for?
@@ -87,6 +89,8 @@ Price: 56,595   Volume: 45,231 (baseline ~1,050)
 ---
 
 ## Ask it anything
+
+> Substitute `python src/main.py` (native) or `./mosaic.sh` (Docker) for `mosaic` below.
 
 ```bash
 mosaic ask "Is this a good time to add to SILVERBEES?"
@@ -148,6 +152,8 @@ Use the zero-dependency Docker CLI wrapper:
 ./mosaic.sh signals --save                           # calculate today's ETF signals
 ./mosaic.sh ask "What is the macro picture for gold today?"
 ```
+
+> **Just want the UI + Data Hub running?** Run `./mosaic.sh` with **no arguments** — it builds/starts ClickHouse, Qdrant, the UI (Data Hub, `:8501`), and the Reports file server (`:8502`) in one shot, then drops you into an interactive chat REPL. This is equivalent to `./run.sh` / `run.bat` but also opens chat immediately.
 
 ---
 
@@ -227,6 +233,8 @@ All market data ingestion, ClickHouse storage, GARCH volatility scaling, LightGB
 ---
 
 ## Daily workflow
+
+> Commands below are the bare `python src/main.py` sub-command name (e.g. `signals` = `python src/main.py signals`, or `./mosaic.sh signals` in Docker).
 
 | What you want | Command |
 |---|---|

--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -88,14 +88,14 @@ CLI (src/main.py)
 
 | Layer | Path | Role |
 |-------|------|------|
-| CLI | `src/main.py` | 13 Typer commands; entry point |
+| CLI | `src/main.py` | 30 Typer commands; entry point |
 | Agents | `src/agents/` | LangChain/LangGraph orchestrators |
 | Signal Sources | `src/agents/signal_sources.py` | Strategy pattern: `SignalSource` ABC + 5 pillar classes + `GARCHAnomalySource`; `SIGNAL_ETFS` list |
 | Analyzers | `src/analyzers/` | `asset_analyzer` (per-holding), `portfolio_analyzer` (aggregate) |
 | Tools | `src/tools/` | Pure functions returning dict/DataFrame; composable in agents or scripts |
 | Importer | `src/data_importer/` | Delta-sync pipeline: Fetcher adapters → ClickHouse |
 | Fetcher ABC | `src/data_importer/base_fetcher.py` | Adapter interface: `fetch()`, `validate()`, `insert()`, `max_date()` |
-| Fetcher Adapters | `src/data_importer/fetchers/adapters.py` | 5 concrete adapters + `FETCHER_REGISTRY` keyed by CLI category |
+| Fetcher Adapters | `src/data_importer/fetchers/adapters.py` | 18 concrete adapters + `FETCHER_REGISTRY` keyed by CLI category |
 | Repository | `src/db/repository.py` | `MarketDataRepository`: typed reads, watermarks, `run_fetcher()` loop, event publish. Point-in-time variants: `ml_prediction_asof(date)`, `signal_composite_asof(symbol, date)` |
 | DB Pool | `src/db/pool.py` | Thread-safe `CHPool` singleton (`get_pool()`); all service modules share pooled connections |
 | Events | `src/events/` | `EventBus` singleton, `DataImportedEvent`, `Observer` ABC, 4 post-import hooks |
@@ -124,15 +124,15 @@ New pattern (Adapter + Repository):
       → EventBus.publish(DataImportedEvent)  ← triggers post-import hooks
 ```
 
-**14 fetchers:** `yfinance`, `mfapi`, `cot` (CFTC Socrata), `nse_inav`, `fii_dii`, `imf_reserves`, `etf_aum`, `mf_holdings` (Morningstar), `fx_rates`, `nse_quote`, `yahoo_snapshot`, `expert_tweets`, `nse_corporate_actions` (NSE equity corporate actions — splits, bonuses, demergers, rights, dividends), plus news tools.
+**15 fetchers:** `yfinance`, `mfapi`, `cot` (CFTC Socrata), `nse_inav`, `fii_dii`, `imf_reserves`, `etf_aum`, `mf_holdings` (Morningstar), `fx_rates`, `nse_quote`, `yahoo_snapshot`, `expert_tweets`, `nse_corporate_actions` (NSE equity corporate actions — splits, bonuses, demergers, rights, dividends), `nse_bulk_block` (NSE Bulk & Block Deals — large institutional/promoter transactions), plus news tools.
 
-**Fetcher adapters** (Adapter pattern, `src/data_importer/fetchers/adapters.py`): All general categories (`etfs`, `stocks`, `fii_dii`, `fx_rates`, `cot`, `cb_reserves`, `etf_aum`, `world_bank`, `imf_weo`, `amfi_flows`, `mf`, etc.) subclass `Fetcher` and map in `FETCHER_REGISTRY`. Orchestrator loop picks up new sources automatically.
+**Fetcher adapters** (Adapter pattern, `src/data_importer/fetchers/adapters.py`): All general categories (`etfs`, `stocks`, `fii_dii`, `fx_rates`, `cot`, `cb_reserves`, `etf_aum`, `world_bank`, `imf_weo`, `amfi_flows`, `mf`, `bulk_deals`/`events`, etc.) subclass `Fetcher` and map in `FETCHER_REGISTRY`. Orchestrator loop picks up new sources automatically.
 
 ### LLM Configuration
 `LLM_PROVIDER` (`openai` or `anthropic`) + `LLM_MODEL` control which model is used. Set `LLM_BASE_URL` to an OpenAI-compatible endpoint (Ollama, LM Studio) for local inference — no API key needed in that case.
 
 ### ClickHouse Schema
-Database: `market_data`. Tables are auto-created on first import (DDL in `src/data_importer/clickhouse.py`). Primary tables: `daily_prices` (OHLCV), `mf_nav`, `fii_dii_flows`, `ml_predictions`, `signal_composite`, `inav_snapshots`, `import_watermarks`, `macro_indicators` (World Bank / IMF WEO annual data), `corporate_actions` (NSE split/bonus/demerger/rights/dividend history — keyed by `(symbol, ex_date, action_type)`). All use `ReplacingMergeTree` — idempotent inserts are safe.
+Database: `market_data`. Tables are auto-created on first import (DDL in `src/data_importer/clickhouse.py`). Primary tables: `daily_prices` (OHLCV), `mf_nav`, `fii_dii_flows`, `ml_predictions`, `signal_composite`, `inav_snapshots`, `import_watermarks`, `macro_indicators` (World Bank / IMF WEO annual data), `corporate_actions` (NSE split/bonus/demerger/rights/dividend history — keyed by `(symbol, ex_date, action_type)`), `bulk_block_deals` (NSE bulk & block deal transactions). All use `ReplacingMergeTree` — idempotent inserts are safe.
 
 ### Qdrant Vector DB
 Database: `Qdrant` (served on port `6333` with built-in dashboard at `/dashboard`). Six collections (all 768-dim nomic-embed-text, COSINE distance). **Full reference incl. diagram, embedding pipeline, two-pass news retrieval, and read tools: [rag-architecture.md](rag-architecture.md).**
@@ -291,7 +291,7 @@ conclusion lands back in the main session — not the raw exploration output.
 - **Caching:** NewsAPI/COMEX responses cached to `output/.cache/` with 1-hour TTL. ML models cached to `output/.cache/ml_models/` keyed by `(max_trade_date, n_rows, n_splits, horizon)` — auto-invalidated by `ModelCacheInvalidator` when new price data arrives.
 - **Output files:** Reports written to `./output/` as JSON.
 - **Repository pattern:** `MarketDataRepository` (`src/db/repository.py`) is the single access point for all ClickHouse reads. Use `repo.fii_dii_5d()`, `repo.ohlcv()`, `repo.latest_ml_prediction()`, `repo.ml_prediction_asof(date)`, `repo.signal_composite_asof(symbol, date)` etc. — never write raw SQL in signal/ML code. The `*_asof(date)` variants are point-in-time queries used for historical anomaly context.
-- **Anomaly pipeline:** `run_composite_anomaly` (`src/ml/anomaly.py`) — 5-step composite: (1) MAD robust Z-score, (2) GARCH(1,1) standardised residuals, (3) Isolation Forest confidence multiplier, (4) PELT change-point detection (`ruptures`, rbf cost on log-returns), (5) Company Event classification. Corporate action suppression: pass `df_corp_actions`; for ETFs (`category="etfs"`) split/bonus/demerger ex-dates are excluded from `df_flagged`; for stocks/commodities they remain in `df_flagged` (labelled `🏢 Price Driven by Company Event`) since corporate events on stocks are real analysable price movements. COT loaded only for gold; FX (USDINR) loaded for all. Falls back to naive `max(2.0, 2.5×std)` if <60 rows or `arch`/`ruptures` missing. Pass `symbol=` and `category=` to auto-store flagged anomalies in Qdrant `market_anomalies` collection.
+- **Anomaly pipeline:** `run_composite_anomaly` (`src/ml/anomaly/` — a package, not a single file; re-exported from `__init__.py` for backward compatibility) — 6-strategy composite: (1) MAD robust Z-score, (2) GARCH(1,1) standardised residuals, (3) Isolation Forest confidence multiplier, (4) PELT change-point detection (`ruptures`, rbf cost on log-returns), (5) Volume GMM institutional-block detection (`p_institutional`, despite the class name `VolumeHMMStrategy`), (6) Company Event classification. Corporate action suppression: pass `df_corp_actions`; for ETFs (`category="etfs"`) split/bonus/demerger ex-dates are excluded from `df_flagged`; for stocks/commodities they remain in `df_flagged` (labelled `🏢 Price Driven by Company Event`) since corporate events on stocks are real analysable price movements. COT loaded only for gold; FX (USDINR) loaded for all. Falls back to naive `max(2.0, 2.5×std)` if <60 rows or `arch`/`ruptures` missing. Pass `symbol=` and `category=` to auto-store flagged anomalies in Qdrant `market_anomalies` collection.
 - **Anomaly explanation tools:**
   - `explain_price_anomalies` (`src/tools/market/gold.py`, re-exported via `skills_tools.py`) — full GARCH report + per-date news correlation; gold/commodity-specific (loads COT + FX).
   - `search_anomaly_events(symbol, days, category)` (`src/tools/market/equity.py`) — equity-generic: detects same red-dot dates as chart, suppresses corp actions, runs **parallel** Google News searches per date (ThreadPoolExecutor, 5 workers); ±1 day fallback + NewsAPI for recent dates.

--- a/docs/agent-architecture.md
+++ b/docs/agent-architecture.md
@@ -117,6 +117,15 @@ The router classifies free-form user questions into one of 10 intents, which map
 - LRU cache: 256 entries keyed by question hash — repeat questions are free
 - `clear_intent_cache()` provided for testing
 
+### RAG Router (semantic fallback, before regex)
+
+- **File:** `src/agents/intent_router.py` → `route_intent_rag()`, called from `_regex_fallback()` before it drops to legacy regex
+- Two-stage semantic match over `GOLDEN_PAIRS` (`src/agents/golden_pairs.py`, ~75 curated `(question, intent)` examples):
+  1. **Embedding similarity** — local Ollama embeddings; returns the matched intent if cosine score ≥ 0.82
+  2. **TF-IDF fallback** (`SimpleTFIDF`, pure Python, no Ollama dependency) — returns the matched intent if similarity ≥ 0.50
+  3. Returns `None` if neither threshold is met → falls through to the regex router
+- Purpose: catches phrasing the LLM router's cache missed and the regex router's fixed patterns don't cover, without spending an extra LLM call
+
 ### Regex Router (fallback)
 
 - **File:** `src/agents/sub_agents/routing.py` → `_regex_route_intent()` / `route_intent()`
@@ -238,7 +247,7 @@ class _SubAgent:
 ### AutonomousResearchAgent (`research`)
 
 - **Purpose:** Multi-domain, self-directed 10-layer research framework: entity resolution → price/momentum → fundamentals → institutional footprint → macro → news intelligence → volatility/signals → correlation/ML → visualisation → synthesis
-- **Tools (~30):** Union of Yahoo Finance, Indian equity, skills, macro, news, intl ETF, code execution, chart, and `AGENT_TOOLS` (delegation tools: `delegate_to_signal_agent`, `delegate_to_macro_agent`, `delegate_to_intl_etf_agent`, `delegate_to_news_agent`, `delegate_to_india_equity_agent`, `check_and_refresh_symbol_data`)
+- **Tools (~30):** Union of Yahoo Finance, Indian equity, skills, macro, news, intl ETF, code execution, chart, and `AGENT_TOOLS` (delegation tools: `delegate_to_signal_agent`, `delegate_to_macro_agent`, `delegate_to_intl_etf_agent`, `delegate_to_news_agent`, `delegate_to_india_equity_agent`, `delegate_to_mf_agent`, `check_and_refresh_symbol_data`)
 - **Recursion limit:** 50
 - **Delegation:** Can hand off to specialised sub-agents for GOLDBEES ML, COMEX commodities, intl ETF deep dives, multi-source news sweeps, or full equity research notes
 
@@ -273,6 +282,8 @@ only for synthesis and adversarial verification.
 | `run_macro(question)` | `macro.py` | build_plan → **[approval]** → fetch (all sources parallel) → synthesise | 1 | ~3,500 |
 | `run_news(question)` | `news.py` | resolve → build_plan → **[approval]** → fetch (3 parallel) → aggregate (+ optional synth) | 0–1 | ~1,500 |
 | `run_mf_planner(question)` | `mf_planner.py` | **plan** (LLM) → **[approval]** → executor ↺ replanner loop | 2–4 | ~6,000–12,000 |
+
+Also in `src/workflows/`: `consolidated_mf_report.py` (`build_consolidated_report()`) — a plain function-based PDF report builder (allocation matrix + shift charts + Qdrant news context for the DSP/Quant/ICICI/Bajaj multi-asset watchlist). It isn't a StateGraph pipeline, so it doesn't fit the node/LLM-call columns above — invoked directly by the `report` CLI command.
 
 ### Shared infrastructure (`base.py`)
 

--- a/docs/anomaly-detection.md
+++ b/docs/anomaly-detection.md
@@ -1,12 +1,12 @@
 # Anomaly Detection — How It Works
 
-The **🔬 Anomaly Detection** tab runs a five-step composite pipeline on any symbol in ClickHouse: robust MAD-Z → GARCH(1,1) volatility normalization → Isolation Forest → PELT change-point detection → Company Event classification.
+The **🔬 Anomaly Detection** tab runs a six-strategy composite pipeline (`src/ml/anomaly/` — a package, not a single file) on any symbol in ClickHouse: robust MAD-Z → GARCH(1,1) volatility normalization → Isolation Forest → PELT change-point detection → Volume GMM (institutional-block detection) → Company Event classification. Cross-asset features (COT gold positioning, USDINR) are injected before the strategies run when available.
 
 Detected anomalies are automatically written to **Qdrant** (`market_anomalies` collection) for semantic memory and historical precedent retrieval. A separate **Correlation Engine** attributes each flagged date to external causal events (macro shocks, FX moves, insider activity) using three pluggable strategies.
 
 ## Architectural Pipeline & Data Flow
 
-The following data flow diagram illustrates how raw market inputs flow through the 5-step anomaly detection pipeline, map to a volatility/trend regime, feed the Correlation Engine and Qdrant memory layer, integrate into the multi-pillar Signal Composite, and finally determine position sizing in the Risk Governor:
+The following data flow diagram illustrates how raw market inputs flow through the anomaly detection pipeline, map to a volatility/trend regime, feed the Correlation Engine and Qdrant memory layer, integrate into the multi-pillar Signal Composite, and finally determine position sizing in the Risk Governor:
 
 ```mermaid
 graph TD
@@ -191,13 +191,20 @@ $$Z_{final} \leftarrow Z_{final} \times \text{cp\_boost} \quad (\text{default } 
 
 and its regime is relabelled **🔀 Regime Shift (Change Point)**. The Final-Z threshold still gates which dates are flagged; CPD only sharpens confidence and labelling.
 
-## Step 5 — Company Event Classification (mechanical shock identification)
+## Step 5 — Volume GMM (institutional block detection)
+
+A 2-component Gaussian Mixture Model is fit on `log(volume)` over the symbol's full history (no rolling window) to separate two latent trading regimes: normal retail/market-maker flow vs. institutional block-deal activity (crossed bulk/block deals, large MF portfolio additions, FII rebalancing). Despite the class name `VolumeHMMStrategy` (`src/ml/anomaly/_pipeline.py`), this is a GMM, not a true HMM — there is no temporal state-transition matrix, only a per-day posterior probability.
+
+- Output column: `p_institutional` (0–1). Values > 0.70 indicate volume more consistent with the institutional cluster than normal trading.
+- A day is flagged **📊 Volume Anomaly (Institutional Block)** when `p_institutional > 0.70` AND `|z_volume| > 5.0` AND the price move is *not* already flagged by the Final-Z gate — i.e. it catches silent block deals that move volume but not price, which the other five strategies (all price-based) cannot see.
+
+## Step 6 — Company Event Classification (mechanical shock identification)
 
 Price jumps on the ex-dates of stock splits, bonus issues, demergers, and rights issues are mechanical adjustments rather than informational market shocks. The suppression logic is **category-aware** — ETF corporate actions are admin events with no signal, while stock corporate actions are real analysable price events.
 
 1. The fetcher [nse_corporate_actions_fetcher.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/data_importer/fetchers/nse_corporate_actions_fetcher.py) scrapes corporate events from the NSE website.
 2. The ex-dates are matched against the price history.
-3. Ex-dates matching price-impacting types (`split`, `bonus`, `demerger`, `rights`, `face_value_split`) are labelled `is_corporate_action=True` and `suppress_corp_action=True` in [anomaly.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/ml/anomaly.py).
+3. Ex-dates matching price-impacting types (`split`, `bonus`, `demerger`, `rights`, `face_value_split`) are labelled `is_corporate_action=True` and `suppress_corp_action=True` in [`_pipeline.py`](file:///Users/dhiraj.thakur/project/ofin-agent/src/ml/anomaly/_pipeline.py) (`src/ml/anomaly/` is a package — not the single `anomaly.py` file this used to be).
 4. **ETFs only** (`category="etfs"`): suppressed rows are excluded from `df_flagged` — their regime is `🏢 Price Driven by Company Event` but they do not trigger anomaly alerts or Qdrant storage. ETF corporate actions (NAV resets, bonus units) carry no market-signal content.
 5. **Stocks, commodities, indices**: suppressed rows ARE included in `df_flagged` and stored in Qdrant — the corporate action is a real price event (merger, demerger, split) worth analysis. The regime label `🏢 Price Driven by Company Event` is still applied so callers can filter if needed.
 6. On the price chart, ex-dates are overlayed as gold `🏢` markers regardless of category.
@@ -489,7 +496,7 @@ _, df_flagged, _ = run_composite_anomaly(df, z_threshold=2.0,
 
 ## Anomaly Explanation Tool (`explain_price_anomalies`)
 
-The agent's anomaly explanation capability (implemented in [gold.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/tools/market/gold.py) and re-exported via [skills_tools.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/tools/skills_tools.py)) is built on top of [run_composite_anomaly](file:///Users/dhiraj.thakur/project/ofin-agent/src/ml/anomaly.py#L464). It bridges the ML detection layer with news/event correlation and forward model context.
+The agent's anomaly explanation capability (implemented in [gold.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/tools/market/gold.py) and re-exported via [skills_tools.py](file:///Users/dhiraj.thakur/project/ofin-agent/src/tools/skills_tools.py)) is built on top of [run_composite_anomaly](file:///Users/dhiraj.thakur/project/ofin-agent/src/ml/anomaly/_pipeline.py) (re-exported from the `src.ml.anomaly` package `__init__.py` for backward compatibility — `from src.ml.anomaly import run_composite_anomaly` still works unchanged). It bridges the ML detection layer with news/event correlation and forward model context.
 
 ### Additional Anomaly & Corporate Action Tools
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,205 @@ See [§ Design Patterns](#design-patterns) at the end for the full reference (co
 
 ---
 
+## System at a Glance
+
+One diagram covering the whole system — CLI entry points, the multi-agent orchestrator, the import pipeline, and the ClickHouse/Qdrant/SQLite storage layer — color-coded by the design pattern each box implements (Repository, Adapter, Observer, Strategy, external source, memory hierarchy). Kept in sync with [architecture.mmd](architecture.mmd).
+
+```mermaid
+flowchart TD
+    User(["👤 User"])
+
+    %% ── CLI ────────────────────────────────────────────────────────────
+    subgraph CLI ["CLI — src/main.py (Typer — 30 commands)"]
+        CLIImport["import --category …"]
+        CLISignals["signals [--save]"]
+        CLIAnalyze["analyze / ask"]
+        CLIMacro["macro / comex / etf-news"]
+        CLIResearch["research / portfolio-wf"]
+        CLIUI["ui  →  localhost:8501"]
+    end
+
+    %% ── Routing & Multi-Agent Orchestrator ────────────────────────
+    subgraph Orchestrator ["Multi-Agent Orchestrator & Workflows"]
+        Router["Intent Router\nsrc/agents/intent_router.py\nLLM classifier + regex fallback"]
+
+        subgraph SubAgents ["LangGraph ReAct Sub-Agents\nsrc/agents/sub_agents/"]
+            SA1["DeepDive · IndianEquity · Signal"]
+            SA2["Macro · MF · News · Code · Database"]
+            SA3["IntlETF · AutonomousResearch"]
+        end
+
+        subgraph Workflows ["StateGraph Workflows (8)\nsrc/workflows/ — 55–81% token savings"]
+            WF1["Signal · Macro · News\nparallel fetch + approval"]
+            WF2["MF Planner\nPlan-Execute-Replan"]
+            WF3["Research · Equity · Consensus · Portfolio\nfixed-structure graphs"]
+        end
+
+        subgraph WorkflowInfra ["Workflow Infrastructure"]
+            CM["ContextManager\ncontext_manager.py — DatasetRef & truncation"]
+            PS["PlanStore\nplan_store.py — SQLite + Jaccard search"]
+            MS["MosaicState\nstate.py — shared TypedDict"]
+        end
+    end
+
+    %% ── Agentic Memory System ────────────────────────────────────────────
+    subgraph Memory ["Agentic Memory & Harness System"]
+        L1["Level 1: Global User Mandate\nNo LLM math · Zero-Trust · QIP check · DSP signal"]
+        L2["Level 2: Context Files\nAGENTS.md · GEMINI.md · docs/CLAUDE.md"]
+        L3["Level 3: Subagent Defs\n.agents/agents/ (21 defs)"]
+        L4["Level 4: Skills & Commands\n.agents/skills/ (21) · .claude/commands/ (5)"]
+        L5["Level 5: Caveman Compression\n.claude/skills/caveman* (60–70% token cut)"]
+        L1 --> L2 --> L3 --> L4 --> L5
+    end
+
+    %% ── Import pipeline (Adapter + Repository + Observer) ──────────────────────
+    subgraph ImportPipeline ["Import Pipeline — Adapter + Repository + Observer"]
+        subgraph Adapters ["Fetcher Adapters  src/data_importer/fetchers/"]
+            FA1["YFinanceFetcher\nstocks · etfs · commodities · indices"]
+            FA2["MFNavFetcher\nMFAPI.in NAV"]
+            FA3["FIIDIIFetcher\nSensibull cash + F&O + monthly"]
+            FA4["FXRatesFetcher\nUSDINR · USDCNY · USDAED …"]
+            FA5["COTGoldFetcher & AMC Importers\nCFTC COT · DSP · Nippon · ICICI"]
+        end
+
+        Repo["MarketDataRepository\nsrc/db/repository.py\nrun_fetcher() — watermark → fetch → insert → event"]
+
+        subgraph EventBus ["EventBus  src/events/bus.py"]
+            EV["DataImportedEvent\nsource · category · n_rows · to_date"]
+        end
+
+        subgraph Observers ["Post-Import Observers  src/events/observers.py"]
+            OBS1["ModelCacheInvalidator\n🔴 sync — deletes stale .joblib"]
+            OBS2["MLPredictionObserver\n🟡 async — re-runs LightGBM"]
+            OBS3["SignalAggregatorObserver\n🟡 async — refreshes composite scores"]
+            OBS4["SanityCheckObserver\n🟡 async — anomaly validation"]
+        end
+    end
+
+    %% ── ClickHouse & Qdrant Data Layer ────────────────────────────────────
+    subgraph DataLayer ["Storage Layer — ClickHouse + Qdrant + SQLite"]
+        subgraph CH ["ClickHouse — market_data (37 tables)"]
+            T1[("daily_prices · mf_nav\nfx_rates · etf_aum")]
+            T2[("fii_dii_flows · cot_gold\ncb_gold_reserves · amfi_category_flows")]
+            T3[("ml_predictions\nsignal_composite")]
+            T4[("inav_snapshots · news_articles\ncorporate_actions")]
+            T5[("import_watermarks · agent_traces")]
+        end
+
+        subgraph Qdrant ["Qdrant Vector DB (6 collections — 768d COSINE)"]
+            Q1[("news_articles\n(tenant: symbol[])")]
+            Q2[("market_anomalies\n(tenant: symbol)")]
+            Q3[("mf_holdings · mf_fund_profiles\n(tenant: isin / fund_name)")]
+            Q4[("clickhouse_metadata · market_data")]
+        end
+
+        subgraph SQLiteDB ["SQLite Stores"]
+            SQ1[("LLM Cache\nllm_cache.db — 24h TTL")]
+            SQ2[("Plan Store & Checkpoints\nplans/index.db · checkpoints.db")]
+        end
+    end
+
+    %% ── Signal pipeline (Repository + Strategy) ────────────────────────
+    subgraph SignalPipeline ["Signal Pipeline — Repository + Strategy"]
+        RepoRead["MarketDataRepository\ntyped reads: fii_dii_5d() · ohlcv()\nml_prediction_asof() · signal_composite_asof()"]
+
+        subgraph Sources ["SignalSource strategies  src/agents/signal_sources.py"]
+            direction LR
+            SS1["MacroSignalSource\n25% — GNews themes"]
+            SS2["SentimentSignalSource\n15% — news_articles"]
+            SS3["ValuationSignalSource\n15% — iNAV Z-score"]
+            SS4["FlowSignalSource\n25% — FII/DII 5D net"]
+            SS5["MLSignalSource\n15% — ml_predictions"]
+            SS6["GARCHAnomalySource\n5% — GARCH + IF"]
+        end
+
+        Aggregator["SignalAggregator\nsrc/agents/signal_aggregator.py\n6 sources × ThreadPoolExecutor\n→ composite 0–100 + BUY/HOLD/SELL\n79 s → 9 s after parallelisation"]
+    end
+
+    %% ── ML pipeline ──────────────────────────────────────────────────
+    subgraph MLPipeline ["ML Pipeline  src/ml/"]
+        TP["TrendPredictor\ntrend_predictor.py\nLightGBM walk-forward CV\nDXY + US10Y fetched in parallel"]
+        ModelCache[("Model cache\noutput/.cache/ml_models/\n*.joblib — auto-invalidated")]
+        AD["AnomalyDetector\nanomaly.py\n6-step: MAD-Z + GARCH(1,1) + IF\n+ PELT + CorpActions + Volume HMM"]
+    end
+
+    %% ── Streamlit UI ───────────────────────────────────────────────
+    UI["Streamlit UI\nsrc/ui/app.py\nExplorer · Anomaly · Signals\nHoldings · Kite · Deep Dive"]
+
+    %% ── External sources ───────────────────────────────────────────────
+    subgraph Ext ["External Data Sources"]
+        E1[("Yahoo Finance\n.NS / futures / DXY / ^TNX")]
+        E2[("NSE API + MFAPI.in\niNAV · NAV")]
+        E3[("Sensibull oxide API\nFII/DII cash + F&O")]
+        E4[("CFTC Socrata + ZIP\nCOT gold weekly")]
+        E5[("GNews RSS & NewsAPI\nmacro themes · news")]
+        E6[("Zerodha Kite MCP\nportfolio + orders")]
+        E7[("OpenAI / Anthropic / Local Ollama\nLLM scoring")]
+    end
+
+    %% ── Flows ──────────────────────────────────────────────────────
+    User --> CLI
+    CLIAnalyze & CLIResearch --> Router
+    Router --> SubAgents & Workflows
+    Workflows --> CM & PS & MS
+    SubAgents & Workflows --> RepoRead
+
+    CLIImport --> Adapters
+    FA1 & FA2 & FA3 & FA4 & FA5 --> Repo
+    Repo --> T5
+    Repo --> T1 & T2
+    Repo --> EV
+    EV -->|sync| OBS1
+    EV -->|async| OBS2 & OBS3 & OBS4
+
+    CLISignals --> RepoRead
+    RepoRead --> SS1 & SS2 & SS3 & SS4 & SS5 & SS6
+    SS1 & SS2 & SS3 & SS4 & SS5 & SS6 --> Aggregator
+    Aggregator --> T3
+
+    OBS2 --> TP
+    OBS3 --> Aggregator
+    TP <--> ModelCache
+    TP --> T3
+    AD --> T3 & Q2
+
+    CLIUI --> UI
+    UI --> T1 & T2 & T3 & T4 & Q1 & Q3
+
+    CLIMacro --> E5
+
+    FA1 -.-> E1
+    FA2 -.-> E2
+    FA3 -.-> E3
+    FA4 -.-> E1
+    FA5 -.-> E4
+    SubAgents -.-> E7
+    Workflows -.-> E7
+    SS1 -.-> E5
+    TP -.-> E1
+    PS --> SQ2
+    CM -.-> SQ1
+
+    %% ── Styles ───────────────────────────────────────────────────
+    classDef repo fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f
+    classDef adapter fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef observer fill:#fef9c3,stroke:#ca8a04,color:#713f12
+    classDef storage fill:#f3e8ff,stroke:#9333ea,color:#3b0764
+    classDef strategy fill:#ffedd5,stroke:#ea580c,color:#7c2d12
+    classDef ext fill:#f1f5f9,stroke:#94a3b8,color:#334155
+    classDef memory fill:#fee2e2,stroke:#ef4444,color:#7f1d1d
+
+    class Repo,RepoRead repo
+    class FA1,FA2,FA3,FA4,FA5 adapter
+    class OBS1,OBS2,OBS3,OBS4 observer
+    class T1,T2,T3,T4,T5,ModelCache,Q1,Q2,Q3,Q4,SQ1,SQ2 storage
+    class SS1,SS2,SS3,SS4,SS5,SS6 strategy
+    class E1,E2,E3,E4,E5,E6,E7 ext
+    class L1,L2,L3,L4,L5 memory
+```
+
+---
+
 ## High-Level Data Flow
 
 ```
@@ -51,7 +250,7 @@ External Data Sources
         └──▶  SanityCheckObserver     (async) → anomaly validation
         │
         ▼
-  ClickHouse  (market_data database — 27 tables)
+  ClickHouse  (market_data database — 37 tables)
         │
         ├──▶  MarketDataRepository reads  ← typed queries, consistent FINAL
         ├──▶  Signal Sources  (src/agents/signal_sources.py)  ← Strategy pattern
@@ -213,47 +412,63 @@ For `stocks` and `us_stocks` categories, the import manager redirects standard s
 
 ## ClickHouse Tables
 
-Database: `market_data`. All tables use `ReplacingMergeTree` for idempotent re-imports.
+Database: `market_data`, 37 tables, all `ReplacingMergeTree` for idempotent re-imports. Grouped by domain:
 
-| Table | Key Columns | Purpose |
+```mermaid
+flowchart TB
+    Prices["📈 Prices & Live Data (5)\ndaily_prices · nse_delivery · inav_snapshots\nlive_quotes · live_alerts"]
+    MF["🏦 Mutual Funds (4)\nmf_nav · mf_holdings\nmf_holding_summaries · amfi_category_flows"]
+    Flows["💰 Institutional Flows & Corp Actions (5)\nfii_dii_flows · fii_dii_monthly · fii_dii_fno_daily\nbulk_block_deals · corporate_actions"]
+    Macro["🌍 Macro & Commodities (6)\ncot_gold · cb_gold_reserves · etf_aum · fx_rates\nmacro_indicators · indian_macro_indicators"]
+    MLRisk["🤖 ML, Signals & Risk (3)\nml_predictions · signal_composite · weight_checkpoints"]
+    USStocks["🇺🇸 US Stock Fundamentals (3)\nstock_earnings · stock_insider_trades · stock_valuation"]
+    News["📰 News (1)\nnews_articles"]
+    UserData["👤 User — Zerodha Kite backups (5)\nuser_holdings · user_profile · user_margins\nuser_positions · user_orders"]
+    Ops["⚙️ System / Ops (5)\nimport_watermarks · import_failures · agent_traces\nagent_preferences · pipeline_manifest"]
+
+    DB[("market_data\n37 tables")]
+    Prices --> DB
+    MF --> DB
+    Flows --> DB
+    Macro --> DB
+    MLRisk --> DB
+    USStocks --> DB
+    News --> DB
+    UserData --> DB
+    Ops --> DB
+
+    classDef domain fill:#dbeafe,stroke:#3b82f6,color:#1e3a5f
+    classDef db fill:#f3e8ff,stroke:#9333ea,color:#3b0764
+    class Prices,MF,Flows,Macro,MLRisk,USStocks,News,UserData,Ops domain
+    class DB db
+```
+
+Full reference (all 37, with `ORDER BY` key) lives in [import-schema.md](import-schema.md#clickhouse-schema) — kept there as the single source of truth so it doesn't drift out of sync in two places. Quick-reference by domain:
+
+| Domain | Tables | Purpose |
 |---|---|---|
-| `daily_prices` | symbol, category, trade_date, OHLCV, imported_at | OHLCV time series — stocks, ETFs, commodities, indices, FX |
-| `mf_nav` | symbol, scheme_code, nav_date, nav | MF / ETF daily NAV (AMFI via MFAPI.in) |
-| `inav_snapshots` | symbol, snapshot_at, inav, market_price, premium_discount_pct | ETF iNAV vs market price (intraday) |
-| `cot_gold` | report_date, mm_long, mm_short, mm_net, open_interest | CFTC COT Gold positioning (weekly) |
-| `cb_gold_reserves` | ref_period, country_code, reserves_tonnes | Central bank gold holdings (quarterly) |
-| `etf_aum` | trade_date, symbol, aum_usd, implied_tonnes | ETF assets under management (daily) |
-| `fx_rates` | symbol, trade_date, OHLC | Currency pair daily OHLC |
-| `ml_predictions` | as_of, horizon_days, expected_return_pct, confidence_low/high, regime_signal, cv_r2_mean | LightGBM 5-day return forecasts for GOLDBEES |
-| `mf_holdings` | scheme_code, as_of_month, isin, security_name, market_value_cr, pct_of_nav | Mutual fund portfolio compositions (monthly) |
-| `fii_dii_flows` | trade_date, fii_net_cr, dii_net_cr | Daily FII/DII cash-market net flows (₹ Crore) |
-| `fii_dii_monthly` | month_date, fii_net_cr, dii_net_cr, nifty_close | Monthly FII/DII aggregate + Nifty context |
-| `fii_dii_fno_daily` | trade_date, fii_fut_net_oi, fii_opt_overall_net_oi | Daily F&O participant OI (futures + options) |
-| `signal_composite` | as_of, etf_symbol, macro_score, sentiment_score, valuation_score, flow_score, ml_score, composite_score, action | Multi-pillar ETF scores 0–100 with BUY/HOLD/SELL action |
-| `news_articles` | fetched_at, title, source, sentiment, etfs_impacted, category, impact_tier | ETF-tagged news + macro events |
-| `import_watermarks` | source, symbol, last_date | Delta-sync state tracking |
+| Prices & Live Data | `daily_prices`, `nse_delivery`, `inav_snapshots`, `live_quotes`, `live_alerts` | OHLCV, NSE delivery stats, live iNAV, real-time quotes/alerts |
+| Mutual Funds | `mf_nav`, `mf_holdings`, `mf_holding_summaries`, `amfi_category_flows` | NAV history, monthly portfolio holdings, cross-fund ownership rollups, AMFI category flows |
+| Institutional Flows & Corp Actions | `fii_dii_flows`, `fii_dii_monthly`, `fii_dii_fno_daily`, `bulk_block_deals`, `corporate_actions` | FII/DII cash + F&O flows, NSE bulk/block deals, split/bonus/dividend history |
+| Macro & Commodities | `cot_gold`, `cb_gold_reserves`, `etf_aum`, `fx_rates`, `macro_indicators`, `indian_macro_indicators` | COT positioning, central bank reserves, ETF AUM, FX, World Bank/IMF + RBI/MOSPI macro series |
+| ML, Signals & Risk | `ml_predictions`, `signal_composite`, `weight_checkpoints` | LightGBM forecasts, composite ETF scores, Kelly/Risk-Governor sizing decisions |
+| US Stock Fundamentals | `stock_earnings`, `stock_insider_trades`, `stock_valuation` | Quarterly earnings, insider transactions, valuation snapshots |
+| News | `news_articles` | ETF-tagged news + sentiment |
+| User (Zerodha Kite) | `user_holdings`, `user_profile`, `user_margins`, `user_positions`, `user_orders` | Personal portfolio backup tables |
+| System / Ops | `import_watermarks`, `import_failures`, `agent_traces`, `agent_preferences`, `pipeline_manifest` | Delta-sync state, failure log, LLM agent traces, preferences, pipeline run manifest |
 
 ## Qdrant Collections
 
-Five vector collections (all 768-dim, nomic-embed-text, COSINE, hosted at `localhost:6333`). All use `is_tenant=True` on the primary filter field per the Qdrant tenant-scaling skill.
+Six vector collections (all 768-dim, nomic-embed-text, COSINE, hosted at `localhost:6333`). Tenant-indexed collections use `is_tenant=True` on the primary filter field per the Qdrant tenant-scaling skill.
 
 | Collection | Dim | Tenant index | Points | Populated by | Queried by |
 |---|---|---|---|---|---|
-| `news_articles` | 768 | — | ~10k+ | `news_rag_backfill.py`, news importers | `retrieve_articles()`, Correlation Engine |
-| `clickhouse_metadata` | 768 | — | ~50 | `db_metadata_init.py` | `db_metadata_rag.py` (schema RAG) |
+| `news_articles` | 768 | — (list field) | ~10k+ | `news_rag_backfill.py`, news importers | `retrieve_articles()`, Correlation Engine |
+| `clickhouse_metadata` | 768 | — | ~50 | `db_metadata_init.py` | `search_db_metadata` (schema RAG) |
 | `market_anomalies` | 768 | `symbol` | grows with use | `run_composite_anomaly(symbol=...)` auto-stores flagged dates | `find_similar_anomaly_events` |
 | `mf_holdings` | 768 | `isin` | 22k+ (809 funds) | `insert_mf_holdings()` + `BaseFundImporter.run()` hooks + `backfill_mf_qdrant.py` | `find_funds_holding` |
 | `mf_fund_profiles` | 768 | `fund_name` | 809+ | same as above | `find_similar_funds`, `search_mf_exposure` |
-| `weight_checkpoints` | as_of, symbol, method, recommended_weight, regime | Position-sizing decisions (Kelly / Risk Governor) |
-| `stock_earnings` | symbol, earnings_date, eps_actual, surprise_pct | US stock quarterly earnings |
-| `stock_insider_trades` | symbol, insider_name, transaction_date, shares | US stock insider buying/selling |
-| `stock_valuation` | symbol, snapshot_date, trailing_pe, forward_pe, roe | US stock valuation & fundamentals snapshot |
-| `user_holdings` | tradingsymbol, isin, quantity, average_price, pnl | Zerodha Kite CNC holdings backup |
-| `user_profile` | user_id, user_name, broker | Zerodha Kite user profile backup |
-| `user_margins` | segment, cash, available_balance | Zerodha Kite account margins backup |
-| `user_positions` | tradingsymbol, product, quantity, average_price | Zerodha Kite live positions backup |
-| `user_orders` | order_id, status, tradingsymbol, quantity | Zerodha Kite order history backup |
-| `macro_indicators` | ref_year, country_code, indicator_code, value, source | World Bank/IMF macro indicators (GDP, CPI, etc.) |
+| `market_data` | 768 | `symbol` | grows with each import | `market_vector.py` (fire-and-forget on import) | **Write-only — no read path wired yet** |
 
 ---
 
@@ -456,21 +671,67 @@ Standalone scripts that run analyses against the live database and print Rich co
 
 ## CLI Commands (`src/main.py`)
 
+`src/main.py` defines **30** Typer commands (not the 13 previously listed here — `who-is-selling` in particular no longer exists in the code). Grouped by category:
+
+**Portfolio & Research**
+
 | Command | Purpose | Writes To |
 |---|---|---|
 | `analyze` | Full portfolio analysis (Zerodha → enrich → score → report) | JSON |
-| `import` | Sync market data to ClickHouse (delta or full) | ClickHouse |
-| `signals` | Run SignalAggregator for 18 ETFs | Console (+ DB with `--save`) |
-| `macro` | Run macro event scanner (8 themes) | Console (+ DB with `--save`) |
-| `etf-news` | ETF-specific news scanner | Console (+ DB with `--save`) |
-| `comex` | Pre-market commodity signals | Console |
-| `who-is-selling` | FII/DII/Retail flow analysis | Console |
-| `premium-alerts` | iNAV premium/discount threshold alerts | Console |
-| `news SYMBOL` | Multi-source sentiment for a symbol | Console |
 | `ask "question"` | Free-form ReAct agent with tool access | Console |
-| `config` | Show current settings (API keys masked) | Console |
-| `research "question"` | Deep equity research via StateGraph workflow (80% fewer tokens than agent) | Console |
+| `chat` | Interactive multi-turn chat session | Console |
+| `mf "question"` | Ask the Mutual Fund sub-agent directly (holdings, NAV, consensus) | Console |
+| `report` | Consolidated Multi-Asset allocation report with Qdrant RAG news context | JSON/PDF |
+| `research "question"` | Deep equity research via StateGraph workflow (80% fewer tokens than the agent loop) | Console |
 | `portfolio-wf` | Portfolio analysis with adversarial verification from ClickHouse holdings | Console |
+| `deepdive SYMBOL` | Company deep-dive for a US-listed stock | Console |
+| `discover` | Live market-hour institutional discovery & breakout pipeline | Console |
+
+**Data Import**
+
+| Command | Purpose | Writes To |
+|---|---|---|
+| `import` | Sync market data to ClickHouse (delta or full, `--category`) | ClickHouse |
+
+**Signals, Macro & News**
+
+| Command | Purpose | Writes To |
+|---|---|---|
+| `signals` | Run SignalAggregator for 18 ETFs | Console (+ DB with `--save`) |
+| `macro` | Macro & geopolitical event scanner mapped to ETF impact (8 themes) | Console (+ DB with `--save`) |
+| `macro-themes` | Long/short macro theme agent (news + quant overlay) | Console |
+| `etf-news` | ETF-specific news sentiment scanner | Console (+ DB with `--save`) |
+| `news SYMBOL` | Multi-source sentiment analysis for a symbol | Console |
+| `comex` | COMEX commodity pre-market signal analysis | Console |
+| `correlate` | Map stock anomalies to company filings & global macro trigger events | Console |
+
+**ML & Risk**
+
+| Command | Purpose | Writes To |
+|---|---|---|
+| `risk` | GARCH-based position sizing / Risk Governor (GOLDBEES) | Console |
+| `drift-monitor` | Monitor GOLDBEES ML prediction model drift | Console |
+| `premium-alerts` | iNAV premium/discount threshold alerts | Console |
+| `crossover` | Moving Average Crossover backtest for a stock/ETF | Console |
+
+**Scanners (18-ETF / cross-AMC)**
+
+| Command | Purpose | Writes To |
+|---|---|---|
+| `scan-setups` | Volume-volatility setup scanner across 18 ETFs | Console |
+| `scan-trends` | Short/medium/long-term trend scanner across 18 ETFs | Console |
+| `scan-whales` | Cross-AMC whale accumulation scanner | Console |
+| `smallcap` | Multi-AMC Small Cap pattern analyzer | Console |
+
+**Interfaces & Ops**
+
+| Command | Purpose | Writes To |
+|---|---|---|
+| `ui` | Launch the Streamlit Data Hub (`localhost:8501`) | — |
+| `studio` | Launch the Mosaic Studio Agent Workspace UI | — |
+| `config` | Show current settings (API keys masked) | Console |
+| `pipeline-status` | Freshness status of all pipeline stages | Console |
+| `telemetry` | Live system telemetry dashboard | Console |
 
 ---
 

--- a/docs/architecture.mmd
+++ b/docs/architecture.mmd
@@ -2,7 +2,7 @@ flowchart TD
     User(["👤 User"])
 
     %% ── CLI ────────────────────────────────────────────────────────────────
-    subgraph CLI ["CLI — src/main.py (Typer — 13 commands)"]
+    subgraph CLI ["CLI — src/main.py (Typer — 30 commands)"]
         CLIImport["import --category …"]
         CLISignals["signals [--save]"]
         CLIAnalyze["analyze / ask"]
@@ -70,7 +70,7 @@ flowchart TD
 
     %% ── ClickHouse & Qdrant Data Layer ─────────────────────────────────────
     subgraph DataLayer ["Storage Layer — ClickHouse + Qdrant + SQLite"]
-        subgraph CH ["ClickHouse — market_data (27 tables)"]
+        subgraph CH ["ClickHouse — market_data (37 tables)"]
             T1[("daily_prices · mf_nav\nfx_rates · etf_aum")]
             T2[("fii_dii_flows · cot_gold\ncb_gold_reserves · amfi_category_flows")]
             T3[("ml_predictions\nsignal_composite")]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,31 +1,79 @@
 # Configuration Reference
 
-All settings are loaded from `.env` via Pydantic `BaseSettings`. Copy `.env.example` to `.env` and fill in your values.
+All settings are loaded from `.env` via Pydantic `BaseSettings` (`config/settings.py`, 50+ fields). Copy `.env.example` to `.env` and fill in your values. Run `python src/main.py config` to see the current effective values (API keys masked).
 
-## LLM
+```mermaid
+flowchart LR
+    Env[".env"] --> Settings["Settings\nconfig/settings.py"]
+    Settings --> LLM["LLM tiers\nmain · code-agent · cloud-fallback"]
+    Settings --> Data["Data sources\nClickHouse · Qdrant · Shoonya · Kite MCP"]
+    Settings --> Cache["Caching\nLLM · COMEX · NewsAPI"]
+    Settings --> Live["Live Monitor & Alerting\nSlack · WhatsApp"]
+```
+
+## LLM — Primary
 
 ```
-OPENAI_API_KEY=sk-...          # or use ANTHROPIC_API_KEY
+OPENAI_API_KEY=sk-...          # or ANTHROPIC_API_KEY, or OPENROUTER_API_KEY, or NVIDIA_API_KEY
 ANTHROPIC_API_KEY=...
-LLM_PROVIDER=openai            # "openai" | "anthropic"
-LLM_MODEL=gpt-4o-mini
-LLM_BASE_URL=                  # set for local model (LM Studio / Ollama)
-LLM_CONTEXT_WINDOW=4096
+LLM_PROVIDER=anthropic         # default is "anthropic", NOT "openai"
+LLM_MODEL=claude-sonnet-5      # default model — NOT gpt-4o-mini
+LLM_BASE_URL=                  # set for a local/self-hosted OpenAI-compatible endpoint (LM Studio / Ollama)
+LLM_CONTEXT_WINDOW_CONFIGURED=0  # 0 = auto-detect from model/provider; env var name is LLM_CONTEXT_WINDOW
+LLM_TEMPERATURE=0.0
+LLM_THINK=false                 # Ollama native thinking mode (qwen3, deepseek-r1)
+LLM_LOCAL_DISABLED=false        # true = always use the cloud LLM, skip local entirely
+LLM_REQUEST_TIMEOUT=600         # per-call HTTP timeout (s); local models default 600, cloud effectively 60
+AGENT_TIMEOUT=600               # total wall-clock budget (s) for one ReAct agent run, all tool calls included
 ```
 
 **Local model (LM Studio / Ollama):**
 ```
 LLM_BASE_URL=http://localhost:1234/v1
 LLM_MODEL=DeepSeek-R1-Distill-Qwen-14B-GGUF
-LLM_CONTEXT_WINDOW=4096
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_FALLBACK_HOST=http://localhost:11434   # tried if OLLAMA_HOST is unreachable
 ```
 > Models < 30B struggle with multi-turn tool orchestration. COMEX and news agents bypass LangGraph for local models automatically.
+
+> **Docker networking auto-rewrite:** `Settings.__init__` rewrites `LLM_BASE_URL`/`CODE_LLM_BASE_URL` automatically depending on where the process runs — `localhost`/`127.0.0.1` → `host.docker.internal` when running *inside* a container, and `host.docker.internal` → `127.0.0.1` when running on the bare host and that name doesn't resolve. You generally don't need to set this per-environment yourself.
+
+## LLM — Code Agent override (optional)
+
+The `CodeSubAgent` can run on a different model than the main agent — useful for routing code execution to a stronger/cheaper model. Blank fields inherit the primary LLM settings above.
+```
+CODE_LLM_PROVIDER=
+CODE_LLM_MODEL=
+CODE_LLM_BASE_URL=
+CODE_LLM_CONTEXT_WINDOW=0        # 0 = inherit
+```
+
+## LLM — Cloud fallback tier (optional)
+
+When the primary LLM is local (Ollama/LM Studio) and a task needs more capability than a local model can reliably deliver, sub-agents can escalate to a cloud model.
+```
+LLM_CLOUD_PROVIDER=              # blank disables cloud fallback entirely
+LLM_CLOUD_MODEL=claude-3-5-haiku-20241022
+LLM_CLOUD_CONTEXT_WINDOW=0       # 0 = auto-detect
+GOOGLE_API_KEY=                  # Gemini, if used as the cloud provider
+```
+
+## Caching
+
+```
+LLM_CACHE_ENABLED=true           # SQLite response cache — saves API cost on repeated queries
+LLM_CACHE_TTL_HOURS=24           # 0 = no expiry
+COMEX_CACHE_TTL_SECONDS=3600     # COMEX API response cache (default 1h)
+NEWSAPI_CACHE_TTL_SECONDS=3600   # NewsAPI response cache (default 1h)
+```
 
 ## API Keys
 
 ```
 NEWSAPI_KEY=...                # free at newsapi.org — 100 req/day
 GOLD_API_KEY=...               # free at gold-api.com — COMEX spot prices
+SEC_API_KEY=...                # sec-api.io — used by the DeepDive sub-agent for US filings
+GEMINI_CLI_PATH=gemini         # path to the gemini CLI binary, if installed
 ```
 
 ## Zerodha Kite MCP
@@ -37,6 +85,15 @@ KITE_API_SECRET=
 KITE_MCP_TIMEOUT=30
 ```
 
+## Shoonya (live NSE data — ETF price/quote primary source)
+
+```
+SHOONYA_USER_ID=
+SHOONYA_PASSWORD=               # a literal "$$" in the value is auto-unescaped to "$"
+SHOONYA_API_SECRET=
+```
+Shoonya is the primary source for ETF prices per the data-source priority order (Shoonya → NSE → yfinance) — leave blank and the pipeline falls back automatically.
+
 ## ClickHouse (Data Hub & Connection Pool)
 
 ```
@@ -47,24 +104,64 @@ CLICKHOUSE_USER=default
 CLICKHOUSE_PASSWORD=
 
 # Connection pool (src/db/pool.py — shared across all service modules)
-CLICKHOUSE_POOL_MIN=2          # warm idle connections kept alive
-CLICKHOUSE_POOL_MAX=10         # hard cap on total live connections
-CLICKHOUSE_POOL_TIMEOUT=10.0   # seconds to wait for a free pool slot
+CLICKHOUSE_POOL_MIN=5           # warm idle connections kept alive
+CLICKHOUSE_POOL_MAX=30          # hard cap on total live connections
+CLICKHOUSE_POOL_TIMEOUT=30.0    # seconds to wait for a free pool slot
 ```
 
 All service modules import the pool singleton via `from src.db.pool import get_pool`.
 Use `pool.query_df(sql)` for SELECT, `pool.execute(sql)` for DDL/INSERT,
 or `with pool.acquire() as client:` for raw multi-statement access.
 
+## Qdrant (vector database)
+
+```
+QDRANT_HOST=localhost
+QDRANT_PORT=6333
+QDRANT_GRPC_PORT=6334           # used when prefer_grpc=True
+```
+See [rag-architecture.md](rag-architecture.md) for the 6 collections and their read/write paths.
+
 ## Behaviour
 
 ```
 NEWS_ARTICLES_PER_STOCK=5
 NEWS_LOOKBACK_DAYS=7
-MAX_HOLDINGS_PER_RUN=0         # 0 = no cap
+MAX_HOLDINGS_PER_RUN=0          # 0 = no cap
 SCRAPE_DELAY_SECONDS=2.0
 OUTPUT_DIR=./output
 LOG_LEVEL=INFO
+ANOMALY_GARCH_Z_THRESHOLD=      # blank/None = off; 3.5 recommended if enabling the GARCH-residual anomaly gate
+```
+
+## Indian Market Constants
+
+```
+NSE_SUFFIX=.NS
+BSE_SUFFIX=.BO
+MARKET_TIMEZONE=Asia/Kolkata
+MARKET_OPEN=09:15
+MARKET_CLOSE=15:30
+```
+
+## Live Monitor & Alerting (`src/agents/live_monitor.py`)
+
+Standalone multi-symbol live anomaly + news-correlation monitor. Watches Shoonya ticks during market hours, scores 5-minute bars for price/volume anomalies, and pushes Slack/WhatsApp alerts. Key settings (see `config/settings.py` for the full set — bar size, buffer size, VIX confirmation gate, polling fallback interval, etc.):
+
+```
+SLACK_WEBHOOK_URL=                        # blank disables Slack delivery (alerts still logged to ClickHouse)
+CALLMEBOT_WHATSAPP_PHONE=                 # country code + number, no "+"
+CALLMEBOT_WHATSAPP_APIKEY=
+LIVE_MONITOR_ZSCORE_THRESHOLD=3.0         # same scale as the EOD pipeline's z_robust, not yet validated intraday
+```
+
+## News Filter LLM (optional semantic pre-filter)
+
+```
+NEWS_FILTER_LLM_ENABLED=false
+NEWS_FILTER_LLM_BASE_URL=http://localhost:11434/v1
+NEWS_FILTER_LLM_MODEL=mistral:7b-instruct
+NEWS_FILTER_LLM_TIMEOUT=10
 ```
 
 ## Check current config

--- a/docs/db-management.md
+++ b/docs/db-management.md
@@ -1,6 +1,6 @@
 # ClickHouse DB Management
 
-> Database: `market_data` · Engine: ClickHouse 24 (Docker) · Tables: 15 × ReplacingMergeTree
+> Database: `market_data` · Engine: ClickHouse 24 (Docker) · Tables: 37 × ReplacingMergeTree — full list in [import-schema.md](import-schema.md#clickhouse-schema)
 
 ---
 
@@ -10,8 +10,8 @@ Three tiers — run manually or via your preferred scheduler.
 
 | Tier | Command | Where stored | When to use |
 |---|---|---|---|
-| **1 — Native** | `python scripts/db_backup.py --mode native` | `clickhouse-backups` Docker volume | Regular snapshots; full restore from single file |
-| **2 — Parquet** | `python scripts/db_backup.py --mode parquet` | `output/db-backups/parquet/YYYYMMDD/` | Insurance for irreplaceable tables; portable |
+| **1 — Native** | `python src/scripts/db/db_backup.py --mode native` | `clickhouse-backups` Docker volume | Regular snapshots; full restore from single file |
+| **2 — Parquet** | `python src/scripts/db/db_backup.py --mode parquet` | `output/db-backups/parquet/YYYYMMDD/` | Insurance for irreplaceable tables; portable |
 | **3 — Volume tar** | See below | Any path on host | Before `docker volume rm`, OS reinstalls, migrations |
 
 **Recommended cadence:**
@@ -44,6 +44,15 @@ Three tiers — run manually or via your preferred scheduler.
 | `etf_aum` | `import --category etf_aum --full` |
 | `fii_dii_flows` / `fii_dii_monthly` / `fii_dii_fno_daily` | `import --category fii_dii --full` |
 | `ml_predictions` | Re-run ML forecast script |
+| `bulk_block_deals` | `import --category bulk_deals --full` |
+| `nse_delivery` | `import --category nse_delivery --full` |
+| `amfi_category_flows` | `import --category amfi_flows --full` |
+| `macro_indicators` | `import --category world_bank,imf_weo --full` |
+| `indian_macro_indicators` | `import --category indian_macro --full` |
+| `stock_earnings` / `stock_insider_trades` / `stock_valuation` | `import --category earnings,insider,valuation --full` |
+| `corporate_actions` | NSE only serves recent history — not guaranteed to fully reconstruct; back up like an irreplaceable table if long history matters |
+| `signal_composite` | Recomputed by `python src/main.py signals --save` (lossy — only reflects current inputs, not the historical composite log) |
+| `mf_holding_summaries` | Auto-rebuilt from `mf_holdings` on next import |
 
 ---
 
@@ -51,22 +60,22 @@ Three tiers — run manually or via your preferred scheduler.
 
 ```bash
 # Full backup (native snapshot + parquet export of irreplaceable tables)
-python scripts/db_backup.py
+python src/scripts/db/db_backup.py
 
 # Native only
-python scripts/db_backup.py --mode native
+python src/scripts/db/db_backup.py --mode native
 
 # Parquet export only
-python scripts/db_backup.py --mode parquet
+python src/scripts/db/db_backup.py --mode parquet
 
 # List all backups
-python scripts/db_backup.py --list
+python src/scripts/db/db_backup.py --list
 
 # Keep only last 14 days of backups
-python scripts/db_backup.py --keep-days 14
+python src/scripts/db/db_backup.py --keep-days 14
 
 # Preview without writing
-python scripts/db_backup.py --dry-run
+python src/scripts/db/db_backup.py --dry-run
 ```
 
 ### Tier 3 — Cold Docker volume snapshot
@@ -102,19 +111,19 @@ docker compose start clickhouse
 
 ```bash
 # List available backups
-python scripts/db_restore.py --list
+python src/scripts/db/db_restore.py --list
 
 # Restore full DB from native backup
-python scripts/db_restore.py --from-native backup_20260412_220000
+python src/scripts/db/db_restore.py --from-native backup_20260412_220000
 
 # Restore from native backup (dry-run — shows SQL only)
-python scripts/db_restore.py --from-native backup_20260412_220000 --dry-run
+python src/scripts/db/db_restore.py --from-native backup_20260412_220000 --dry-run
 
 # Restore all precious tables from parquet export
-python scripts/db_restore.py --from-parquet 20260412
+python src/scripts/db/db_restore.py --from-parquet 20260412
 
 # Restore only mf_holdings from parquet export
-python scripts/db_restore.py --from-parquet 20260412 --table mf_holdings
+python src/scripts/db/db_restore.py --from-parquet 20260412 --table mf_holdings
 ```
 
 ### Restore Runbook

--- a/docs/docker_install_guide.md
+++ b/docs/docker_install_guide.md
@@ -2,6 +2,17 @@
 
 This guide walks you through setting up and running the Mosaic Fund Agent platform on **Windows**, **macOS**, and **Ubuntu (Linux)** using Docker. This method packages all python libraries and database dependencies automatically, so you do not need to install Python, compilers, or local packages.
 
+> **Project root** below always means the top-level folder you cloned/downloaded — the one that directly contains `run.sh` / `run.bat`, `stop.sh` / `stop.bat`, `mosaic.sh` / `mosaic.bat`, and `docker-compose.yml`. It is **not** `data_importer` — that's a git submodule nested a few levels inside the project, used only for the data-import pipeline's own source code.
+
+```mermaid
+flowchart LR
+    A["Which OS?"] -->|Windows| B["Install Docker Desktop (WSL2)\n→ double-click run.bat"]
+    A -->|macOS| C["Install Docker Desktop\n→ cd project root → ./run.sh"]
+    A -->|Ubuntu/Linux| D["Install Docker Engine + Compose\n→ cd project root → ./run.sh"]
+    B & C & D --> E[".env created on first run —\nfill in API keys, run again"]
+    E --> F["Dashboard live at\nlocalhost:8501"]
+```
+
 ---
 
 ## 🪟 Windows Setup
@@ -13,7 +24,7 @@ This guide walks you through setting up and running the Mosaic Fund Agent platfo
 4. Launch **Docker Desktop** from your Start menu and accept the agreement. Keep the application open.
 
 ### 2. Configure & Run
-1. Open the project folder (`data_importer`) in Windows Explorer.
+1. Open the project root folder (see note above — **not** `data_importer`) in Windows Explorer.
 2. Double-click the file **`run.bat`**.
    - *First-run only:* The script will create a file named `.env` in the root folder and then exit.
 3. Open the new **`.env`** file using Notepad, fill in your API keys (e.g. `OPENAI_API_KEY`, Zerodha keys, etc.), and save it.
@@ -35,9 +46,9 @@ When you are done, double-click **`stop.bat`** to shut down the background conta
 3. Accept the license agreement and wait for the status indicator in the bottom-left corner to turn green.
 
 ### 2. Configure & Run
-1. Open terminal and navigate to the project directory:
+1. Open terminal and navigate to the project root (see note above — **not** `data_importer`):
    ```bash
-   cd /path/to/data_importer
+   cd /path/to/mosaic-fund-agent
    ```
 2. Run the startup script:
    ```bash
@@ -89,9 +100,9 @@ sudo usermod -aG docker $USER
 *Note: After adding your user to the group, close your terminal window and open a new one (or run `newgrp docker`) for the changes to apply.*
 
 ### 2. Configure & Run
-1. Navigate to the project directory:
+1. Navigate to the project root (see note above — **not** `data_importer`):
    ```bash
-   cd /path/to/data_importer
+   cd /path/to/mosaic-fund-agent
    ```
 2. Run the startup script:
    ```bash

--- a/docs/import-schema.md
+++ b/docs/import-schema.md
@@ -2,23 +2,62 @@
 
 ## Import Categories
 
-Run imports via CLI: `python src/main.py import --category <name>`
+Run imports via CLI: `python src/main.py import --category <name>` (comma-separated; omit `--category` or use `all` to run every registered category).
+
+```mermaid
+flowchart LR
+    CLI["import --category X"] --> Router{"How is X handled?"}
+    Router -->|"in FETCHER_REGISTRY\n(19 categories)"| Reg["MarketDataRepository.run_fetcher()\nwatermark → fetch → validate → insert → event"]
+    Router -->|"special-cased in cli.py\n(inav, mf_holdings, earnings,\ninsider, valuation)"| Special["Direct fetch + insert,\nbypasses the registry loop"]
+    Router -->|"AMC name\n(icici, dsp, nippon, … 14 total)"| AMC["fetch_amc_holdings()\nFactory pattern → mf_holdings"]
+    Reg --> DB[(ClickHouse)]
+    Special --> DB
+    AMC --> DB
+```
+
+### Registry-driven categories (`FETCHER_REGISTRY`, 19)
 
 | Category | Source | Symbols | ClickHouse Table |
 |---|---|---|---|
-| `stocks` | Yahoo Finance (`.NS`) | 50 NSE large/mid-caps | `daily_prices` |
-| `etfs` | Yahoo Finance (`.NS`) | 15 NSE ETFs | `daily_prices` |
+| `stocks` | Yahoo Finance (`.NS`) | 50 NSE large/mid-caps | `daily_prices`, `stock_earnings`, `stock_insider_trades`, `stock_valuation` |
+| `us_stocks` | Yahoo Finance | US-listed stocks | `daily_prices`, `stock_earnings`, `stock_insider_trades`, `stock_valuation` |
+| `etfs` | Shoonya → nselib → Yahoo Finance fallback chain | 30+ NSE ETFs | `daily_prices` |
 | `commodities` | Yahoo Finance (futures) | Gold, Silver, Copper, Crude Oil, etc. | `daily_prices` |
 | `indices` | Yahoo Finance | Nifty50, Sensex, S&P500, Nasdaq, etc. | `daily_prices` |
+| `nse_indices` | nselib (direct NSE) | Sectoral/factor indices not on Yahoo | `daily_prices` |
+| `nse_eod` | NSE official EOD bulk archive | ETFs + stocks | `daily_prices` |
+| `nse_delivery` | NSE official delivery archive | ETFs + stocks | `nse_delivery` |
+| `fx_rates` | Yahoo Finance (free) | Daily OHLC for USDINR, USDCNY, USDAED, USDSAR, USDKWD | `fx_rates` |
 | `mf` | MFAPI.in (AMFI official) | NAV history for 13 ETF schemes | `mf_nav` |
-| `inav` | NSE API (live) | 15 ETFs — iNAV + market price + premium/discount | `inav_snapshots` |
+| `fii_dii` | Sensibull oxide API | Daily + monthly FII/DII institutional cash flows + F&O OI | `fii_dii_flows`, `fii_dii_monthly`, `fii_dii_fno_daily` |
 | `cot` | CFTC Socrata API (free) | Weekly Gold COT — Managed Money + Commercials | `cot_gold` |
 | `cb_reserves` | IMF IFS REST API (free) | Monthly gold reserves for 9 central banks | `cb_gold_reserves` |
 | `etf_aum` | Yahoo Finance (free) | Daily AUM snapshot for GLD, IAU, SGOL, PHYS | `etf_aum` |
-| `fx_rates` | Yahoo Finance (free) | Daily OHLC for USDINR, USDCNY, USDAED, USDSAR, USDKWD | `fx_rates` |
+| `world_bank` | World Bank WDI API (free) | Annual macro indicators (GDP, CPI, etc.) | `macro_indicators` |
+| `imf_weo` | IMF WEO API (free) | Annual macro projections/forecasts | `macro_indicators` |
+| `indian_macro` | RBI / MOSPI public series | Indian macro indicators | `indian_macro_indicators` |
+| `amfi_flows` | AMFI portal | Category-wise monthly MF flows + AUM | `amfi_category_flows` |
+| `bulk_deals` / `events` | NSE bulk & block deals API (aliases — same fetcher) | Large institutional/promoter transactions | `bulk_block_deals` |
+
+### Special-cased categories (handled directly in `cli.py`, not via the registry)
+
+| Category | Source | Symbols | ClickHouse Table |
+|---|---|---|---|
+| `inav` | NSE API (live) | 15 ETFs — iNAV + market price + premium/discount | `inav_snapshots` |
 | `mf_holdings` | Morningstar via mstarpy | Current portfolio snapshot for DSP, Quant, ICICI multi-asset funds. Auto-vectorizes into Qdrant `mf_holdings` + `mf_fund_profiles` on each insert. | `mf_holdings` |
-| `fii_dii` | Sensibull oxide API | Daily + monthly FII/DII institutional cash flows + F&O OI | `fii_dii_flows`, `fii_dii_monthly`, `fii_dii_fno_daily` |
-| `user_data` | Zerodha Kite MCP | Personal portfolio, margins, profile, positions, and orders | `user_*` tables |
+| `earnings` | Yahoo Finance | US_STOCKS watchlist quarterly earnings | `stock_earnings` |
+| `insider` | Yahoo Finance | US_STOCKS watchlist insider transactions | `stock_insider_trades` |
+| `valuation` | Yahoo Finance | US_STOCKS watchlist valuation snapshot | `stock_valuation` |
+
+### AMC fund-holdings importers (factory pattern, 14 AMCs)
+
+`icici`, `nippon`, `icici-index`, `dsp`, `bajaj`, `quant`, `hdfc`, `kotak`, `abakkus`, `abacus`, `helios`, `invesco`, `canara`, `mirae` — each dispatches through `fetch_amc_holdings()` (`src/data_importer/fetchers/amc_holdings_fetcher.py`) into `mf_holdings`.
+
+### Personal data
+
+| Category | Source | Symbols | ClickHouse Table |
+|---|---|---|---|
+| `user_data` | Zerodha Kite MCP | Personal portfolio, margins, profile, positions, and orders | `user_holdings`, `user_profile`, `user_margins`, `user_positions`, `user_orders` |
 
 ### Delta-sync
 
@@ -66,6 +105,9 @@ All general data categories have typed **Fetcher adapters** (`src/data_importer/
 | `WorldBankMacroFetcher` | world_bank | 365 days | World Bank WDI annual macro indicators |
 | `IMFWEOFetcher` | imf_weo | 180 days | IMF WEO projections & forecasts |
 | `AmfiCategoryFlowsFetcher` | amfi_flows | 0 days | AMFI category-wise monthly flows + AUM |
+| `NseDeliveryFetcher` | nse_delivery | 3 days | NSE daily delivery %/volume (bhavcopy, whole-market) |
+| `BulkBlockDealsFetcher` | bulk_deals, events | 3 days | NSE Bulk & Block Deals (large institutional/promoter transactions) |
+| `MfHoldingsFetcher` | mf_holdings | — (month-presence check, not watermark) | Monthly MF portfolio holdings (constructed per-call in `cli.py`, not registry-cached) |
 
 Use `MarketDataRepository.run_fetcher(fetcher)` to execute the full watermark → fetch → validate → insert → event cycle programmatically:
 
@@ -139,29 +181,89 @@ Once registered:
 
 ## ClickHouse Schema
 
-Database: `market_data`. All tables use `ReplacingMergeTree` for idempotent re-imports.
+Database: `market_data`, **37 tables**, all `ReplacingMergeTree` for idempotent re-imports. This is the single source of truth for the full schema — [architecture.md](architecture.md#clickhouse-tables) links back here rather than duplicating it.
 
-| Table | Engine | Partition | Order Key | Purpose |
-|---|---|---|---|---|
-| `daily_prices` | ReplacingMergeTree(imported_at) | toYYYYMM(trade_date) | (symbol, trade_date) | OHLCV for stocks, ETFs, commodities, indices |
-| `mf_nav` | ReplacingMergeTree(imported_at) | toYYYYMM(nav_date) | (symbol, nav_date) | Daily MF/ETF NAV from AMFI via MFAPI.in |
-| `inav_snapshots` | ReplacingMergeTree(snapshot_at) | toYYYYMM(snapshot_at) | (symbol, snapshot_at) | Live iNAV + premium/discount snapshots |
-| `import_watermarks` | ReplacingMergeTree(updated_at) | — | (source, symbol) | Delta-sync watermarks |
-| `cot_gold` | ReplacingMergeTree | — | (report_date) | Weekly CFTC COT — mm_net, comm_net, open_interest |
-| `cb_gold_reserves` | ReplacingMergeTree | toYYYYMM(ref_period) | (ref_period, country_code) | Monthly central bank gold reserves (metric tonnes) |
-| `etf_aum` | ReplacingMergeTree | toYYYYMM(trade_date) | (trade_date, symbol) | Daily ETF AUM (USD) + implied gold tonnes |
-| `fx_rates` | ReplacingMergeTree(imported_at) | toYYYYMM(trade_date) | (symbol, trade_date) | Daily OHLC for 5 USD pairs |
-| `ml_predictions` | ReplacingMergeTree(created_at) | — | (as_of, horizon_days) | LightGBM forecast log |
-| `mf_holdings` | ReplacingMergeTree(imported_at) | toYYYYMM(as_of_month) | (scheme_code, as_of_month, isin) | Monthly MF portfolio holdings snapshot |
-| `fii_dii_flows` | ReplacingMergeTree(imported_at) | — | (trade_date) | Daily FII/DII cash-market net flows (₹ Crore) |
-| `fii_dii_monthly` | ReplacingMergeTree(imported_at) | — | (month_date) | Monthly FII/DII aggregate + Nifty (Sep 2018→present) |
-| `fii_dii_fno_daily` | ReplacingMergeTree(imported_at) | — | (trade_date) | Daily F&O participant OI (futures + options, 4 categories) |
-| `news_articles` | ReplacingMergeTree(imported_at) | — | (fetched_at, source_type, category, title) | ETF-tagged news + macro events (gnews + yfinance, no key) |
-| `user_holdings` | ReplacingMergeTree(imported_at) | — | (tradingsymbol, imported_at) | Personal CNC holdings snapshot |
-| `user_profile` | ReplacingMergeTree(imported_at) | — | (user_id, imported_at) | Kite account profile details |
-| `user_margins` | ReplacingMergeTree(imported_at) | — | (segment, imported_at) | Available cash & utilised margins |
-| `user_positions` | ReplacingMergeTree(imported_at) | — | (tradingsymbol, imported_at) | Intraday (MIS/NRML) open positions |
-| `user_orders` | ReplacingMergeTree(imported_at) | — | (order_id, imported_at) | Historical order book log |
+#### Prices & Live Market Data
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `daily_prices` | toYYYYMM(trade_date) | (symbol, trade_date) | OHLCV for stocks, ETFs, commodities, indices |
+| `nse_delivery` | toYYYYMM(trade_date) | (symbol, trade_date, series) | NSE daily delivery %/volume stats (bhavcopy) |
+| `inav_snapshots` | toYYYYMM(snapshot_at) | (symbol, snapshot_at) | Live ETF iNAV vs market price (intraday) |
+| `live_quotes` | toYYYYMM(last_trade_time) | (symbol, last_trade_time) | Real-time quote snapshots |
+| `live_alerts` | toYYYYMM(alert_timestamp) | (symbol, alert_timestamp) | Real-time z-score/volume anomaly alert log |
+
+#### Mutual Funds
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `mf_nav` | toYYYYMM(nav_date) | (symbol, nav_date) | Daily MF/ETF NAV from AMFI via MFAPI.in |
+| `mf_holdings` | toYYYYMM(as_of_month) | (scheme_code, as_of_month, isin) | Monthly MF portfolio holdings snapshot |
+| `mf_holding_summaries` | — | (isin, as_of_month) | Cross-fund security ownership rollup (active_funds_count, total value) |
+| `amfi_category_flows` | — | (report_month, category_name) | AMFI category-wise monthly flows + AUM |
+
+#### Institutional Flows & Corporate Actions
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `fii_dii_flows` | — | (trade_date) | Daily FII/DII cash-market net flows (₹ Crore) |
+| `fii_dii_monthly` | — | (month_date) | Monthly FII/DII aggregate + Nifty (Sep 2018→present) |
+| `fii_dii_fno_daily` | — | (trade_date) | Daily F&O participant OI (futures + options, 4 categories) |
+| `bulk_block_deals` | — | (deal_date, deal_type, symbol, client_name, buy_sell, quantity, trade_price) | NSE bulk & block deal transactions |
+| `corporate_actions` | — | (symbol, ex_date, action_type) | NSE split/bonus/demerger/rights/dividend history |
+
+#### Macro & Commodities
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `cot_gold` | — | (report_date) | Weekly CFTC COT — mm_net, comm_net, open_interest |
+| `cb_gold_reserves` | — | (ref_period, country_code) | Monthly central bank gold reserves (metric tonnes) |
+| `etf_aum` | toYYYYMM(trade_date) | (trade_date, symbol) | Daily ETF AUM (USD) + implied gold tonnes |
+| `fx_rates` | toYYYYMM(trade_date) | (symbol, trade_date) | Daily OHLC for 5 USD pairs |
+| `macro_indicators` | — | (ref_year, country_code, indicator_code, source) | World Bank / IMF WEO annual macro indicators |
+| `indian_macro_indicators` | — | (as_of_date, indicator_code) | RBI/MOSPI Indian macro series |
+
+#### ML, Signals & Risk
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `ml_predictions` | — | (as_of, horizon_days) | LightGBM 5-day forecast log |
+| `signal_composite` | — | (as_of, etf_symbol) | Multi-pillar ETF composite scores + BUY/HOLD/SELL |
+| `weight_checkpoints` | — | (as_of, symbol, method) | Kelly / Risk Governor position-sizing decisions |
+
+#### US Stock Fundamentals
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `stock_earnings` | — | (symbol, earnings_date) | US quarterly earnings + surprise % |
+| `stock_insider_trades` | — | (symbol, transaction_date, insider_name) | US insider buy/sell transactions |
+| `stock_valuation` | — | (symbol, snapshot_date) | US valuation/fundamentals snapshot |
+
+#### News
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `news_articles` | — | (fetched_at, source_type, category, title) | ETF-tagged news + macro events (gnews + yfinance, no key) |
+
+#### User (Zerodha Kite backups)
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `user_holdings` | — | (tradingsymbol, imported_at) | Personal CNC holdings snapshot |
+| `user_profile` | — | (user_id, imported_at) | Kite account profile details |
+| `user_margins` | — | (segment, imported_at) | Available cash & utilised margins |
+| `user_positions` | — | (tradingsymbol, imported_at) | Intraday (MIS/NRML) open positions |
+| `user_orders` | — | (order_id, imported_at) | Historical order book log |
+
+#### System / Ops
+
+| Table | Partition | Order Key | Purpose |
+|---|---|---|---|
+| `import_watermarks` | — | (source, symbol, dataset) | Delta-sync watermarks |
+| `import_failures` | — | (source, dataset, symbol, failed_at) | Failed fetch/insert attempts log |
+| `agent_traces` | toYYYYMM(created_at) | (agent, run_id, step_idx) | LLM agent tool-call execution traces (latency, tokens, errors) |
+| `agent_preferences` | — | (preference_key) | Key-value store for agent-learned preferences |
+| `pipeline_manifest` | — | (stage, symbol) | Per-stage pipeline run manifest (fingerprint/idempotency tracking) |
 
 ### Querying tips
 


### PR DESCRIPTION
## Summary
- Full audit of `docs/*.md`, `AGENTS.md`, `GEMINI.md`, `CONTRIBUTING.md`, and `CLAUDE.md` against the current codebase — several docs had drifted significantly out of sync with the code (some counts stale by 2x+, one section outright corrupted, one install-guide instruction actively misleading).
- Highlights:
  - `architecture.md` — un-corrupted the ClickHouse-tables section (a Qdrant table had been spliced into it), expanded to all 37 tables, fixed the CLI table (13 → 30 commands), embedded the previously-orphaned `architecture.mmd` diagram.
  - `docker_install_guide.md` — fixed instructions telling new users to `cd` into `data_importer` (a git submodule) instead of the actual project root.
  - `import-schema.md` — expanded Import Categories (12 → ~31) and ClickHouse Schema (19 → 37 tables).
  - `agent-architecture.md` — documented a previously-undocumented RAG router tier (embedding + TF-IDF) between the LLM router and regex fallback.
  - `anomaly-detection.md` — fixed dead links to `src/ml/anomaly.py` (now a package) and documented a missing Volume-GMM detection strategy.
  - `configuration.md` — corrected wrong defaults (LLM provider/model, ClickHouse pool sizes) and documented ~30 previously-missing settings.
  - `AGENTS.md`/`GEMINI.md` — were ~95% duplicated and had drifted (stale path, missing rule, phantom table); now content-identical except each file's header.
  - `CONTRIBUTING.md` — project-structure tree was missing several real directories and pointed at a stale path.
  - `CLAUDE.md` (root + docs copy) — fixed stale command/pipeline-step counts.
- Added mermaid diagrams to `architecture.md`, `import-schema.md`, `docker_install_guide.md`, and `configuration.md` for readability.

## Test plan
- [ ] Render each edited `.md` file (GitHub preview or a mermaid-aware viewer) to confirm the new mermaid diagrams parse cleanly
- [ ] Spot-check a few corrected counts against code (`grep -c '@app.command' src/main.py`, `grep -c 'CREATE TABLE' src/data_importer/clickhouse.py`)
- [ ] Confirm `AGENTS.md` and `GEMINI.md` bodies are identical (`diff <(tail -n +6 AGENTS.md) <(tail -n +6 GEMINI.md)`)

Docs-only change — no code/behavior affected.